### PR TITLE
feat(DEQ-20): Add confirmation dialog before reminder deletion

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackDetailView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackDetailView.swift
@@ -36,6 +36,8 @@ struct StackDetailView: View {
     @State private var selectedReminderForSnooze: Reminder?
     @State private var showEditReminder = false
     @State private var selectedReminderForEdit: Reminder?
+    @State private var showDeleteReminderConfirmation = false
+    @State private var reminderToDelete: Reminder?
 
     private var stackService: StackService {
         StackService(modelContext: modelContext)
@@ -158,6 +160,14 @@ struct StackDetailView: View {
                         existingReminder: reminder
                     )
                 }
+            }
+            .confirmationDialog("Delete Reminder", isPresented: $showDeleteReminderConfirmation) {
+                Button("Delete", role: .destructive) {
+                    if let reminder = reminderToDelete { reminderActionHandler.delete(reminder) }
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("Are you sure you want to delete this reminder?")
             }
         }
     }
@@ -337,7 +347,8 @@ struct StackDetailView: View {
                     showSnoozePicker = true
                 },
                 onDelete: isReadOnly ? nil : {
-                    reminderActionHandler.delete(reminder)
+                    reminderToDelete = reminder
+                    showDeleteReminderConfirmation = true
                 }
             )
         }
@@ -465,13 +476,6 @@ struct StackDetailView: View {
         newTaskTitle = ""
         newTaskDescription = ""
         showAddTask = false
-    }
-
-    private func deleteReminders(at offsets: IndexSet) {
-        let remindersToDelete = offsets.map { stack.activeReminders[$0] }
-        for reminder in remindersToDelete {
-            reminderActionHandler.delete(reminder)
-        }
     }
 
     private func showError(_ error: Error) {

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -30,6 +30,8 @@ struct TaskDetailView: View {
     @State private var selectedReminderForSnooze: Reminder?
     @State private var showEditReminder = false
     @State private var selectedReminderForEdit: Reminder?
+    @State private var showDeleteReminderConfirmation = false
+    @State private var reminderToDelete: Reminder?
 
     private var taskService: TaskService {
         TaskService(modelContext: modelContext)
@@ -123,6 +125,14 @@ struct TaskDetailView: View {
                     existingReminder: reminder
                 )
             }
+        }
+        .confirmationDialog("Delete Reminder", isPresented: $showDeleteReminderConfirmation) {
+            Button("Delete", role: .destructive) {
+                if let reminder = reminderToDelete { reminderActionHandler.delete(reminder) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Are you sure you want to delete this reminder?")
         }
     }
 
@@ -324,7 +334,8 @@ struct TaskDetailView: View {
                             showSnoozePicker = true
                         },
                         onDelete: {
-                            reminderActionHandler.delete(reminder)
+                            reminderToDelete = reminder
+                            showDeleteReminderConfirmation = true
                         }
                     )
                 }


### PR DESCRIPTION
## Summary
- Add confirmation alert that prompts user before deleting reminders, preventing accidental deletion
- Applied to both TaskDetailView and StackDetailView
- Removed unused `deleteReminders` function from StackDetailView (dead code cleanup)

## Changes
- `TaskDetailView.swift`: Added `showDeleteReminderConfirmation` state and confirmation dialog
- `StackDetailView.swift`: Added same confirmation pattern, removed unused `deleteReminders` function

## Test Plan
- [ ] Swipe to delete on a reminder → confirmation dialog appears
- [ ] Tap "Delete" → reminder is deleted
- [ ] Tap "Cancel" → reminder is preserved
- [ ] Test on both Task and Stack detail views
- [ ] Verify macOS and iOS builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)