### PR TITLE
fix(DEQ-102): Fix notification badge number being cut off

### DIFF
--- a/Dequeue/Dequeue/Views/Home/HomeView.swift
+++ b/Dequeue/Dequeue/Views/Home/HomeView.swift
@@ -68,9 +68,11 @@ struct HomeView: View {
                                 .font(.caption2)
                                 .fontWeight(.bold)
                                 .foregroundStyle(.white)
-                                .padding(4)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .frame(minWidth: 16, minHeight: 16)
                                 .background(Color.red)
-                                .clipShape(Circle())
+                                .clipShape(Capsule())
                                 .offset(x: 8, y: -8)
                         }
                     }


### PR DESCRIPTION
## Summary

- Badge showing overdue reminder count was being cut off by Circle clip shape
- Fixed by using Capsule shape and proper padding/minimum sizing

## Changes

- Use `.padding(.horizontal, 5)` and `.padding(.vertical, 2)` instead of uniform `.padding(4)`
- Add `.frame(minWidth: 16, minHeight: 16)` to ensure proper sizing for single digits
- Use `.clipShape(Capsule())` instead of `.clipShape(Circle())` - stretches horizontally for multi-digit numbers

## Before/After

| Before | After |
|--------|-------|
| Circle clips "12" | Capsule expands to fit "12" |

## Test plan

- [ ] Single digit (1-9) displays correctly in circular badge
- [ ] Double digit (10+) displays correctly in pill-shaped badge
- [ ] Badge positioning doesn't overlap navigation elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)