### PR TITLE
claude/fix-mac-multiple-tasks-KOBQs

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+CreateMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+CreateMode.swift
@@ -78,6 +78,7 @@ extension StackEditorView {
                     Image(systemName: "plus.circle.fill")
                         .foregroundStyle(.blue)
                 }
+                .buttonStyle(.borderless)
                 .accessibilityIdentifier("addTaskButton")
             }
         }

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -123,6 +123,7 @@ extension StackEditorView {
                         Image(systemName: "plus.circle.fill")
                             .foregroundStyle(.blue)
                     }
+                    .buttonStyle(.borderless)
                     .accessibilityIdentifier("addTaskButton")
                 }
             }

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -344,6 +344,7 @@ extension StackEditorView {
                         Image(systemName: "plus.circle.fill")
                             .foregroundStyle(.blue)
                     }
+                    .buttonStyle(.borderless)
                     .accessibilityIdentifier("addStackReminderButton")
                 }
             }

--- a/Dequeue/Dequeue/Views/Task/AddTaskSheet.swift
+++ b/Dequeue/Dequeue/Views/Task/AddTaskSheet.swift
@@ -43,7 +43,11 @@ struct AddTaskSheet: View {
                 }
             }
         }
+        #if os(iOS)
         .presentationDetents([.medium])
+        #else
+        .frame(minWidth: 400, minHeight: 200)
+        #endif
     }
 }
 


### PR DESCRIPTION
- Add .buttonStyle(.borderless) to all section header buttons in StackEditorView to ensure they are interactive on macOS
- Add macOS-specific frame sizing to AddTaskSheet since presentationDetents only works on iOS
- Make presentationDetents iOS-only to avoid warnings on macOS

This addresses potential issues where buttons in Form section headers may not be tappable on macOS without explicit button styling.