### PR TITLE
fix(DEQ-192): Hide stack from In Progress list during undo window

### DIFF
--- a/Dequeue/Dequeue/Views/Stacks/InProgressStacksListView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/InProgressStacksListView.swift
@@ -56,12 +56,16 @@ struct InProgressStacksListView: View {
         )
     }
 
-    /// Stacks filtered by selected tags (OR logic)
+    /// Stacks filtered by selected tags (OR logic) and excluding pending completion
     private var filteredStacks: [Stack] {
+        // First, filter out any stack that's pending completion (in undo window)
+        let pendingCompletionId = undoCompletionManager?.pendingStack?.id
+        let visibleStacks = stacks.filter { $0.id != pendingCompletionId }
+
         if selectedTagIds.isEmpty {
-            return stacks
+            return visibleStacks
         }
-        return stacks.filter { stack in
+        return visibleStacks.filter { stack in
             stack.tagObjects.contains { tag in
                 selectedTagIds.contains(tag.id) && !tag.isDeleted
             }


### PR DESCRIPTION
## Summary
Fixes DEQ-192: When marking a stack as "Complete", the stack now immediately disappears from the In Progress list while the undo banner is shown.

## Problem
Previously, when a user tapped "Complete" on a stack with no pending tasks:
1. The undo banner appeared ✅
2. The stack **remained visible** in the In Progress list ❌

This was confusing because the user expected the stack to disappear immediately.

## Solution
Filter out `pendingStack` from the `filteredStacks` computed property in `InProgressStacksListView`. The `UndoCompletionManager` already holds a reference to the pending stack, so we just need to exclude it from the list.

## Behavior
- Stack disappears from In Progress list as soon as "Complete" is triggered
- If user taps Undo before timer expires, stack reappears (pendingStack becomes nil)
- If undo timer expires, stack is permanently marked completed and moves to Completed list

## Test plan
- [ ] Mark a stack with no pending tasks as complete
- [ ] Verify stack disappears from In Progress list immediately
- [ ] Verify undo banner appears
- [ ] Tap Undo before timer expires
- [ ] Verify stack reappears in In Progress list
- [ ] Mark another stack as complete and let timer expire
- [ ] Verify stack moves to Completed list

🤖 Generated with [Claude Code](https://claude.com/claude-code)