### PR TITLE
feat(DEQ-170): Add VoiceOver accessibility for TagInputView

### DIFF
--- a/Dequeue/Dequeue/Views/Components/Tags/TagInputView.swift
+++ b/Dequeue/Dequeue/Views/Components/Tags/TagInputView.swift
@@ -109,6 +109,8 @@ struct TagInputView: View {
                 }
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Selected tags, \(selectedTags.count) \(selectedTags.count == 1 ? "tag" : "tags")")
     }
 
     // MARK: - Input Field
@@ -126,6 +128,8 @@ struct TagInputView: View {
                     .onSubmit {
                         handleSubmit()
                     }
+                    .accessibilityLabel("Add tag")
+                    .accessibilityHint("Type to search for existing tags or create a new one")
                 #if os(iOS)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
@@ -140,6 +144,8 @@ struct TagInputView: View {
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                    .accessibilityHint("Clears the tag search text")
                 }
             }
             .padding(.horizontal, 12)
@@ -186,6 +192,7 @@ struct TagInputView: View {
                     Circle()
                         .fill(color)
                         .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
                 }
 
                 Text(tag.name)
@@ -204,17 +211,31 @@ struct TagInputView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(suggestionAccessibilityLabel(for: tag))
+        .accessibilityHint("Double-tap to add this tag")
+    }
+
+    private func suggestionAccessibilityLabel(for tag: Tag) -> String {
+        if tag.activeStackCount > 0 {
+            let stacksWord = tag.activeStackCount == 1 ? "stack" : "stacks"
+            return "Suggestion: \(tag.name), \(tag.activeStackCount) \(stacksWord)"
+        } else {
+            return "Suggestion: \(tag.name)"
+        }
     }
 
     private var createNewRow: some View {
-        Button {
+        let trimmedInput = inputText.trimmingCharacters(in: .whitespaces)
+        return Button {
             createNewTag()
         } label: {
             HStack {
                 Image(systemName: "plus.circle.fill")
                     .foregroundStyle(.blue)
+                    .accessibilityHidden(true)
 
-                Text("Create \"\(inputText.trimmingCharacters(in: .whitespaces))\"")
+                Text("Create \"\(trimmedInput)\"")
                     .foregroundStyle(.primary)
 
                 Spacer()
@@ -224,6 +245,9 @@ struct TagInputView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Create new tag: \(trimmedInput)")
+        .accessibilityHint("Double-tap to create and add this new tag")
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- Add VoiceOver accessibility support to TagInputView component
- TextField announces "Add tag" with hint about searching/creating tags
- Suggestions list navigable with VoiceOver, announcing "Suggestion: [name], [count] stacks"
- Create new option announces "Create new tag: [name]"
- Selected tags section announces count of selected tags

## Changes
- `TagInputView.swift`: Added accessibility labels, hints, and element grouping

## Test plan
- [ ] Enable VoiceOver on device/simulator
- [ ] Navigate to Stack editor and focus tag input
- [ ] Verify TextField announces "Add tag"
- [ ] Type to show suggestions, verify suggestions announce correctly
- [ ] Verify "Create new" option announces correctly
- [ ] Verify selected tags section announces tag count

## Linear Issue
DEQ-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)