### PR TITLE
feat(DEQ-116): Add navigation from Reminder to associated Stack/Task

### DIFF
--- a/Dequeue/Dequeue/Views/Reminder/ReminderRowView.swift
+++ b/Dequeue/Dequeue/Views/Reminder/ReminderRowView.swift
@@ -12,6 +12,7 @@ struct ReminderRowView: View {
     let reminder: Reminder
     var parentTitle: String?
     var onTap: (() -> Void)?
+    var onGoToItem: (() -> Void)?
     var onSnooze: (() -> Void)?
     var onDismiss: (() -> Void)?
     var onDelete: (() -> Void)?
@@ -49,6 +50,18 @@ struct ReminderRowView: View {
                 }
                 .tint(.orange)
             }
+            // Go to parent item (Stack or Task)
+            if let onGoToItem {
+                Button {
+                    onGoToItem()
+                } label: {
+                    Label(
+                        reminder.parentType == .task ? "Go to Task" : "Go to Stack",
+                        systemImage: reminder.parentType == .task ? "doc.text" : "square.stack.3d.up"
+                    )
+                }
+                .tint(.blue)
+            }
         }
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             if let onSnooze, reminder.status != .snoozed {
@@ -61,6 +74,17 @@ struct ReminderRowView: View {
             }
         }
         .contextMenu {
+            // Go to parent item - primary action
+            if let onGoToItem {
+                Button {
+                    onGoToItem()
+                } label: {
+                    Label(
+                        reminder.parentType == .task ? "Go to Task" : "Go to Stack",
+                        systemImage: reminder.parentType == .task ? "doc.text" : "square.stack.3d.up"
+                    )
+                }
+            }
             if let onSnooze, reminder.status != .snoozed {
                 Button {
                     onSnooze()
@@ -230,6 +254,10 @@ struct ReminderRowView: View {
 
         if onTap != nil {
             hints.append("Double tap to edit")
+        }
+        if onGoToItem != nil {
+            let itemType = reminder.parentType == .task ? "task" : "stack"
+            hints.append("Swipe left to go to \(itemType)")
         }
         if onSnooze != nil && reminder.status != .snoozed {
             hints.append("Swipe right to snooze")


### PR DESCRIPTION
## Summary
- Add "Go to Stack" and "Go to Task" navigation options to ReminderRowView
- New swipe action and context menu option for quick navigation
- Dismiss reminders sheet and navigate to the associated item

## Changes
- **ReminderRowView**: Added `onGoToItem` callback, swipe action (blue tint), and context menu option
- **RemindersListView**: Added `onGoToItem` parameter that dismisses sheet then calls parent callback
- **HomeView**: Added handler to navigate to Stack (StackEditorView) or Task (TaskDetailView)

## Test Plan
- [ ] Swipe left on a reminder and verify "Go to Stack" or "Go to Task" option appears with blue tint
- [ ] Long-press on a reminder and verify "Go to Stack/Task" is first option in context menu
- [ ] Tap the action and verify the reminders sheet dismisses, then the correct Stack/Task opens
- [ ] Test with both Stack reminders and Task reminders
- [ ] Verify accessibility labels read correctly

Linear: DEQ-116

🤖 Generated with [Claude Code](https://claude.com/claude-code)