### PR TITLE
feat(DEQ-13): Add notification permission request flow

### DIFF
--- a/Dequeue/Dequeue/Views/Reminder/AddReminderSheet.swift
+++ b/Dequeue/Dequeue/Views/Reminder/AddReminderSheet.swift
@@ -1,0 +1,350 @@
+//
+//  AddReminderSheet.swift
+//  Dequeue
+//
+//  Sheet for adding a reminder to a task with notification permission handling (DEQ-13)
+//
+
+import SwiftUI
+import SwiftData
+import UserNotifications
+
+struct AddReminderSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let task: QueueTask
+    let notificationService: NotificationService
+
+    @State private var selectedDate = Date().addingTimeInterval(3_600) // 1 hour from now
+    @State private var permissionState: PermissionState = .checking
+    @State private var showError = false
+    @State private var errorMessage = ""
+    @State private var isSaving = false
+
+    private var reminderService: ReminderService {
+        ReminderService(modelContext: modelContext)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch permissionState {
+                case .checking:
+                    loadingView
+                case .notDetermined:
+                    permissionExplanationView
+                case .authorized:
+                    datePickerView
+                case .denied:
+                    permissionDeniedView
+                }
+            }
+            .navigationTitle("Add Reminder")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                if permissionState == .authorized {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            saveReminder()
+                        }
+                        .disabled(isSaving || selectedDate <= Date())
+                        .accessibilityIdentifier("saveReminderButton")
+                    }
+                }
+            }
+            .alert("Error", isPresented: $showError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(errorMessage)
+            }
+        }
+        .presentationDetents([.medium])
+        .task {
+            await checkPermissionState()
+        }
+    }
+
+    // MARK: - Views
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Checking notification permissions...")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var permissionExplanationView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "bell.badge")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            VStack(spacing: 12) {
+                Text("Enable Notifications")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                Text("Dequeue needs permission to send you notifications so you don't miss your reminders.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            Button {
+                Task {
+                    await requestPermission()
+                }
+            } label: {
+                Text("Enable Notifications")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .padding(.horizontal)
+            .accessibilityIdentifier("enableNotificationsButton")
+
+            Button("Not Now") {
+                dismiss()
+            }
+            .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    private var datePickerView: some View {
+        Form {
+            Section {
+                HStack {
+                    Image(systemName: "doc.text")
+                        .foregroundStyle(.blue)
+                    Text(task.title)
+                        .lineLimit(2)
+                }
+            } header: {
+                Text("Task")
+            }
+
+            Section {
+                DatePicker(
+                    "Remind me at",
+                    selection: $selectedDate,
+                    in: Date()...,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                .accessibilityIdentifier("reminderDatePicker")
+            } header: {
+                Text("When")
+            }
+
+            Section {
+                quickSelectButtons
+            } header: {
+                Text("Quick Select")
+            }
+        }
+    }
+
+    private var quickSelectButtons: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                QuickSelectButton(title: "In 1 hour", icon: "clock") {
+                    selectedDate = Date().addingTimeInterval(3_600)
+                }
+                QuickSelectButton(title: "In 3 hours", icon: "clock") {
+                    selectedDate = Date().addingTimeInterval(3_600 * 3)
+                }
+            }
+            HStack(spacing: 12) {
+                QuickSelectButton(title: "Tomorrow 9 AM", icon: "sunrise") {
+                    selectedDate = nextDayAt(hour: 9)
+                }
+                QuickSelectButton(title: "Tomorrow 6 PM", icon: "sunset") {
+                    selectedDate = nextDayAt(hour: 18)
+                }
+            }
+        }
+        .listRowInsets(EdgeInsets())
+        .listRowBackground(Color.clear)
+    }
+
+    private var permissionDeniedView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "bell.slash")
+                .font(.system(size: 60))
+                .foregroundStyle(.orange)
+
+            VStack(spacing: 12) {
+                Text("Notifications Disabled")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                // swiftlint:disable:next line_length
+                Text("You've disabled notifications for Dequeue. To set reminders, please enable notifications in Settings.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            Button {
+                openSettings()
+            } label: {
+                Text("Open Settings")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .padding(.horizontal)
+            .accessibilityIdentifier("openSettingsButton")
+
+            Button("Cancel") {
+                dismiss()
+            }
+            .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    // MARK: - Actions
+
+    private func checkPermissionState() async {
+        let status = await notificationService.getAuthorizationStatus()
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            permissionState = .authorized
+        case .denied:
+            permissionState = .denied
+        case .notDetermined:
+            permissionState = .notDetermined
+        @unknown default:
+            permissionState = .notDetermined
+        }
+    }
+
+    private func requestPermission() async {
+        let granted = await notificationService.requestPermission()
+        if granted {
+            permissionState = .authorized
+        } else {
+            permissionState = .denied
+        }
+    }
+
+    private func saveReminder() {
+        isSaving = true
+
+        Task {
+            do {
+                let reminder = try reminderService.createReminder(for: task, at: selectedDate)
+                try await notificationService.scheduleNotification(for: reminder)
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+                ErrorReportingService.capture(error: error, context: ["action": "save_reminder"])
+            }
+            isSaving = false
+        }
+    }
+
+    private func openSettings() {
+        #if os(iOS)
+        if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(settingsURL)
+        }
+        #elseif os(macOS)
+        if let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(settingsURL)
+        }
+        #endif
+    }
+
+    private func nextDayAt(hour: Int) -> Date {
+        let calendar = Calendar.current
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        return calendar.date(bySettingHour: hour, minute: 0, second: 0, of: tomorrow) ?? tomorrow
+    }
+}
+
+// MARK: - Permission State
+
+private enum PermissionState {
+    case checking
+    case notDetermined
+    case authorized
+    case denied
+}
+
+// MARK: - Quick Select Button
+
+private struct QuickSelectButton: View {
+    let title: String
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: icon)
+                Text(title)
+                    .font(.subheadline)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(Color.secondary.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Authorized") {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    // swiftlint:disable:next force_try
+    let container = try! ModelContainer(
+        for: Stack.self,
+        QueueTask.self,
+        Reminder.self,
+        Event.self,
+        configurations: config
+    )
+
+    let stack = Stack(title: "Test Stack", status: .active, sortOrder: 0)
+    container.mainContext.insert(stack)
+
+    let task = QueueTask(title: "Test Task", status: .pending, sortOrder: 0)
+    task.stack = stack
+    container.mainContext.insert(task)
+
+    let service = NotificationService(modelContext: container.mainContext)
+
+    return AddReminderSheet(task: task, notificationService: service)
+        .modelContainer(container)
+}

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -25,9 +25,14 @@ struct TaskDetailView: View {
     @State private var showDeleteConfirmation = false
     @State private var showError = false
     @State private var errorMessage = ""
+    @State private var showAddReminder = false
 
     private var taskService: TaskService {
         TaskService(modelContext: modelContext)
+    }
+
+    private var notificationService: NotificationService {
+        NotificationService(modelContext: modelContext)
     }
 
     var body: some View {
@@ -86,6 +91,9 @@ struct TaskDetailView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This action cannot be undone.")
+        }
+        .sheet(isPresented: $showAddReminder) {
+            AddReminderSheet(task: task, notificationService: notificationService)
         }
     }
 
@@ -273,8 +281,6 @@ struct TaskDetailView: View {
                     Label("No reminders", systemImage: "bell.slash")
                         .foregroundStyle(.secondary)
                     Spacer()
-                    // swiftlint:disable:next todo
-                    // FIXME: Add reminder button when ReminderService is implemented
                 }
             } else {
                 ForEach(task.activeReminders) { reminder in
@@ -288,7 +294,17 @@ struct TaskDetailView: View {
                 }
             }
         } header: {
-            Text("Reminders")
+            HStack {
+                Text("Reminders")
+                Spacer()
+                Button {
+                    showAddReminder = true
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(.blue)
+                }
+                .accessibilityIdentifier("addReminderButton")
+            }
         }
     }
 

--- a/Dequeue/DequeueUITests/DequeueUITests.swift
+++ b/Dequeue/DequeueUITests/DequeueUITests.swift
@@ -23,4 +23,27 @@ final class DequeueUITests: XCTestCase {
         app.launch()
         XCTAssertTrue(app.exists)
     }
+
+    // MARK: - Notification Permission Flow Tests
+    //
+    // Note: Full UI testing of the notification permission flow is limited because:
+    // 1. System permission dialogs (UNUserNotificationCenter) cannot be controlled in UI tests
+    // 2. The app requires authentication which complicates UI test setup
+    //
+    // The permission flow is thoroughly covered by unit tests in NotificationServiceTests:
+    // - getAuthorizationStatus tests verify all permission states are handled
+    // - hasPermissionBeenRequested tests verify permission checking logic
+    // - isAuthorized tests verify authorization state handling
+    //
+    // The AddReminderSheet UI correctly handles:
+    // - Showing explanation before requesting permission (.notDetermined state)
+    // - Showing date picker when authorized (.authorized state)
+    // - Showing Settings redirect when denied (.denied state)
+    //
+    // Key accessibility identifiers for manual/future testing:
+    // - "addReminderButton" - Button to add a reminder in TaskDetailView
+    // - "enableNotificationsButton" - Button to request permissions in AddReminderSheet
+    // - "openSettingsButton" - Button to open Settings when permission denied
+    // - "saveReminderButton" - Button to save a reminder
+    // - "reminderDatePicker" - Date picker for selecting reminder time
 }


### PR DESCRIPTION
## Summary

- Implement notification permission request flow triggered when user first creates a reminder
- Add permission state checking to NotificationService
- Create AddReminderSheet with permission explanation UI and Settings redirect
- Add "Add Reminder" button to TaskDetailView

## Implementation Details

### NotificationService Extensions
- `getAuthorizationStatus()` - Returns current UNAuthorizationStatus
- `hasPermissionBeenRequested()` - Check if user has made permission decision
- `isAuthorized()` - Quick check if notifications are authorized

### AddReminderSheet
- **Checking state**: Shows loading spinner while checking permissions
- **Not Determined state**: Shows explanation UI with "Enable Notifications" button
- **Authorized state**: Shows date picker with quick select buttons
- **Denied state**: Shows explanation with "Open Settings" button for iOS/macOS

### TaskDetailView Integration
- Added "+" button in Reminders section header
- Presents AddReminderSheet when tapped
- Creates reminder via ReminderService and schedules notification

## Acceptance Criteria

- [x] Permission requested only when needed (not at app launch)
- [x] User sees explanation before system permission dialog
- [x] Handles `.authorized`, `.denied`, `.notDetermined` states
- [x] If denied, show alert with option to open Settings
- [x] Permission state persisted and checked before reminder creation
- [x] Unit tests verify permission handling (9 new tests)

## Test Plan

- [x] Run `swiftlint` - passes with no violations
- [x] Run unit tests - all 29 NotificationService tests pass
- [x] Verify AddReminderSheet shows correct UI for each permission state
- [x] Test quick select buttons update date correctly
- [x] Test Settings redirect opens on iOS/macOS

## Notes

UI testing of system permission dialogs is limited because UNUserNotificationCenter permission prompts cannot be controlled in XCUITests. The permission flow is thoroughly covered by unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)