### PR TITLE
Update sync server URL to sync.ardonos.com [DEQ-147]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,5 +223,5 @@ If the Linear MCP server is not available (e.g., in Claude Code Cloud or other r
 
 ## Related Projects
 
-- **stacks-sync** - Backend sync service (https://stacks-sync.fly.dev)
+- **stacks-sync** - Backend sync service (https://sync.ardonos.com)
 - **stacks** - Legacy React Native app (deprecated)

--- a/Dequeue/CLAUDE.md
+++ b/Dequeue/CLAUDE.md
@@ -163,5 +163,5 @@ Would you like me to [specific improvement]?"
 
 ## Related Projects
 
-- **stacks-sync** - Backend sync service (https://stacks-sync.fly.dev)
+- **stacks-sync** - Backend sync service (https://sync.ardonos.com)
 - **stacks** - Legacy React Native app (deprecated)

--- a/Dequeue/Dequeue/Configuration.swift
+++ b/Dequeue/Dequeue/Configuration.swift
@@ -42,7 +42,7 @@ enum Configuration {
     /// Base URL for the sync service (without app path)
     private static let syncServiceBaseURL: URL = {
         // swiftlint:disable:next force_unwrapping
-        return URL(string: "https://stacks-sync.fly.dev")!
+        return URL(string: "https://sync.ardonos.com")!
     }()
 
     /// Base URL for the sync API (includes /apps/{appId} prefix)


### PR DESCRIPTION
## Summary
Updates the sync server configuration to use the new DNS record at sync.ardonos.com instead of the old Fly.io address.

## Changes
- Updated `Configuration.swift` to use `https://sync.ardonos.com`
- Updated documentation references in both CLAUDE.md files
- Old URL: `https://stacks-sync.fly.dev`
- New URL: `https://sync.ardonos.com`

## Testing
- [ ] Verify app builds successfully
- [ ] Test sync functionality with new URL
- [ ] Confirm WebSocket connection works

## Related
Closes DEQ-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)