### PR TITLE
feat: add explicit active stack tracking mechanism (DEQ-23)

### DIFF
--- a/Dequeue/CLAUDE.md
+++ b/Dequeue/CLAUDE.md
@@ -131,6 +131,16 @@ do {
 - Test on both iOS and macOS
 - **ALWAYS run tests locally before pushing**
 
+## Project Management
+
+- **Issue Tracker**: Linear (project key: DEQ)
+- **Always use Linear MCP** to fetch issue details when given a ticket ID (e.g., DEQ-10)
+- When starting work on an issue:
+  1. Update the Linear issue status to "In Progress"
+  2. Add a comment with your implementation plan/approach
+  3. Update the issue with any relevant findings or decisions
+- Issues follow format: DEQ-XX
+
 ## Git and Commit Guidelines
 
 - Create feature branches off main (`feat/`, `fix/`, `refactor/`)

--- a/Dequeue/Dequeue/Models/Stack.swift
+++ b/Dequeue/Dequeue/Models/Stack.swift
@@ -28,6 +28,9 @@ final class Stack {
     var updatedAt: Date
     var isDeleted: Bool
     var isDraft: Bool
+    /// Explicit tracking for the single active stack constraint.
+    /// Only one stack should have isActive = true at any time.
+    var isActive: Bool
 
     // Sync fields
     var userId: String?
@@ -68,6 +71,7 @@ final class Stack {
         updatedAt: Date = Date(),
         isDeleted: Bool = false,
         isDraft: Bool = false,
+        isActive: Bool = false,
         userId: String? = nil,
         deviceId: String? = nil,
         syncState: SyncState = .pending,
@@ -92,6 +96,7 @@ final class Stack {
         self.updatedAt = updatedAt
         self.isDeleted = isDeleted
         self.isDraft = isDraft
+        self.isActive = isActive
         self.userId = userId
         self.deviceId = deviceId
         self.syncState = syncState

--- a/Dequeue/Dequeue/Services/EventService.swift
+++ b/Dequeue/Dequeue/Services/EventService.swift
@@ -237,6 +237,7 @@ struct StackState: Codable {
     let updatedAt: Int64
     let deleted: Bool
     let isDraft: Bool
+    let isActive: Bool
 
     static func from(_ stack: Stack) -> StackState {
         StackState(
@@ -249,7 +250,8 @@ struct StackState: Codable {
             createdAt: Int64(stack.createdAt.timeIntervalSince1970 * 1_000),
             updatedAt: Int64(stack.updatedAt.timeIntervalSince1970 * 1_000),
             deleted: stack.isDeleted,
-            isDraft: stack.isDraft
+            isDraft: stack.isDraft,
+            isActive: stack.isActive
         )
     }
 }
@@ -484,11 +486,12 @@ struct StackEventPayload: Codable {
     let priority: Int?
     let sortOrder: Int
     let isDraft: Bool
+    let isActive: Bool
     let deleted: Bool
 
     // Handle status as string from server
     enum CodingKeys: String, CodingKey {
-        case id, title, description, status, priority, sortOrder, isDraft, deleted
+        case id, title, description, status, priority, sortOrder, isDraft, isActive, deleted
     }
 
     init(from decoder: Decoder) throws {
@@ -508,6 +511,7 @@ struct StackEventPayload: Codable {
         priority = try container.decodeIfPresent(Int.self, forKey: .priority)
         sortOrder = try container.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
         isDraft = try container.decodeIfPresent(Bool.self, forKey: .isDraft) ?? false
+        isActive = try container.decodeIfPresent(Bool.self, forKey: .isActive) ?? false
         deleted = try container.decodeIfPresent(Bool.self, forKey: .deleted) ?? false
     }
 
@@ -520,6 +524,7 @@ struct StackEventPayload: Codable {
         try container.encodeIfPresent(priority, forKey: .priority)
         try container.encode(sortOrder, forKey: .sortOrder)
         try container.encode(isDraft, forKey: .isDraft)
+        try container.encode(isActive, forKey: .isActive)
         try container.encode(deleted, forKey: .deleted)
     }
 }

--- a/Dequeue/DequeueTests/ActiveStackConstraintTests.swift
+++ b/Dequeue/DequeueTests/ActiveStackConstraintTests.swift
@@ -1,0 +1,269 @@
+//
+//  ActiveStackConstraintTests.swift
+//  DequeueTests
+//
+//  Tests for the single-active-stack constraint (DEQ-23)
+//
+
+import Testing
+import SwiftData
+import Foundation
+@testable import Dequeue
+
+@Suite("Active Stack Constraint Tests")
+struct ActiveStackConstraintTests {
+
+    // MARK: - Test Helpers
+
+    private func createTestContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: Stack.self, QueueTask.self, Reminder.self, Event.self,
+            configurations: config
+        )
+    }
+
+    // MARK: - Stack Model Tests
+
+    @Test("Stack initializes with isActive = false by default")
+    func stackInitializesWithIsActiveFalse() {
+        let stack = Stack(title: "Test Stack")
+        #expect(stack.isActive == false)
+    }
+
+    @Test("Stack can be initialized with isActive = true")
+    func stackInitializesWithIsActiveTrue() {
+        let stack = Stack(title: "Test Stack", isActive: true)
+        #expect(stack.isActive == true)
+    }
+
+    // MARK: - StackService.createStack Tests
+
+    @Test("First non-draft stack becomes active automatically")
+    @MainActor
+    func firstStackBecomesActive() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let stack = try service.createStack(title: "First Stack")
+
+        #expect(stack.isActive == true)
+    }
+
+    @Test("Draft stacks do not become active")
+    @MainActor
+    func draftStacksNotActive() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let draft = try service.createStack(title: "Draft Stack", isDraft: true)
+
+        #expect(draft.isActive == false)
+    }
+
+    @Test("Second stack is not active when first exists")
+    @MainActor
+    func secondStackNotActive() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let first = try service.createStack(title: "First Stack")
+        let second = try service.createStack(title: "Second Stack")
+
+        #expect(first.isActive == true)
+        #expect(second.isActive == false)
+    }
+
+    // MARK: - StackService.setAsActive Tests
+
+    @Test("setAsActive activates target stack")
+    @MainActor
+    func setAsActiveActivatesTarget() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let first = try service.createStack(title: "First Stack")
+        let second = try service.createStack(title: "Second Stack")
+
+        #expect(first.isActive == true)
+        #expect(second.isActive == false)
+
+        try service.setAsActive(second)
+
+        #expect(first.isActive == false)
+        #expect(second.isActive == true)
+    }
+
+    @Test("setAsActive deactivates all other stacks")
+    @MainActor
+    func setAsActiveDeactivatesOthers() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let first = try service.createStack(title: "First Stack")
+        let second = try service.createStack(title: "Second Stack")
+        let third = try service.createStack(title: "Third Stack")
+
+        // Manually set all to active to test deactivation
+        first.isActive = true
+        second.isActive = true
+        third.isActive = true
+        try context.save()
+
+        try service.setAsActive(third)
+
+        #expect(first.isActive == false)
+        #expect(second.isActive == false)
+        #expect(third.isActive == true)
+    }
+
+    @Test("Only one stack is active after multiple setAsActive calls")
+    @MainActor
+    func onlyOneActiveAfterMultipleCalls() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let first = try service.createStack(title: "First Stack")
+        let second = try service.createStack(title: "Second Stack")
+        let third = try service.createStack(title: "Third Stack")
+
+        try service.setAsActive(second)
+        try service.setAsActive(first)
+        try service.setAsActive(third)
+        try service.setAsActive(second)
+
+        let activeCount = [first, second, third].filter { $0.isActive }.count
+        #expect(activeCount == 1)
+        #expect(second.isActive == true)
+    }
+
+    // MARK: - getCurrentActiveStack Tests
+
+    @Test("getCurrentActiveStack returns the active stack")
+    @MainActor
+    func getCurrentActiveStackReturnsActive() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let first = try service.createStack(title: "First Stack")
+        _ = try service.createStack(title: "Second Stack")
+
+        let active = try service.getCurrentActiveStack()
+        #expect(active?.id == first.id)
+    }
+
+    @Test("getCurrentActiveStack returns nil when no active stack")
+    @MainActor
+    func getCurrentActiveStackReturnsNilWhenNone() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        // Create only drafts
+        _ = try service.createStack(title: "Draft 1", isDraft: true)
+        _ = try service.createStack(title: "Draft 2", isDraft: true)
+
+        let active = try service.getCurrentActiveStack()
+        #expect(active == nil)
+    }
+
+    // MARK: - Migration Tests
+
+    @Test("Migration activates first stack when none are active")
+    @MainActor
+    func migrationActivatesFirstStack() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+
+        // Manually create stacks without isActive set (simulates pre-migration data)
+        let stack1 = Stack(title: "Stack 1", sortOrder: 1, isActive: false)
+        let stack2 = Stack(title: "Stack 2", sortOrder: 0, isActive: false)
+        let stack3 = Stack(title: "Stack 3", sortOrder: 2, isActive: false)
+
+        context.insert(stack1)
+        context.insert(stack2)
+        context.insert(stack3)
+        try context.save()
+
+        let service = StackService(modelContext: context)
+        try service.migrateActiveStackState()
+
+        // Stack with sortOrder 0 should become active
+        #expect(stack2.isActive == true)
+        #expect(stack1.isActive == false)
+        #expect(stack3.isActive == false)
+    }
+
+    @Test("Migration keeps single active stack unchanged")
+    @MainActor
+    func migrationKeepsSingleActiveUnchanged() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+
+        let stack1 = Stack(title: "Stack 1", sortOrder: 0, isActive: false)
+        let stack2 = Stack(title: "Stack 2", sortOrder: 1, isActive: true)
+
+        context.insert(stack1)
+        context.insert(stack2)
+        try context.save()
+
+        let service = StackService(modelContext: context)
+        try service.migrateActiveStackState()
+
+        #expect(stack1.isActive == false)
+        #expect(stack2.isActive == true)
+    }
+
+    @Test("Migration resolves multiple active stacks")
+    @MainActor
+    func migrationResolvesMultipleActive() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+
+        let stack1 = Stack(title: "Stack 1", sortOrder: 2, isActive: true)
+        let stack2 = Stack(title: "Stack 2", sortOrder: 0, isActive: true)
+        let stack3 = Stack(title: "Stack 3", sortOrder: 1, isActive: true)
+
+        context.insert(stack1)
+        context.insert(stack2)
+        context.insert(stack3)
+        try context.save()
+
+        let service = StackService(modelContext: context)
+        try service.migrateActiveStackState()
+
+        // Only stack with lowest sortOrder should remain active
+        let activeCount = [stack1, stack2, stack3].filter { $0.isActive }.count
+        #expect(activeCount == 1)
+        #expect(stack2.isActive == true)
+    }
+
+    // MARK: - Persistence Tests
+
+    @Test("isActive state persists across fetch")
+    @MainActor
+    func isActiveStatePersists() async throws {
+        let container = try createTestContainer()
+        let context = ModelContext(container)
+        let service = StackService(modelContext: context)
+
+        let stack = try service.createStack(title: "Test Stack")
+        let stackId = stack.id
+
+        #expect(stack.isActive == true)
+
+        // Fetch the stack again
+        let predicate = #Predicate<Stack> { $0.id == stackId }
+        let descriptor = FetchDescriptor<Stack>(predicate: predicate)
+        let fetched = try context.fetch(descriptor).first
+
+        #expect(fetched?.isActive == true)
+    }
+}


### PR DESCRIPTION
## Summary

Implements explicit tracking to ensure only one stack is truly "active" at any time (DEQ-23).

### Changes
- Add `isActive: Bool` field to Stack model with default `false`
- Update `StackService.setAsActive()` to deactivate all other stacks atomically
- Update `createStack()` to auto-activate first non-draft stack
- Add `getCurrentActiveStack()` helper method for querying
- Add `migrateActiveStackState()` for existing data migration
- Update `StackState` and `StackEventPayload` for sync compatibility
- Add comprehensive unit tests (14 test cases)
- Update CLAUDE.md with Linear issue tracking guidelines

### Migration Strategy

The migration handles three scenarios:
1. **No stack is active** → activates stack with lowest sortOrder
2. **One stack is active** → no change needed  
3. **Multiple stacks active** → keeps only lowest sortOrder active

### Test Plan

- [x] All 14 new unit tests pass
- [x] All existing tests pass (no regressions)
- [x] SwiftLint passes with 0 violations
- [ ] Manual testing: Create stack, verify isActive = true
- [ ] Manual testing: Create second stack, verify first stays active
- [ ] Manual testing: Call setAsActive on second, verify first deactivates

**Linear Issue:** [DEQ-23](https://linear.app/dequeue/issue/DEQ-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)