### PR TITLE
fix: add proper display for task.activated events in History view (DEQ-113)

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
@@ -136,6 +136,7 @@ struct StackHistoryRow: View {
         case "task.created": return "Task Added"
         case "task.updated": return "Task Updated"
         case "task.completed": return "Task Completed"
+        case "task.activated": return "Task Activated"
         case "task.deleted": return "Task Deleted"
         case "task.reordered": return "Tasks Reordered"
         // Reminder events
@@ -162,6 +163,7 @@ struct StackHistoryRow: View {
         case "task.created": return "checklist"
         case "task.updated": return "pencil"
         case "task.completed": return "checkmark.square.fill"
+        case "task.activated": return "star.fill"
         case "task.deleted": return "trash"
         case "task.reordered": return "arrow.up.arrow.down"
         // Reminder events
@@ -188,6 +190,7 @@ struct StackHistoryRow: View {
         case "task.created": return .teal
         case "task.updated": return .blue
         case "task.completed": return .purple
+        case "task.activated": return .cyan
         case "task.deleted": return .red
         case "task.reordered": return .secondary
         // Reminder events


### PR DESCRIPTION
## Summary
Fixes the Event History view to properly display `task.activated` events instead of showing raw event type with a question mark icon.

## Changes
Added `task.activated` to the three switch statements in `StackHistoryRow`:
- **Label**: "Task Activated" (was showing raw "task.activated")
- **Icon**: `star.fill` (was showing `questionmark.circle.fill`)
- **Color**: `.cyan` (was showing `.secondary`)

## Before/After
| Before | After |
|--------|-------|
| task.activated | Task Activated |
| ❓ | ⭐ |
| Gray | Cyan |

## Test plan
- [ ] Activate a task using the "Set as Active Task" button
- [ ] View the stack's Event History
- [ ] Verify "Task Activated" displays with star icon and cyan color
- [ ] Verify it matches the style of other task events

🤖 Generated with [Claude Code](https://claude.com/claude-code)