### PR TITLE
claude/fix-new-stack-reminders-K7zTR

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+CreateMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+CreateMode.swift
@@ -33,10 +33,7 @@ extension StackEditorView {
 
             createModeTasksSection
 
-            // Reminders section - only show when draft exists
-            if draftStack != nil {
-                remindersSection
-            }
+            remindersSection
         }
     }
 

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -351,15 +351,38 @@ extension StackEditorView {
             HStack {
                 Text("Reminders")
                 Spacer()
-                if !isReadOnly && currentStack != nil {
+                // Show add button when: not read-only AND (stack exists OR in create mode)
+                if !isReadOnly && (currentStack != nil || mode == .create) {
                     Button {
-                        showAddReminder = true
+                        handleAddReminderTap()
                     } label: {
                         Image(systemName: "plus.circle.fill")
                             .foregroundStyle(.blue)
                     }
                     .accessibilityIdentifier("addStackReminderButton")
                 }
+            }
+        }
+    }
+
+    /// Handles the add reminder button tap.
+    /// In create mode without a draft, auto-creates a draft first so reminders can be attached.
+    func handleAddReminderTap() {
+        // If we already have a stack, just show the sheet
+        if currentStack != nil {
+            showAddReminder = true
+            return
+        }
+
+        // In create mode without a draft, create the draft first
+        if case .create = mode {
+            // Use the current title or "Untitled" as fallback
+            let draftTitle = title.isEmpty ? "Untitled" : title
+            createDraft(title: draftTitle)
+
+            // Show the sheet - draftStack is now set
+            if draftStack != nil {
+                showAddReminder = true
             }
         }
     }


### PR DESCRIPTION
Previously, the reminders section was hidden in create mode until a draft existed, preventing users from adding reminders to new stacks. This was an arbitrary restriction that forced users to create a stack first, then edit it to add reminders.

Changes:
- Always show reminders section in stack create mode
- Add handleAddReminderTap() to auto-create draft when adding reminders
- If no title entered yet, uses "Untitled" as draft title when creating a reminder triggers draft creation