### PR TITLE
Fix active stack showing set active button

### DIFF
--- a/Dequeue/Dequeue/Views/Components/ActiveStackBanner.swift
+++ b/Dequeue/Dequeue/Views/Components/ActiveStackBanner.swift
@@ -18,15 +18,14 @@ struct ActiveStackBanner: View {
         onStackTapped: @escaping (Stack) -> Void,
         onEmptyTapped: @escaping () -> Void
     ) {
-        // Query for the active stack: sortOrder == 0, status == active, not deleted/draft
-        let activeRawValue = StackStatus.active.rawValue
+        // Query for the explicitly active stack (isActive == true)
+        // This ensures consistency with StackService.getCurrentActiveStack()
         _activeStacks = Query(
             filter: #Predicate<Stack> { stack in
                 stack.isDeleted == false &&
                 stack.isDraft == false &&
-                stack.statusRawValue == activeRawValue
-            },
-            sort: \Stack.sortOrder
+                stack.isActive == true
+            }
         )
         self.onStackTapped = onStackTapped
         self.onEmptyTapped = onEmptyTapped
@@ -155,7 +154,8 @@ private enum BannerConstants {
         title: "My Active Stack",
         stackDescription: "Working on the new feature implementation",
         status: .active,
-        sortOrder: 0
+        sortOrder: 0,
+        isActive: true
     )
     container.mainContext.insert(stack)
 


### PR DESCRIPTION
The banner was querying stacks by statusRawValue and sortOrder, which could show a stack as "active" even when its isActive property was false. This caused the "Set as Active Stack" button to appear on already-active stacks, leading to constraint violations when tapped.

Now queries by isActive == true, consistent with
StackService.getCurrentActiveStack().