### PR TITLE
feat: add Set as Active button and rename Done to Complete on Task Detail (DEQ-110)

### DIFF
--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -66,7 +66,7 @@ struct TaskDetailView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 if task.status != .completed {
-                    Button("Done") {
+                    Button("Complete") {
                         completeTask()
                     }
                     .fontWeight(.semibold)
@@ -357,6 +357,14 @@ struct TaskDetailView: View {
 
     private var actionsSection: some View {
         Section {
+            if task.status == .pending && !isActiveTask {
+                Button {
+                    setTaskActive()
+                } label: {
+                    Label("Set as Active Task", systemImage: "star.fill")
+                }
+            }
+
             if task.status == .blocked {
                 Button {
                     unblockTask()
@@ -446,6 +454,14 @@ struct TaskDetailView: View {
     private func unblockTask() {
         do {
             try taskService.unblock(task)
+        } catch {
+            showError(error)
+        }
+    }
+
+    private func setTaskActive() {
+        do {
+            try taskService.activateTask(task)
         } catch {
             showError(error)
         }


### PR DESCRIPTION
## Summary
- Add "Set as Active Task" button to the Task Detail page actions section
- Button only appears for pending tasks that are not already active
- Calls `taskService.activateTask()` to make the task the active task in its stack
- Rename toolbar button from "Done" to "Complete" for consistency with Stack Detail page (DEQ-64)

## Test plan
- [ ] Navigate to a task that is NOT currently the active task in its stack
- [ ] Verify "Set as Active Task" button appears in Actions section
- [ ] Tap the button
- [ ] Verify the task becomes the active task (shows "Active" badge)
- [ ] Navigate to the already-active task
- [ ] Verify the "Set as Active Task" button does NOT appear
- [ ] Verify the toolbar button says "Complete" (not "Done")
- [ ] Tap Complete and verify it still completes the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)