### PR TITLE
fix: position Active Stack banner at bottom on macOS

### DIFF
--- a/Dequeue/Dequeue/Views/App/MainTabView.swift
+++ b/Dequeue/Dequeue/Views/App/MainTabView.swift
@@ -123,12 +123,13 @@ struct MainTabView: View {
                 }
             }
         } detail: {
-            ZStack(alignment: .top) {
+            ZStack(alignment: .bottom) {
                 detailContent
+                    .frame(maxHeight: .infinity, alignment: .top)
 
                 activeStackBanner
                     .padding(.horizontal)
-                    .padding(.top, 8)
+                    .padding(.bottom, 16)
             }
         }
         .sheet(isPresented: $showAddSheet) {


### PR DESCRIPTION
## Summary
- Move Active Stack banner from top to bottom of detail pane on macOS
- Keeps content visible and matches iOS/iPadOS positioning

## Test plan
- [x] Verified banner appears at bottom on macOS
- [x] iOS/iPadOS layout unchanged (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)