### PR TITLE
fix: add sign out and fix completed stacks filter

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/CompletedStacksView.swift
+++ b/Dequeue/Dequeue/Views/Stack/CompletedStacksView.swift
@@ -10,13 +10,18 @@ import SwiftData
 
 struct CompletedStacksView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(
-        filter: #Predicate<Stack> { stack in
-            stack.isDeleted == false && stack.isDraft == false
-        },
-        sort: \Stack.updatedAt,
-        order: .reverse
-    ) private var completedStacks: [Stack]
+    @Query private var completedStacks: [Stack]
+
+    init() {
+        let completed = StackStatus.completed
+        _completedStacks = Query(
+            filter: #Predicate<Stack> { stack in
+                stack.isDeleted == false && stack.status == completed
+            },
+            sort: \Stack.updatedAt,
+            order: .reverse
+        )
+    }
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## Summary
- Add sign out button to Settings with loading state and error handling
- Show user email in Account section
- Fix CompletedStacksView query to filter by `status == .completed` (was incorrectly showing all non-draft stacks)

## Test plan
- [ ] Verify sign out works and returns to auth screen
- [ ] Verify completed stacks only shows stacks with completed status
- [ ] Verify user email displays in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)