### PR TITLE
fix: remove confusing rotation animation from cloud sync icon

### DIFF
--- a/Dequeue/Dequeue/Views/Sync/SyncStatusIndicator.swift
+++ b/Dequeue/Dequeue/Views/Sync/SyncStatusIndicator.swift
@@ -13,8 +13,6 @@ internal struct SyncStatusIndicator: View {
 
     private enum Constants {
         static let iconFrameSize: CGFloat = 32
-        static let rotationAnimationDuration: TimeInterval = 2.0
-        static let fullRotation = Angle.degrees(360)
         static let popoverMinWidth: CGFloat = 200
         static let badgeOffset = CGSize(width: 6, height: -6)
     }
@@ -32,13 +30,6 @@ internal struct SyncStatusIndicator: View {
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(iconColor, .primary)
                     .font(.body)
-                    .rotationEffect(viewModel.isSyncing ? Constants.fullRotation : .zero)
-                    .animation(
-                        viewModel.isSyncing ?
-                            .linear(duration: Constants.rotationAnimationDuration).repeatForever(autoreverses: false) :
-                            .default,
-                        value: viewModel.isSyncing
-                    )
 
                 // Badge for pending event count
                 if viewModel.pendingEventCount > 0 {


### PR DESCRIPTION
The cloud icon was spinning continuously whenever there were pending
events, which falsely implied active work was happening. The rotation
was triggered by isSyncing=true (connected + pending events), not by
actual sync activity.

The static icons already communicate state effectively:
- checkmark.icloud (green) = synced
- arrow.triangle.2.circlepath (orange) = has pending events
- icloud.slash (red) = disconnected

The badge count shows pending items. No animation needed.