### PR TITLE
fix: add macOS sandbox network entitlements

### DIFF
--- a/Dequeue/Dequeue/Dequeue.entitlements
+++ b/Dequeue/Dequeue/Dequeue.entitlements
@@ -7,5 +7,9 @@
 		<string>applinks:expert-halibut-82.clerk.accounts.dev</string>
 		<string>webcredentials:expert-halibut-82.clerk.accounts.dev</string>
 	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add missing macOS sandbox entitlements for network access
- Fixes DNS resolution failures on macOS ("A server with the specified hostname could not be found")

Without `com.apple.security.network.client`, sandboxed macOS apps cannot resolve DNS, causing Clerk authentication and Sentry telemetry to fail.

## Test plan
- [x] Verified login works on macOS after adding entitlements
- [x] iOS/iPadOS unaffected (they don't require explicit network entitlements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)