### PR TITLE
fix(DEQ-100): Reminders appear immediately after creation

### DIFF
--- a/Dequeue/Dequeue/Services/ReminderService.swift
+++ b/Dequeue/Dequeue/Services/ReminderService.swift
@@ -28,6 +28,7 @@ final class ReminderService {
         )
 
         modelContext.insert(reminder)
+        task.reminders.append(reminder)
         try eventService.recordReminderCreated(reminder)
         try modelContext.save()
 
@@ -42,6 +43,7 @@ final class ReminderService {
         )
 
         modelContext.insert(reminder)
+        stack.reminders.append(reminder)
         try eventService.recordReminderCreated(reminder)
         try modelContext.save()
 


### PR DESCRIPTION
## Summary

Fixes bug where newly created reminders didn't appear in the reminders list until the view was dismissed and reopened.

## Root Cause

`ReminderService.createReminder()` was setting `parentId` as a string reference but not adding the reminder to the parent's `reminders` array. Since `Stack.activeReminders` and `QueueTask.reminders` filter from this array, they returned empty.

## Fix

Added two lines to establish the SwiftData relationship:
- `task.reminders.append(reminder)` for task reminders  
- `stack.reminders.append(reminder)` for stack reminders

## Changes

- `ReminderService.swift`: Added relationship establishment in both `createReminder` methods

## Test Plan

- [ ] Create a reminder on a Stack → appears immediately in list
- [ ] Create a reminder on a Task → appears immediately in list
- [ ] Edit existing reminder → still works
- [ ] Delete reminder → still works

## Linked Issues

Closes DEQ-100

🤖 Generated with [Claude Code](https://claude.com/claude-code)