### PR TITLE
fix(DEQ-128): Fix Active Stack display and sort order bugs

### DIFF
--- a/Dequeue/Dequeue/Services/StackService.swift
+++ b/Dequeue/Dequeue/Services/StackService.swift
@@ -71,11 +71,21 @@ final class StackService {
         let existingActiveStacks = try getActiveStacks()
         let shouldBeActive = !isDraft && existingActiveStacks.isEmpty
 
+        // Determine sortOrder: active stack gets 0, inactive stacks get next available
+        let sortOrder: Int
+        if shouldBeActive {
+            sortOrder = 0
+        } else {
+            // Find the max sortOrder and add 1
+            let maxSortOrder = existingActiveStacks.map(\.sortOrder).max() ?? -1
+            sortOrder = maxSortOrder + 1
+        }
+
         let stack = Stack(
             title: title,
             stackDescription: description,
             status: .active,
-            sortOrder: 0,
+            sortOrder: sortOrder,
             isDraft: isDraft,
             isActive: shouldBeActive,
             syncState: .pending

--- a/Dequeue/Dequeue/Views/Home/HomeView.swift
+++ b/Dequeue/Dequeue/Views/Home/HomeView.swift
@@ -229,10 +229,11 @@ struct StackRowView: View {
 
                 Spacer()
 
-                if stack.sortOrder == 0 {
+                if stack.isActive {
                     Image(systemName: "star.fill")
                         .foregroundStyle(.yellow)
                         .font(.caption)
+                        .accessibilityLabel("Active stack")
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes multiple issues with Active Stack indicator (gold star) display and sort order management.

## Problem

When creating a new Stack:
- **Device A**: New Stack appeared second in list with gold star (should not have gold star)
- **Device A**: Old Stack also had gold star (TWO gold stars total)
- **Device B** (after sync): New Stack appeared first with gold star, but banner showed different Stack as Active
- UI inconsistency between ActiveStackBanner (correct) and list display (incorrect)

## Root Causes

### 1. Gold Star Display Bug
- **StackRowView** showed gold star for `sortOrder == 0` instead of `isActive == true`
- **ActiveStackBanner** correctly used `isActive == true`
- Result: Banner and list disagreed on what was "active"

### 2. Sort Order Collision
- `createStack()` always assigned `sortOrder = 0` to new Stacks
- When an active Stack already existed (also with `sortOrder = 0`), both had the same sortOrder
- Result: Multiple stacks with `sortOrder == 0`, unpredictable ordering

## Changes

### HomeView.swift (StackRowView)
```diff
- if stack.sortOrder == 0 {
+ if stack.isActive {
      Image(systemName: "star.fill")
          .foregroundStyle(.yellow)
          .font(.caption)
+         .accessibilityLabel("Active stack")
  }
```

### StackService.swift (createStack)
```swift
// Determine sortOrder: active stack gets 0, inactive stacks get next available
let sortOrder: Int
if shouldBeActive {
    sortOrder = 0
} else {
    // Find the max sortOrder and add 1
    let maxSortOrder = existingActiveStacks.map(\.sortOrder).max() ?? -1
    sortOrder = maxSortOrder + 1
}
```

## Testing

- ✅ Build succeeds on iOS Simulator
- ✅ SwiftLint passes (no new violations)
- ⏳ CI tests pending
- 📱 Device testing needed to verify sync behavior

## Expected Behavior After Fix

1. ✅ Only ONE Stack shows gold star (the one with `isActive == true`)
2. ✅ Creating new Stacks assigns proper sort order (no duplicates)
3. ✅ Banner and list agree on which Stack is Active
4. ✅ Sync maintains correct active/inactive state across devices

## Related

Closes DEQ-128