### PR TITLE
feat(DEQ-19): Implement reminder edit functionality

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackDetailView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackDetailView.swift
@@ -34,6 +34,8 @@ struct StackDetailView: View {
     @State private var showAddReminder = false
     @State private var showSnoozePicker = false
     @State private var selectedReminderForSnooze: Reminder?
+    @State private var showEditReminder = false
+    @State private var selectedReminderForEdit: Reminder?
 
     private var stackService: StackService {
         StackService(modelContext: modelContext)
@@ -145,6 +147,15 @@ struct StackDetailView: View {
                             reminderActionHandler.snooze(reminder, until: snoozeUntil)
                             selectedReminderForSnooze = nil
                         }
+                    )
+                }
+            }
+            .sheet(isPresented: $showEditReminder) {
+                if let reminder = selectedReminderForEdit {
+                    AddReminderSheet(
+                        parent: .stack(stack),
+                        notificationService: notificationService,
+                        existingReminder: reminder
                     )
                 }
             }
@@ -318,7 +329,8 @@ struct StackDetailView: View {
             ReminderRowView(
                 reminder: reminder,
                 onTap: isReadOnly ? nil : {
-                    // TODO: DEQ-19 - Edit reminder
+                    selectedReminderForEdit = reminder
+                    showEditReminder = true
                 },
                 onSnooze: isReadOnly ? nil : {
                     selectedReminderForSnooze = reminder

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -28,6 +28,8 @@ struct TaskDetailView: View {
     @State private var showAddReminder = false
     @State private var showSnoozePicker = false
     @State private var selectedReminderForSnooze: Reminder?
+    @State private var showEditReminder = false
+    @State private var selectedReminderForEdit: Reminder?
 
     private var taskService: TaskService {
         TaskService(modelContext: modelContext)
@@ -110,6 +112,15 @@ struct TaskDetailView: View {
                         reminderActionHandler.snooze(reminder, until: snoozeUntil)
                         selectedReminderForSnooze = nil
                     }
+                )
+            }
+        }
+        .sheet(isPresented: $showEditReminder) {
+            if let reminder = selectedReminderForEdit {
+                AddReminderSheet(
+                    parent: .task(task),
+                    notificationService: notificationService,
+                    existingReminder: reminder
                 )
             }
         }
@@ -305,7 +316,8 @@ struct TaskDetailView: View {
                     ReminderRowView(
                         reminder: reminder,
                         onTap: {
-                            // TODO: DEQ-19 - Edit reminder
+                            selectedReminderForEdit = reminder
+                            showEditReminder = true
                         },
                         onSnooze: {
                             selectedReminderForSnooze = reminder


### PR DESCRIPTION
## Summary
- Add edit mode to existing AddReminderSheet (reused instead of creating new sheet)
- Pre-populate date picker with current reminder time when editing
- Update reminder time via ReminderService and reschedule notification
- Wire up tap handler on reminder rows to open edit sheet

## Changes
- **Modified**: `AddReminderSheet.swift` - Added `existingReminder` parameter for edit mode
- **Modified**: `TaskDetailView.swift` - Added edit state variables and sheet
- **Modified**: `StackDetailView.swift` - Added edit state variables and sheet

## How It Works
1. User taps a reminder row → edit sheet opens
2. Current reminder time is pre-filled in the date picker
3. User can modify using date picker or quick select buttons
4. On Save: existing notification cancelled, reminder updated, new notification scheduled
5. On Cancel: sheet dismissed with no changes

## Test Plan
- [x] iOS build succeeds
- [x] macOS build succeeds  
- [x] Unit tests pass
- [ ] Verify tapping reminder opens edit sheet (TaskDetailView)
- [ ] Verify tapping reminder opens edit sheet (StackDetailView)
- [ ] Verify current time is pre-filled
- [ ] Verify save updates reminder and reschedules notification
- [ ] Verify cancel discards changes

## Related
Closes DEQ-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)