### PR TITLE
fix: Event decoding for stack.updated and macOS Event Details modal

### DIFF
--- a/Dequeue/Dequeue/Views/Settings/EventLogView.swift
+++ b/Dequeue/Dequeue/Views/Settings/EventLogView.swift
@@ -205,6 +205,9 @@ struct EventDetailView: View {
                 }
             }
         }
+        #if os(macOS)
+        .frame(minWidth: 500, minHeight: 400)
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary
Two bug fixes:

1. **Sync hydration bug**: `stack.updated` events weren't properly hydrating on other devices - only showing first letter of title
2. **macOS Event Log bug**: Event Details modal was blank on macOS

## Root Causes

### Bug 1: Sync hydration
The `decodePayload` method only checked for `state` wrapper but `stack.updated` events use `fullState` wrapper:
```json
{
  "stackId": "...",
  "changes": {...},
  "fullState": { "id": "...", "title": "..." }  // <-- decoder wasn't finding this
}
```

### Bug 2: macOS modal
macOS sheets need explicit sizing constraints or they collapse to minimum size.

## Changes
- **Event.swift**: Check for both `fullState` and `state` wrappers when decoding
- **EventLogView.swift**: Add `frame(minWidth: 500, minHeight: 400)` for macOS

## Test plan
- [ ] Create a draft stack with a title on Device A
- [ ] Verify it syncs correctly to Device B with full title (not just first letter)
- [ ] On macOS, open Settings > Event Log and tap an event
- [ ] Verify Event Details modal shows full content

🤖 Generated with [Claude Code](https://claude.com/claude-code)