### PR TITLE
refactor: rename Done button to Complete on Stack Detail page (DEQ-64)

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -237,7 +237,7 @@ struct StackEditorView: View {
             }
             if !isReadOnly {
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { showCompleteConfirmation = true }
+                    Button("Complete") { showCompleteConfirmation = true }
                         .fontWeight(.semibold)
                 }
             }


### PR DESCRIPTION
## Summary
- Change toolbar button text from "Done" to "Complete" on Stack Detail page
- Provides clearer indication of the action being performed

## Test plan
- [ ] Open a Stack Detail page
- [ ] Verify the toolbar button says "Complete" (not "Done")
- [ ] Tap the button and verify it still triggers the complete stack confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)