### PR TITLE
chore: remove accidentally committed local config files

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 7
-max_iterations: 0
-completion_promise: null
-started_at: "2026-01-04T03:15:52Z"
----
-
-We are working on an issue and I want your help fixing it. It is https://github.com/DequeueApp/dequeue-ios/pull/74 and we are working on multiple performance fixes. I want you to 1. Pull down the latest 2. Analyze the most recent comment from Claude Code on the PR 3. Address all of the feedback 4. Commit and push 5. Wait for CI to complete and for Claude Code to give feedback again 6. Repeat until Claude Code suggests merging it and the CI checks are all green then you are done and you may output <promise>COMPLETE</promise>

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "additionalDirectories": [
-      "/Users/victor/Development/dequeue/stacks-app/",
-      "/Users/victor/Development/dequeue/stacks-sync"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ coverage/
 
 # Archives
 *.xcarchive
+
+# Claude Code local config (user-specific)
+.claude/*.local.md
+.claude/*.local.json


### PR DESCRIPTION
## Summary

- Remove `.claude/ralph-loop.local.md` and `.claude/settings.local.json` which should never have been committed (they are user-specific local configuration files)
- Added `.claude/*.local.md` and `.claude/*.local.json` patterns to `.gitignore` to prevent future accidental commits

## Test plan

- [x] Files are removed from repository
- [x] Patterns added to .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)