### PR TITLE
fix: Filter legacy events from push to prevent server constraint violations

### DIFF
--- a/Dequeue/Dequeue/Services/EventService.swift
+++ b/Dequeue/Dequeue/Services/EventService.swift
@@ -229,8 +229,12 @@ final class EventService {
     // MARK: - Query
 
     func fetchPendingEvents() throws -> [Event] {
+        // Filter for unsynced events with current payload version (>= 2).
+        // Legacy events (payloadVersion < 2) are pre-DEQ-137 format and should not be synced.
+        // They lack userId/deviceId in payload and would cause server constraint violations.
+        let minVersion = Event.currentPayloadVersion
         let predicate = #Predicate<Event> { event in
-            event.isSynced == false
+            event.isSynced == false && event.payloadVersion >= minVersion
         }
         let descriptor = FetchDescriptor<Event>(
             predicate: predicate,


### PR DESCRIPTION
## Summary
- Filter out legacy events (payloadVersion < 2) from `fetchPendingEvents()`
- Legacy events are pre-DEQ-137 format and lack userId/deviceId in payloads
- Prevents server constraint violations when pushing events with payloadVersion=0

## Problem
Events created before the `payloadVersion` field was added to the Event model have `payloadVersion = 0` (Swift's default for Int). When pushed to the server:
1. The database constraint `CHECK (payload_version > 0)` would reject them
2. The current server workaround defaults 0 → 2, which incorrectly marks legacy events as current format, potentially corrupting data

## Solution
Add `payloadVersion >= 2` filter to `fetchPendingEvents()`. This matches the existing pull logic (SyncManager lines 555-565) that already filters out legacy events when receiving.

Legacy events remain on the device for local history but are not synced - this is the correct behavior since they predate the sync system.

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] Create new event → should sync successfully
- [ ] Legacy events with payloadVersion=0 should not appear in pending queue
- [ ] Server should no longer receive events with payload_version=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)