### PR TITLE
feat(DEQ-163): Display tags in StackRowView

### DIFF
--- a/Dequeue/Dequeue/Views/Home/HomeView.swift
+++ b/Dequeue/Dequeue/Views/Home/HomeView.swift
@@ -440,68 +440,6 @@ struct HomeView: View {
     }
 }
 
-// MARK: - Stack Row
-
-struct StackRowView: View {
-    let stack: Stack
-
-    /// Non-deleted tags to display
-    private var visibleTags: [Tag] {
-        stack.tagObjects.filter { !$0.isDeleted }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(stack.title)
-                    .font(.headline)
-
-                Spacer()
-
-                if stack.isActive {
-                    Image(systemName: "star.fill")
-                        .foregroundStyle(.yellow)
-                        .font(.caption)
-                        .accessibilityLabel("Active stack")
-                }
-            }
-
-            if let activeTask = stack.activeTask {
-                Text(activeTask.title)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-
-            if !stack.activeReminders.isEmpty {
-                HStack(spacing: 4) {
-                    Image(systemName: "bell.fill")
-                        .font(.caption2)
-                    Text("\(stack.activeReminders.count)")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.orange)
-            }
-
-            // Tags row - show up to 3 tags with "+N more" indicator
-            if !visibleTags.isEmpty {
-                HStack(spacing: 4) {
-                    ForEach(Array(visibleTags.prefix(3))) { tag in
-                        TagChip(tag: tag)
-                    }
-
-                    if visibleTags.count > 3 {
-                        Text("+\(visibleTags.count - 3) more")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-        }
-        .padding(.vertical, 4)
-    }
-}
-
 #Preview {
     HomeView()
         .modelContainer(for: [Stack.self, QueueTask.self, Reminder.self], inMemory: true)

--- a/Dequeue/Dequeue/Views/Home/StackRowView.swift
+++ b/Dequeue/Dequeue/Views/Home/StackRowView.swift
@@ -1,0 +1,84 @@
+//
+//  StackRowView.swift
+//  Dequeue
+//
+//  Stack row component for Home view list
+//
+
+import SwiftUI
+
+/// Row view displaying a stack with title, active task, reminders, and tags.
+struct StackRowView: View {
+    let stack: Stack
+
+    /// Non-deleted tags to display
+    private var visibleTags: [Tag] {
+        stack.tagObjects.filter { !$0.isDeleted }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(stack.title)
+                    .font(.headline)
+
+                Spacer()
+
+                if stack.isActive {
+                    Image(systemName: "star.fill")
+                        .foregroundStyle(.yellow)
+                        .font(.caption)
+                        .accessibilityLabel("Active stack")
+                }
+            }
+
+            if let activeTask = stack.activeTask {
+                Text(activeTask.title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if !stack.activeReminders.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "bell.fill")
+                        .font(.caption2)
+                    Text("\(stack.activeReminders.count)")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
+            }
+
+            // Tags row - show up to 3 tags with "+N more" indicator
+            if !visibleTags.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(Array(visibleTags.prefix(3))) { tag in
+                        TagChip(tag: tag)
+                    }
+
+                    if visibleTags.count > 3 {
+                        Text("+\(visibleTags.count - 3) more")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Simple Stack") {
+    let stack = Stack(title: "Test Stack", stackDescription: nil, status: .active, sortOrder: 0)
+    return StackRowView(stack: stack)
+        .padding()
+}
+
+#Preview("Active Stack") {
+    let stack = Stack(title: "Active Stack", stackDescription: nil, status: .active, sortOrder: 0)
+    stack.isActive = true
+    return StackRowView(stack: stack)
+        .padding()
+}


### PR DESCRIPTION
## Summary
- Add tags display to StackRowView on Home view
- Show up to 3 tags as TagChip components
- Show "+N more" indicator for stacks with more than 3 tags

## Changes
- **HomeView.swift (StackRowView)**: Added `visibleTags` computed property and tags row below reminders

## Test plan
- [ ] Stack with no tags - no tags row displayed
- [ ] Stack with 1-3 tags - all tags displayed as chips
- [ ] Stack with 4+ tags - show 3 chips + "+N more"
- [ ] Test on iOS and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)