### PR TITLE
fix: correct CI workflow paths for Xcode project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build for iOS
         run: |
           xcodebuild build \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' \
             -configuration Debug \
@@ -46,6 +47,7 @@ jobs:
       - name: Run Tests
         run: |
           xcodebuild test \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' \
             -configuration Debug \
@@ -74,6 +76,7 @@ jobs:
       - name: Build for macOS
         run: |
           xcodebuild build \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -destination 'platform=macOS' \
             -configuration Debug \
@@ -92,3 +95,4 @@ jobs:
 
       - name: Run SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging
+        working-directory: Dequeue

--- a/Dequeue/.swiftlint.yml
+++ b/Dequeue/.swiftlint.yml
@@ -9,6 +9,7 @@ excluded:
   - DerivedData
   - .build
   - Pods
+  - DequeueUITests
 
 # Rules
 disabled_rules:


### PR DESCRIPTION
## Summary
- Adds `-project Dequeue/Dequeue.xcodeproj` to all xcodebuild commands since the project is in a subdirectory
- Moves `.swiftlint.yml` to `Dequeue/` directory and runs SwiftLint with `working-directory: Dequeue`
- Excludes `DequeueUITests` from SwiftLint to avoid linting generated Xcode UI test files

## Test plan
- [ ] Verify CI passes for iOS build
- [ ] Verify CI passes for macOS build  
- [ ] Verify CI passes for SwiftLint

🤖 Generated with [Claude Code](https://claude.com/claude-code)