### PR TITLE
feat(DEQ-89): Implement Quick Look integration for viewing attachments

### DIFF
--- a/Dequeue/Dequeue/Views/Attachment/AttachmentPreviewCoordinator.swift
+++ b/Dequeue/Dequeue/Views/Attachment/AttachmentPreviewCoordinator.swift
@@ -198,18 +198,18 @@ struct AttachmentQuickLookView: NSViewRepresentable {
         // swiftlint:disable implicitly_unwrapped_optional
         // These method signatures are required by the Objective-C QLPreviewPanel API
         // nonisolated to match the NSResponder method signatures
-        nonisolated override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
+        override nonisolated func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
             true
         }
 
-        nonisolated override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        override nonisolated func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
             MainActor.assumeIsolated {
                 panel.dataSource = self
                 panel.delegate = self
             }
         }
 
-        nonisolated override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        override nonisolated func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
             MainActor.assumeIsolated {
                 onDismiss?()
             }


### PR DESCRIPTION
## Summary
- Adds `AttachmentPreviewCoordinator` for managing preview state and download-before-preview flow
- Adds `AttachmentQuickLookView` with cross-platform Quick Look support (iOS/macOS)
- Adds `AttachmentDownloadOverlay` for showing download progress before preview

## Implementation Details
- **AttachmentPreviewCoordinator**: @Observable state manager with:
  - Automatic download triggering for non-local files
  - Progress tracking during download
  - Error handling with user alerts
  - Preview URL management

- **AttachmentQuickLookView**: Cross-platform wrapper:
  - iOS: `UIViewControllerRepresentable` with `QLPreviewController`
  - macOS: `NSViewRepresentable` with `QLPreviewPanel`
  - Dismiss callbacks for cleanup

- **AttachmentDownloadOverlay**: Visual feedback component:
  - Circular progress indicator
  - Filename display
  - Percentage progress

**View modifier API:**
```swift
.attachmentPreview(coordinator: previewCoordinator)
```

## Test Plan
- [ ] Verify Quick Look opens for local files
- [ ] Test download-before-preview flow for cloud files
- [ ] Test progress indicator visibility during download
- [ ] Test error alert for failed downloads
- [ ] Verify share functionality within Quick Look
- [ ] Test dismiss callback execution
- [ ] Test on both iOS and macOS

Closes DEQ-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)