### PR TITLE
fix(DEQ-103): Add dismiss action for overdue reminders

### DIFF
--- a/Dequeue/Dequeue/Services/ReminderService.swift
+++ b/Dequeue/Dequeue/Services/ReminderService.swift
@@ -72,6 +72,19 @@ final class ReminderService {
         try modelContext.save()
     }
 
+    // MARK: - Dismiss
+
+    /// Dismisses an overdue reminder, marking it as handled without deleting it.
+    /// This removes it from the active/overdue lists and decreases the badge count.
+    func dismissReminder(_ reminder: Reminder) throws {
+        reminder.status = .fired
+        reminder.updatedAt = Date()
+        reminder.syncState = .pending
+
+        try eventService.recordReminderUpdated(reminder)
+        try modelContext.save()
+    }
+
     // MARK: - Delete
 
     func deleteReminder(_ reminder: Reminder) throws {

--- a/Dequeue/Dequeue/Views/Reminder/ReminderActionHandler.swift
+++ b/Dequeue/Dequeue/Views/Reminder/ReminderActionHandler.swift
@@ -57,4 +57,19 @@ struct ReminderActionHandler {
             onError(error)
         }
     }
+
+    /// Dismisses an overdue reminder, marking it as handled.
+    /// This removes it from the active/overdue list without deleting it.
+    func dismiss(_ reminder: Reminder) {
+        do {
+            // Cancel notification (if any)
+            Task {
+                await notificationService.cancelNotification(for: reminder)
+            }
+
+            try reminderService.dismissReminder(reminder)
+        } catch {
+            onError(error)
+        }
+    }
 }

--- a/Dequeue/Dequeue/Views/Reminder/ReminderRowView.swift
+++ b/Dequeue/Dequeue/Views/Reminder/ReminderRowView.swift
@@ -13,6 +13,7 @@ struct ReminderRowView: View {
     var parentTitle: String?
     var onTap: (() -> Void)?
     var onSnooze: (() -> Void)?
+    var onDismiss: (() -> Void)?
     var onDelete: (() -> Void)?
 
     var body: some View {
@@ -22,13 +23,22 @@ struct ReminderRowView: View {
             rowContent
         }
         .buttonStyle(.plain)
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if let onDelete {
                 Button(role: .destructive) {
                     onDelete()
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
+            }
+            // Dismiss action for overdue reminders
+            if let onDismiss, reminder.isPastDue {
+                Button {
+                    onDismiss()
+                } label: {
+                    Label("Dismiss", systemImage: "checkmark.circle")
+                }
+                .tint(.green)
             }
         }
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -183,6 +193,9 @@ struct ReminderRowView: View {
         }
         if onSnooze != nil && reminder.status != .snoozed {
             hints.append("Swipe right to snooze")
+        }
+        if onDismiss != nil && reminder.isPastDue {
+            hints.append("Swipe left to dismiss")
         }
         if onDelete != nil {
             hints.append("Swipe left to delete")

--- a/Dequeue/Dequeue/Views/Reminder/RemindersListView.swift
+++ b/Dequeue/Dequeue/Views/Reminder/RemindersListView.swift
@@ -233,6 +233,9 @@ struct RemindersListView: View {
                 selectedReminderForSnooze = reminder
                 showSnoozePicker = true
             } : nil,
+            onDismiss: reminder.isPastDue ? {
+                reminderActionHandler.dismiss(reminder)
+            } : nil,
             onDelete: {
                 reminderToDelete = reminder
                 showDeleteConfirmation = true


### PR DESCRIPTION
## Summary
- Add `dismissReminder()` to ReminderService that marks reminders as `.fired` (handled)
- Add `dismiss()` method to ReminderActionHandler for UI integration
- Add `onDismiss` parameter to ReminderRowView with green swipe action
- Wire up dismiss handler in RemindersListView for overdue reminders only

## User Experience
Users can now swipe left on overdue reminders to reveal a green "Dismiss" action (checkmark icon). This marks the reminder as handled without deleting it, which:
- Removes it from the active/overdue lists
- Decreases the badge count
- Preserves the reminder data for history/sync purposes

## Test plan
- [ ] Open reminders list with overdue reminders
- [ ] Swipe left on an overdue reminder to see Dismiss action
- [ ] Tap Dismiss - verify reminder disappears from list
- [ ] Verify badge count decreases
- [ ] Verify non-overdue reminders don't show Dismiss action

🤖 Generated with [Claude Code](https://claude.com/claude-code)