### PR TITLE
fix(DEQ-114): Fix infinite recursion crash in app badge update

### DIFF
--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -47,7 +47,7 @@ protocol NotificationCenterProtocol: Sendable {
     func pendingNotificationRequests() async -> [UNNotificationRequest]
     func getAuthorizationStatus() async -> UNAuthorizationStatus
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
-    func setBadgeCount(_ count: Int) async throws
+    func updateBadgeCount(_ count: Int) async throws
 }
 
 /// Extension to make UNUserNotificationCenter conform to our protocol
@@ -56,8 +56,8 @@ extension UNUserNotificationCenter: NotificationCenterProtocol {
         await notificationSettings().authorizationStatus
     }
 
-    func setBadgeCount(_ count: Int) async throws {
-        try await self.setBadgeCount(count)
+    func updateBadgeCount(_ count: Int) async throws {
+        try await setBadgeCount(count)
     }
 }
 
@@ -237,7 +237,7 @@ final class NotificationService: NSObject {
     func updateAppBadge() async {
         do {
             let overdueCount = try fetchOverdueReminderCount()
-            try await notificationCenter.setBadgeCount(overdueCount)
+            try await notificationCenter.updateBadgeCount(overdueCount)
         } catch {
             // Log error but don't throw - best effort badge update
             ErrorReportingService.capture(
@@ -249,7 +249,7 @@ final class NotificationService: NSObject {
 
     /// Clears the app badge
     func clearAppBadge() async {
-        try? await notificationCenter.setBadgeCount(0)
+        try? await notificationCenter.updateBadgeCount(0)
     }
 
     private func fetchOverdueReminderCount() throws -> Int {

--- a/Dequeue/DequeueTests/NotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/NotificationServiceTests.swift
@@ -58,7 +58,7 @@ final class MockNotificationCenter: NotificationCenterProtocol, @unchecked Senda
     }
 
     var badgeCount: Int = 0
-    func setBadgeCount(_ count: Int) async throws {
+    func updateBadgeCount(_ count: Int) async throws {
         badgeCount = count
     }
 }


### PR DESCRIPTION
## Summary

- Fixed infinite recursion crash when updating app badge count
- Root cause: Protocol method `setBadgeCount` shadowed `UNUserNotificationCenter.setBadgeCount`, causing the extension to call itself

## Changes

- Renamed protocol method from `setBadgeCount` to `updateBadgeCount` to avoid shadowing the system method
- Updated all call sites in `NotificationService`
- Updated mock in tests

## Test plan

- [x] All NotificationServiceTests pass (30/30)
- [x] Build succeeds on macOS and iOS
- [ ] Manual test: Verify badge updates without crash

Fixes DEQ-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)