### PR TITLE
fix(DEQ-53): Add large presentation detent for landscape layouts

### DIFF
--- a/Dequeue/Dequeue/Views/Reminder/AddReminderSheet.swift
+++ b/Dequeue/Dequeue/Views/Reminder/AddReminderSheet.swift
@@ -102,7 +102,7 @@ struct AddReminderSheet: View {
                 Text(errorMessage)
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .task {
             await checkPermissionState()
         }

--- a/Dequeue/Dequeue/Views/Reminder/SnoozePickerSheet.swift
+++ b/Dequeue/Dequeue/Views/Reminder/SnoozePickerSheet.swift
@@ -65,7 +65,7 @@ struct SnoozePickerSheet: View {
             }
         }
         #if os(iOS)
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         #endif
     }
 }


### PR DESCRIPTION
## Summary
- Add `.large` detent option to iOS sheet presentations to improve landscape orientation usability
- Users can now expand sheets when in landscape mode where vertical space is limited

## Changes
- `AddReminderSheet.swift`: Added `.large` detent alongside `.medium`
- `SnoozePickerSheet.swift`: Added `.large` detent alongside `.medium`

## Test plan
- [x] Build project successfully
- [x] Run swiftlint - no violations
- [x] Run unit tests - all pass
- [ ] Manual testing: Verify AddReminderSheet in landscape allows expansion
- [ ] Manual testing: Verify SnoozePickerSheet in landscape allows expansion

## Linear Issue
Fixes DEQ-53

🤖 Generated with [Claude Code](https://claude.com/claude-code)