### PR TITLE
feat: Show creation date on Stack and Task detail pages

### DIFF
--- a/Dequeue/Dequeue/Utilities/Date+SmartFormat.swift
+++ b/Dequeue/Dequeue/Utilities/Date+SmartFormat.swift
@@ -1,0 +1,27 @@
+//
+//  Date+SmartFormat.swift
+//  Dequeue
+//
+//  Smart date formatting utilities
+//
+
+import Foundation
+
+extension Date {
+    /// Formats the date as "X hours ago" if it was today, otherwise shows the day and time.
+    ///
+    /// Examples:
+    /// - "2 hours ago" (if created today)
+    /// - "Jan 10, 10:30 AM" (if created on a different day)
+    func smartFormatted() -> String {
+        if Calendar.current.isDateInToday(self) {
+            // Use relative formatting for today
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .full
+            return formatter.localizedString(for: self, relativeTo: Date())
+        } else {
+            // Use abbreviated date and time for other days
+            return self.formatted(date: .abbreviated, time: .shortened)
+        }
+    }
+}

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -21,6 +21,7 @@ extension StackEditorView {
 
             remindersSection
             actionsSection
+            detailsSection
             eventHistorySection
         }
     }
@@ -226,6 +227,15 @@ extension StackEditorView {
             dismiss()
         } catch {
             handleError(error)
+        }
+    }
+
+    @ViewBuilder
+    var detailsSection: some View {
+        if case .edit(let stack) = mode {
+            Section {
+                LabeledContent("Created", value: stack.createdAt.smartFormatted())
+            }
         }
     }
 

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -71,6 +71,8 @@ struct TaskDetailView: View {
 
             actionsSection
 
+            detailsSection
+
             eventHistorySection
         }
         #if os(macOS)
@@ -414,6 +416,12 @@ struct TaskDetailView: View {
             } label: {
                 Label("Delete Task", systemImage: "trash")
             }
+        }
+    }
+
+    private var detailsSection: some View {
+        Section {
+            LabeledContent("Created", value: task.createdAt.smartFormatted())
         }
     }
 


### PR DESCRIPTION
Add a "Created" field to both Stack and Task detail views that displays
when the item was created. The date is formatted contextually:
- "X hours ago" if created today
- "Jan 10, 10:30 AM" style for older dates

Added Date+SmartFormat.swift extension with smartFormatted() method.