### PR TITLE
feat: add automatic build number bump on merge to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,54 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+
+# Prevent infinite loops - don't run on commits from this workflow
+jobs:
+  bump-version:
+    name: Bump Build Number
+    runs-on: macos-14
+    # Skip if the commit was made by this workflow (prevents infinite loop)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Get current build number
+        id: get-version
+        run: |
+          # Extract current build number from project.pbxproj
+          CURRENT_BUILD=$(grep -m 1 'CURRENT_PROJECT_VERSION = ' Dequeue/Dequeue.xcodeproj/project.pbxproj | sed 's/.*= //' | sed 's/;.*//')
+          echo "Current build number: $CURRENT_BUILD"
+          echo "current=$CURRENT_BUILD" >> $GITHUB_OUTPUT
+
+      - name: Increment build number
+        id: bump-version
+        run: |
+          CURRENT_BUILD=${{ steps.get-version.outputs.current }}
+          NEW_BUILD=$((CURRENT_BUILD + 1))
+          echo "New build number: $NEW_BUILD"
+          echo "new=$NEW_BUILD" >> $GITHUB_OUTPUT
+
+          # Update all occurrences of CURRENT_PROJECT_VERSION in project.pbxproj
+          sed -i '' "s/CURRENT_PROJECT_VERSION = ${CURRENT_BUILD};/CURRENT_PROJECT_VERSION = ${NEW_BUILD};/g" Dequeue/Dequeue.xcodeproj/project.pbxproj
+
+          # Verify the change
+          grep 'CURRENT_PROJECT_VERSION' Dequeue/Dequeue.xcodeproj/project.pbxproj
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add Dequeue/Dequeue.xcodeproj/project.pbxproj
+          git commit -m "chore: bump build number to ${{ steps.bump-version.outputs.new }} [skip ci]"
+          git push


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically increments the build number when code is merged to main
- Uses `[skip ci]` in commit message to prevent infinite loops
- Updates `CURRENT_PROJECT_VERSION` in project.pbxproj

## How it works
1. Workflow triggers on push to main
2. Extracts current build number from project.pbxproj
3. Increments by 1
4. Commits and pushes the change with `[skip ci]`

## Test plan
- [ ] Merge this PR
- [ ] Verify the version-bump workflow runs
- [ ] Verify build number is incremented in project.pbxproj

🤖 Generated with [Claude Code](https://claude.com/claude-code)