### PR TITLE
feat: add lastActiveTime field to QueueTask model (DEQ-27)

### DIFF
--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -22,6 +22,7 @@ final class QueueTask {
     var priority: Int?
     var blockedReason: String?
     var sortOrder: Int
+    var lastActiveTime: Date?
     var createdAt: Date
     var updatedAt: Date
     var isDeleted: Bool
@@ -53,6 +54,7 @@ final class QueueTask {
         priority: Int? = nil,
         blockedReason: String? = nil,
         sortOrder: Int = 0,
+        lastActiveTime: Date? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         isDeleted: Bool = false,
@@ -76,6 +78,7 @@ final class QueueTask {
         self.priority = priority
         self.blockedReason = blockedReason
         self.sortOrder = sortOrder
+        self.lastActiveTime = lastActiveTime
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.isDeleted = isDeleted

--- a/Dequeue/Dequeue/Services/TaskService.swift
+++ b/Dequeue/Dequeue/Services/TaskService.swift
@@ -131,6 +131,9 @@ final class TaskService {
         stack.updatedAt = Date()
         stack.syncState = .pending
 
+        // Track when this task was last activated
+        task.lastActiveTime = Date()
+
         // Reorder tasks to maintain sort order consistency
         let pendingTasks = stack.pendingTasks
         var reorderedTasks = pendingTasks.filter { $0.id != task.id }

--- a/Dequeue/Dequeue/Sync/ProjectorService.swift
+++ b/Dequeue/Dequeue/Sync/ProjectorService.swift
@@ -276,6 +276,7 @@ enum ProjectorService {
                 status: payload.status,
                 priority: payload.priority,
                 sortOrder: payload.sortOrder,
+                lastActiveTime: payload.lastActiveTime,
                 syncState: .synced,
                 lastSyncedAt: Date()
             )
@@ -345,6 +346,7 @@ enum ProjectorService {
 
         task.status = .pending
         task.sortOrder = 0
+        task.lastActiveTime = event.timestamp  // Track when task was activated
         task.updatedAt = event.timestamp  // LWW: Use event timestamp
         task.syncState = .synced
         task.lastSyncedAt = Date()
@@ -516,6 +518,7 @@ enum ProjectorService {
         task.status = payload.status
         task.priority = payload.priority
         task.sortOrder = payload.sortOrder
+        task.lastActiveTime = payload.lastActiveTime
         task.updatedAt = eventTimestamp  // LWW: Use event timestamp for determinism
         task.syncState = .synced
         task.lastSyncedAt = Date()


### PR DESCRIPTION
## Summary
- Add `lastActiveTime: Date?` field to QueueTask model to track when a task was last activated
- Update TaskState and TaskEventPayload to include lastActiveTime for event sourcing
- Set lastActiveTime in TaskService.activateTask() when a task is activated
- Handle lastActiveTime in ProjectorService sync processing for cross-device sync
- Add comprehensive unit tests for lastActiveTime functionality

This complements the existing `activeTaskId` on Stack to provide full activation history, enabling features like "last worked on" sorting and time tracking.

## Test plan
- [x] Unit tests for QueueTask initialization with/without lastActiveTime
- [x] Unit test verifying activateTask() sets lastActiveTime
- [x] Unit tests for TaskState capturing lastActiveTime from QueueTask
- [x] All existing tests pass (swiftlint clean, 90+ tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)