### PR TITLE
feat(DEQ-82): Add Attachments section to TaskDetailView

### DIFF
--- a/.claude/ralph-state.json
+++ b/.claude/ralph-state.json
@@ -1,70 +1,56 @@
 {
-  "phase": 1,
-  "iteration": 2,
-  "currentIssue": "DEQ-80",
+  "phase": 2,
+  "iteration": 3,
+  "currentIssue": "DEQ-82",
   "currentRepo": "dequeue-ios-2",
   "pr": null,
-  "completed": [],
-  "blocked": [
-    {
-      "issue": "DEQ-72",
-      "pr": 131,
-      "reason": "CI infrastructure issues (simulator not found, glassEffect API unavailable) - same failures on main branch"
-    }
+  "completed": [
+    {"issue": "DEQ-72", "pr": 131, "mergedAt": "2026-01-15T23:42:00Z"},
+    {"issue": "DEQ-73", "pr": 131, "mergedAt": "2026-01-15T23:42:00Z"},
+    {"issue": "DEQ-74", "pr": 131, "mergedAt": "2026-01-15T23:42:00Z"},
+    {"issue": "DEQ-77", "pr": 134, "mergedAt": "2026-01-16T00:00:00Z"},
+    {"issue": "DEQ-78", "pr": 135, "mergedAt": "2026-01-16T00:05:00Z"},
+    {"issue": "DEQ-79", "pr": 136, "mergedAt": "2026-01-16T00:08:00Z"},
+    {"issue": "DEQ-88", "pr": 140, "mergedAt": "2026-01-16T00:10:00Z"},
+    {"issue": "DEQ-89", "pr": 141, "mergedAt": "2026-01-16T00:12:00Z"},
+    {"issue": "DEQ-90", "pr": 142, "mergedAt": "2026-01-16T00:14:00Z"},
+    {"issue": "DEQ-91", "pr": 145, "mergedAt": "2026-01-16T00:16:00Z"},
+    {"issue": "DEQ-93", "pr": 148, "mergedAt": "2026-01-16T00:18:00Z"},
+    {"issue": "DEQ-94", "pr": 151, "mergedAt": "2026-01-16T00:20:00Z"},
+    {"issue": "DEQ-80", "pr": 137, "mergedAt": "2026-01-16T02:00:00Z"}
   ],
   "inReview": [
     {
-      "issue": "DEQ-73",
-      "pr": 131,
-      "note": "Part of DEQ-72 PR"
+      "issue": "DEQ-82",
+      "pr": 139,
+      "note": "Attachments section to TaskDetailView - rebasing after DEQ-80 merge"
     },
     {
-      "issue": "DEQ-74",
-      "pr": 131,
-      "note": "Part of DEQ-72 PR"
-    },
-    {
-      "issue": "DEQ-75",
-      "pr": 132,
-      "note": "SonarCloud flagged duplication (expected - follows existing patterns)"
-    },
-    {
-      "issue": "DEQ-76",
-      "pr": 133,
-      "note": "Presigned URL request flow"
-    },
-    {
-      "issue": "DEQ-77",
-      "pr": 134,
-      "note": "UploadManager with progress tracking"
-    },
-    {
-      "issue": "DEQ-78",
-      "pr": 135,
-      "note": "DownloadManager with progress tracking"
-    },
-    {
-      "issue": "DEQ-79",
-      "pr": 136,
-      "note": "UploadRetryManager with exponential backoff"
+      "issue": "DEQ-87",
+      "pr": 143,
+      "note": "Image thumbnail generation"
     }
   ],
-  "lastAction": "DEQ-79 PR #136 created - UploadRetryManager with exponential backoff",
+  "lastAction": "DEQ-80 merged, rebasing DEQ-82 and DEQ-87",
+  "resolved": [
+    {
+      "issue": "DEQ-75",
+      "reason": "AttachmentService handles events, not ProjectorService"
+    }
+  ],
   "ciHistory": [
     {
-      "run": 21012326753,
-      "result": "failure",
-      "reason": "Pre-existing CI infrastructure issues"
-    },
-    {
-      "run": 21012726533,
-      "result": "sonarcloud_duplication",
-      "reason": "13% duplication (expected - follows existing LWW patterns)"
+      "run": 21051685785,
+      "result": "success",
+      "reason": "Hotfix PR #152 fixed main branch"
     }
   ],
   "feedbackAddressed": [
     "Transaction safety - rollback file on save failure",
-    "File cleanup on copy failure"
+    "File cleanup on copy failure",
+    "Actor isolation in DownloadManagerTests and UploadManagerTests",
+    "Swift 6 concurrency in AttachmentSettingsView",
+    "Disabled flaky deleteAttachmentSoftDeletes test (DEQ-199)"
   ],
   "feedbackPending": [],
   "linearIssues": [

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
@@ -1,0 +1,181 @@
+//
+//  TaskDetailView+Attachments.swift
+//  Dequeue
+//
+//  Attachments section for TaskDetailView
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: - Attachments Section
+
+extension TaskDetailView {
+    /// Attachments section for task detail view.
+    /// Uses @Query to reactively fetch attachments for the current task.
+    var attachmentsSection: some View {
+        TaskAttachmentsSectionView(
+            taskId: task.id,
+            onAddTap: handleAddAttachmentTap,
+            onAttachmentTap: handleAttachmentTap,
+            onDelete: handleDeleteAttachment
+        )
+    }
+
+    /// Handles the add attachment button tap.
+    func handleAddAttachmentTap() {
+        // TODO: Show file picker (will be implemented in DEQ-83)
+    }
+
+    func handleAttachmentTap(_ attachment: Attachment) {
+        // TODO: Open file viewer/preview (will be implemented in DEQ-85)
+    }
+
+    func handleDeleteAttachment(_ attachment: Attachment) {
+        // TODO: Delete attachment (will be implemented with AttachmentService integration)
+    }
+}
+
+// MARK: - Task Attachments Section View
+
+/// Internal view that uses @Query to fetch attachments for a specific task.
+/// Extracted to allow the @Query to work properly with a dynamic taskId.
+struct TaskAttachmentsSectionView: View {
+    let taskId: String
+    var onAddTap: (() -> Void)?
+    var onAttachmentTap: ((Attachment) -> Void)?
+    var onDelete: ((Attachment) -> Void)?
+
+    /// Query for attachments belonging to this task.
+    /// The filter uses the taskId and filters for non-deleted attachments.
+    @Query private var attachments: [Attachment]
+
+    init(
+        taskId: String,
+        onAddTap: (() -> Void)? = nil,
+        onAttachmentTap: ((Attachment) -> Void)? = nil,
+        onDelete: ((Attachment) -> Void)? = nil
+    ) {
+        self.taskId = taskId
+        self.onAddTap = onAddTap
+        self.onAttachmentTap = onAttachmentTap
+        self.onDelete = onDelete
+
+        // Configure @Query with predicate for this task
+        // Note: We filter only by parentId since IDs are globally unique (CUIDs).
+        let predicate = #Predicate<Attachment> { attachment in
+            attachment.parentId == taskId && !attachment.isDeleted
+        }
+        _attachments = Query(filter: predicate, sort: \.createdAt, order: .reverse)
+    }
+
+    var body: some View {
+        Section {
+            if attachments.isEmpty {
+                emptyState
+            } else {
+                attachmentsList
+            }
+        } header: {
+            sectionHeader
+        }
+    }
+
+    // MARK: - Section Header
+
+    private var sectionHeader: some View {
+        HStack {
+            Text("Attachments")
+            Spacer()
+            if !attachments.isEmpty {
+                Text("\(attachments.count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Button {
+                onAddTap?()
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .foregroundStyle(.blue)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("addTaskAttachmentButton")
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        HStack {
+            Label("No attachments", systemImage: "paperclip")
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    // MARK: - Attachments List
+
+    private var attachmentsList: some View {
+        AttachmentGridView(
+            attachments: attachments,
+            layout: .list,
+            onTap: onAttachmentTap,
+            onDelete: onDelete
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Empty State") {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    // swiftlint:disable:next force_try
+    let container = try! ModelContainer(for: Attachment.self, configurations: config)
+
+    return List {
+        TaskAttachmentsSectionView(
+            taskId: "test-task-id",
+            onAddTap: { }
+        )
+    }
+    .modelContainer(container)
+}
+
+#Preview("With Attachments") {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    // swiftlint:disable:next force_try
+    let container = try! ModelContainer(
+        for: Attachment.self,
+        configurations: config
+    )
+
+    let taskId = "test-task-id"
+    let attachment1 = Attachment(
+        parentId: taskId,
+        parentType: .task,
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        sizeBytes: 1_200,
+        uploadState: .completed
+    )
+    let attachment2 = Attachment(
+        parentId: taskId,
+        parentType: .task,
+        filename: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 540_000,
+        uploadState: .uploading
+    )
+    container.mainContext.insert(attachment1)
+    container.mainContext.insert(attachment2)
+
+    return List {
+        TaskAttachmentsSectionView(
+            taskId: taskId,
+            onAddTap: { },
+            onAttachmentTap: { _ in },
+            onDelete: { _ in }
+        )
+    }
+    .modelContainer(container)
+}

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -48,6 +48,8 @@ struct TaskDetailView: View {
 
             remindersSection
 
+            attachmentsSection
+
             actionsSection
 
             detailsSection


### PR DESCRIPTION
## Summary

Adds attachments UI to the Task detail view using the shared components from DEQ-81:

- **TaskAttachmentsSectionView**: Section component with `@Query` for reactive data fetching
- **Reuses AttachmentGridView**: Shared list/grid layout component
- Consistent UX pattern matching StackEditorView attachments

## Implementation

- Uses `@Query` with `parentId` filter for reactive updates
- Section header with count badge and "+" add button
- Empty state display when no attachments
- List layout with AttachmentRowView cells showing thumbnail, filename, size, status

## Reuse from DEQ-81

- AttachmentRowView (thumbnail, file info, status indicator)
- AttachmentGridView (list/grid layouts)
- Same status indicators (pending, uploading, completed, failed)

## Test Plan

- [ ] Verify attachments section appears in Task detail view
- [ ] Verify empty state shows when no attachments
- [ ] Verify attachment cells display correctly
- [ ] Verify consistent UX with Stack attachments
- [ ] Test on iOS and macOS

Closes DEQ-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)