### PR TITLE
feat: emit stack.deactivated event when activating another stack (DEQ-24)

### DIFF
--- a/Dequeue/Dequeue/Services/EventService.swift
+++ b/Dequeue/Dequeue/Services/EventService.swift
@@ -66,6 +66,15 @@ final class EventService {
         try recordEvent(type: .stackActivated, payload: payload, entityId: stack.id)
     }
 
+    func recordStackDeactivated(_ stack: Stack) throws {
+        let payload = StackStatusPayload(
+            stackId: stack.id,
+            status: StackStatus.active.rawValue,  // Captures state before deactivation
+            fullState: StackState.from(stack)
+        )
+        try recordEvent(type: .stackDeactivated, payload: payload, entityId: stack.id)
+    }
+
     func recordStackReordered(_ stacks: [Stack]) throws {
         let payload = StackReorderedPayload(
             stackIds: stacks.map { $0.id },

--- a/Dequeue/Dequeue/Services/StackService.swift
+++ b/Dequeue/Dequeue/Services/StackService.swift
@@ -170,6 +170,14 @@ final class StackService {
     func setAsActive(_ stack: Stack) throws {
         let activeStacks = try getActiveStacks()
 
+        // Find the currently active stack to record deactivation event BEFORE changing state
+        let previouslyActiveStack = activeStacks.first { $0.isActive && $0.id != stack.id }
+
+        // Record deactivation event for previously active stack (captures state while still active)
+        if let previousStack = previouslyActiveStack {
+            try eventService.recordStackDeactivated(previousStack)
+        }
+
         // Deactivate all other stacks and update sort orders
         for (index, activeStack) in activeStacks.enumerated() {
             if activeStack.id == stack.id {


### PR DESCRIPTION
## Summary
- Add `recordStackDeactivated()` method to EventService for recording stack deactivation events
- Update `setAsActive()` to emit `stack.deactivated` event BEFORE activating the new stack
- Deactivation event captures the stack's state while it's still active (`isActive=true`)
- No deactivation event is emitted when activating an already-active stack

## Event Sequence

When switching active stack from A to B:
1. `stack.deactivated` - Previous stack A (captures `isActive=true` state)
2. `stack.activated` - New stack B
3. `stack.reordered` - Updated sort orders

## Test Plan
- [x] Run SwiftLint - passes with 0 violations
- [x] Run unit tests locally - all pass
- [x] Added 4 new tests for deactivation event:
  - `setAsActiveEmitsDeactivatedEvent()` - Verifies event is emitted
  - `deactivatedEventBeforeActivatedEvent()` - Verifies event order
  - `noDeactivationEventForSameStack()` - No event when already active
  - `deactivationEventCapturesActiveState()` - Verifies `isActive=true` in payload

## Linear Issue
Closes DEQ-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)