### PR TITLE
fix(DEQ-117): Fix macOS Event History blank view and title consistency

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
@@ -33,9 +33,15 @@ struct StackHistoryView: View {
                 historyList
             }
         }
-        .navigationTitle("History")
-        .task {
-            await loadHistory()
+        .navigationTitle("Event History")
+        .onAppear {
+            // Use onAppear instead of .task for better macOS compatibility
+            // in nested navigation contexts (e.g., NavigationLink inside a sheet)
+            if events.isEmpty && isLoading {
+                Task {
+                    await loadHistory()
+                }
+            }
         }
         .confirmationDialog(
             "Revert to this version?",

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -503,24 +503,33 @@ struct TaskHistoryView: View {
     @Environment(\.modelContext) private var modelContext
 
     @State private var events: [Event] = []
+    @State private var isLoading = true
 
     var body: some View {
-        List {
-            if events.isEmpty {
+        Group {
+            if isLoading {
+                ProgressView("Loading history...")
+            } else if events.isEmpty {
                 ContentUnavailableView {
                     Label("No History", systemImage: "clock")
                 } description: {
                     Text("No events recorded for this task")
                 }
             } else {
-                ForEach(events) { event in
-                    EventRowView(event: event)
+                List {
+                    ForEach(events) { event in
+                        EventRowView(event: event)
+                    }
                 }
             }
         }
-        .navigationTitle("Task History")
-        .task {
-            loadEvents()
+        .navigationTitle("Event History")
+        .onAppear {
+            // Use onAppear instead of .task for better macOS compatibility
+            // in nested navigation contexts (e.g., NavigationLink inside a sheet)
+            if events.isEmpty && isLoading {
+                loadEvents()
+            }
         }
     }
 
@@ -538,6 +547,7 @@ struct TaskHistoryView: View {
         } catch {
             ErrorReportingService.capture(error: error, context: ["view": "TaskHistoryView"])
         }
+        isLoading = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix Event History showing blank on macOS
- Fix inconsistent title ("History" vs "Event History")

## Root Cause
The `.task` modifier was not firing reliably on macOS when navigating via NavigationLink inside a sheet context. This caused the history to never load, resulting in a blank view.

## Changes
- **StackHistoryView**: Changed title from "History" to "Event History", replaced `.task` with `.onAppear`
- **TaskHistoryView**: Changed title from "Task History" to "Event History" for consistency, replaced `.task` with `.onAppear`, added loading state with ProgressView

## Test Plan
- [ ] Open a Stack on macOS and click "Event History" - verify events load and title says "Event History"
- [ ] Open a Task on macOS and click "Event History" - verify events load and title says "Event History"
- [ ] Verify iOS still works correctly (Event History for both Stack and Task)
- [ ] Verify loading spinner shows briefly while data loads

Linear: DEQ-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)