### PR TITLE
feat: add Set as Active button to Stack Detail page (DEQ-63)

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -181,12 +181,31 @@ extension StackEditorView {
     var actionsSection: some View {
         if !isReadOnly && !isCreateMode {
             Section {
+                if case .edit(let stack) = mode, !stack.isActive {
+                    Button {
+                        setStackActive()
+                    } label: {
+                        Label("Set as Active Stack", systemImage: "star.fill")
+                    }
+                }
+
                 Button(role: .destructive) {
                     showCloseConfirmation = true
                 } label: {
                     Label("Close Without Completing", systemImage: "xmark.circle")
                 }
             }
+        }
+    }
+
+    func setStackActive() {
+        guard case .edit(let stack) = mode else { return }
+
+        do {
+            try stackService.setAsActive(stack)
+            dismiss()
+        } catch {
+            handleError(error)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add "Set as Active Stack" button to the actions section of the Stack Detail page
- Button only appears for non-active stacks
- Calls `stackService.setAsActive()` to make the stack active, then dismisses the view

## Test plan
- [ ] Navigate to a stack that is NOT currently active
- [ ] Verify "Set as Active Stack" button appears in Actions section
- [ ] Tap the button
- [ ] Verify the stack becomes the active stack
- [ ] Verify the view dismisses
- [ ] Navigate to the already-active stack
- [ ] Verify the "Set as Active Stack" button does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)