### PR TITLE
feat(DEQ-41): Implement task uncomplete functionality

### DIFF
--- a/Dequeue/Dequeue/Models/Enums.swift
+++ b/Dequeue/Dequeue/Models/Enums.swift
@@ -56,6 +56,7 @@ enum EventType: String, Codable, CaseIterable {
     case taskDeleted = "task.deleted"
     case taskActivated = "task.activated"
     case taskCompleted = "task.completed"
+    case taskUncompleted = "task.uncompleted"
     case taskClosed = "task.closed"
     case taskReordered = "task.reordered"
 

--- a/Dequeue/Dequeue/Services/EventService.swift
+++ b/Dequeue/Dequeue/Services/EventService.swift
@@ -119,6 +119,16 @@ final class EventService {
         try recordEvent(type: .taskCompleted, payload: payload, entityId: task.id)
     }
 
+    func recordTaskUncompleted(_ task: QueueTask) throws {
+        let payload = TaskStatusPayload(
+            taskId: task.id,
+            stackId: task.stack?.id ?? "",
+            status: TaskStatus.pending.rawValue,
+            fullState: TaskState.from(task)
+        )
+        try recordEvent(type: .taskUncompleted, payload: payload, entityId: task.id)
+    }
+
     func recordTaskActivated(_ task: QueueTask) throws {
         let payload = TaskStatusPayload(
             taskId: task.id,

--- a/Dequeue/Dequeue/Services/TaskService.swift
+++ b/Dequeue/Dequeue/Services/TaskService.swift
@@ -68,6 +68,15 @@ final class TaskService {
         try modelContext.save()
     }
 
+    func markAsUncompleted(_ task: QueueTask) throws {
+        task.status = .pending
+        task.updatedAt = Date()
+        task.syncState = .pending
+
+        try eventService.recordTaskUncompleted(task)
+        try modelContext.save()
+    }
+
     func markAsBlocked(_ task: QueueTask, reason: String?) throws {
         task.status = .blocked
         task.blockedReason = reason

--- a/Dequeue/Dequeue/Sync/ProjectorService.swift
+++ b/Dequeue/Dequeue/Sync/ProjectorService.swift
@@ -46,6 +46,8 @@ enum ProjectorService {
             try applyTaskDeleted(event: event, context: context)
         case .taskCompleted:
             try applyTaskCompleted(event: event, context: context)
+        case .taskUncompleted:
+            try applyTaskUncompleted(event: event, context: context)
         case .taskActivated:
             try applyTaskActivated(event: event, context: context)
         case .taskClosed:
@@ -329,6 +331,22 @@ enum ProjectorService {
         guard event.timestamp > task.updatedAt else { return }
 
         task.status = .completed
+        task.updatedAt = event.timestamp  // LWW: Use event timestamp
+        task.syncState = .synced
+        task.lastSyncedAt = Date()
+    }
+
+    private static func applyTaskUncompleted(event: Event, context: ModelContext) throws {
+        let payload = try event.decodePayload(EntityStatusPayload.self)
+        guard let task = try findTask(id: payload.id, context: context) else { return }
+
+        // LWW: Skip updates to deleted entities
+        guard !task.isDeleted else { return }
+
+        // LWW: Only apply if this event is newer than current state
+        guard event.timestamp > task.updatedAt else { return }
+
+        task.status = .pending
         task.updatedAt = event.timestamp  // LWW: Use event timestamp
         task.syncState = .synced
         task.lastSyncedAt = Date()

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -159,7 +159,10 @@ extension StackEditorView {
                         NavigationLink {
                             TaskDetailView(task: task)
                         } label: {
-                            CompletedTaskRowView(task: task)
+                            CompletedTaskRowView(
+                                task: task,
+                                onUncomplete: isReadOnly ? nil : { uncompleteTask(task) }
+                            )
                         }
                         .buttonStyle(.plain)
                     }
@@ -245,6 +248,14 @@ extension StackEditorView {
             if task.status != .completed {
                 try taskService.markAsCompleted(task)
             }
+        } catch {
+            handleError(error)
+        }
+    }
+
+    func uncompleteTask(_ task: QueueTask) {
+        do {
+            try taskService.markAsUncompleted(task)
         } catch {
             handleError(error)
         }

--- a/Dequeue/Dequeue/Views/Task/TaskRowViews.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskRowViews.swift
@@ -99,12 +99,11 @@ private struct ActiveBadge: View {
 
 struct CompletedTaskRowView: View {
     let task: QueueTask
+    var onUncomplete: (() -> Void)?
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.title2)
-                .foregroundStyle(.green)
+            leadingIcon
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(task.title)
@@ -117,5 +116,25 @@ struct CompletedTaskRowView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var leadingIcon: some View {
+        if let onUncomplete {
+            Button {
+                onUncomplete()
+            } label: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.green)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Mark as incomplete")
+            .accessibilityHint("Moves task back to pending")
+        } else {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.green)
+        }
     }
 }

--- a/Dequeue/DequeueTests/TaskServiceTests.swift
+++ b/Dequeue/DequeueTests/TaskServiceTests.swift
@@ -173,4 +173,122 @@ struct TaskServiceTests {
         #expect(stack.pendingTasks.isEmpty)
         #expect(stack.completedTasks.count == 1)
     }
+
+    // MARK: - Mark Uncomplete Tests (DEQ-41)
+
+    @Test("markAsUncompleted changes task status back to pending")
+    @MainActor
+    func markAsUncompletedChangesStatus() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let stack = Stack(title: "Test Stack")
+        context.insert(stack)
+        let task = QueueTask(title: "Test Task", status: .completed, stack: stack)
+        context.insert(task)
+        stack.tasks.append(task)
+        try context.save()
+
+        let taskService = TaskService(modelContext: context)
+        try taskService.markAsUncompleted(task)
+
+        #expect(task.status == .pending)
+    }
+
+    @Test("uncompleted task moves from completedTasks to pendingTasks")
+    @MainActor
+    func uncompletedTaskMovesToPendingList() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let stack = Stack(title: "Test Stack")
+        context.insert(stack)
+        let task = QueueTask(title: "Test Task", status: .completed, stack: stack)
+        context.insert(task)
+        stack.tasks.append(task)
+        try context.save()
+
+        #expect(stack.pendingTasks.isEmpty)
+        #expect(stack.completedTasks.count == 1)
+
+        let taskService = TaskService(modelContext: context)
+        try taskService.markAsUncompleted(task)
+
+        #expect(stack.pendingTasks.count == 1)
+        #expect(stack.completedTasks.isEmpty)
+    }
+
+    @Test("markAsUncompleted updates syncState to pending")
+    @MainActor
+    func markAsUncompletedSetsSyncState() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let stack = Stack(title: "Test Stack")
+        context.insert(stack)
+        let task = QueueTask(title: "Test Task", status: .completed, stack: stack)
+        task.syncState = .synced
+        context.insert(task)
+        stack.tasks.append(task)
+        try context.save()
+
+        let taskService = TaskService(modelContext: context)
+        try taskService.markAsUncompleted(task)
+
+        #expect(task.syncState == .pending)
+    }
+
+    @Test("markAsUncompleted updates the updatedAt timestamp")
+    @MainActor
+    func markAsUncompletedUpdatesTimestamp() async throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let stack = Stack(title: "Test Stack")
+        context.insert(stack)
+        let task = QueueTask(title: "Test Task", status: .completed, stack: stack)
+        let originalUpdatedAt = task.updatedAt
+        context.insert(task)
+        stack.tasks.append(task)
+        try context.save()
+
+        // Wait a small amount to ensure timestamp difference
+        try await Task.sleep(for: .milliseconds(10))
+
+        let taskService = TaskService(modelContext: context)
+        try taskService.markAsUncompleted(task)
+
+        #expect(task.updatedAt > originalUpdatedAt)
+    }
+
+    @Test("complete then uncomplete round-trip preserves task data")
+    @MainActor
+    func completeUncompleteRoundTrip() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let stack = Stack(title: "Test Stack")
+        context.insert(stack)
+
+        let taskService = TaskService(modelContext: context)
+        let task = try taskService.createTask(
+            title: "Round Trip Task",
+            description: "Test description",
+            stack: stack
+        )
+
+        #expect(task.status == .pending)
+        #expect(stack.pendingTasks.count == 1)
+
+        // Complete the task
+        try taskService.markAsCompleted(task)
+        #expect(task.status == .completed)
+        #expect(stack.completedTasks.count == 1)
+        #expect(stack.pendingTasks.isEmpty)
+
+        // Uncomplete the task
+        try taskService.markAsUncompleted(task)
+        #expect(task.status == .pending)
+        #expect(stack.pendingTasks.count == 1)
+        #expect(stack.completedTasks.isEmpty)
+
+        // Verify original data preserved
+        #expect(task.title == "Round Trip Task")
+        #expect(task.taskDescription == "Test description")
+    }
 }


### PR DESCRIPTION
## Summary
- Add ability to mark completed tasks as uncompleted, moving them back to pending
- User can tap the green checkmark on completed tasks in the Completed section
- Includes full sync support via new `taskUncompleted` event type

## Changes
- **Enums.swift**: Add `taskUncompleted` event type for sync
- **EventService.swift**: Add `recordTaskUncompleted` method
- **TaskService.swift**: Add `markAsUncompleted` method
- **TaskRowViews.swift**: Update `CompletedTaskRowView` with optional `onUncomplete` callback
- **StackEditorView+EditMode.swift**: Wire up uncomplete action in completed tasks section
- **ProjectorService.swift**: Add `applyTaskUncompleted` for sync projection with LWW

## Test plan
- [x] Unit tests for TaskService.markAsUncompleted (5 new tests)
- [x] Test status changes from completed to pending
- [x] Test task moves between completedTasks and pendingTasks
- [x] Test syncState is set to pending
- [x] Test updatedAt timestamp is updated
- [x] Test complete/uncomplete round-trip preserves data
- [ ] Manual test: tap completed task checkmark, verify it moves to pending section

🤖 Generated with [Claude Code](https://claude.com/claude-code)