### PR TITLE
feat(DEQ-90): Add file type icons for unsupported preview formats

### DIFF
--- a/Dequeue/Dequeue/Views/Attachment/FileTypeIcon.swift
+++ b/Dequeue/Dequeue/Views/Attachment/FileTypeIcon.swift
@@ -229,12 +229,12 @@ struct AttachmentFileIconView: View {
 
 extension Attachment {
     /// Returns the SF Symbol name for this attachment's file type
-    var fileTypeIconName: String {
+    @MainActor var fileTypeIconName: String {
         FileTypeIcon.symbolName(for: mimeType)
     }
 
     /// Returns the color for this attachment's file type icon
-    var fileTypeIconColor: Color {
+    @MainActor var fileTypeIconColor: Color {
         FileTypeIcon.color(for: mimeType)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `FileTypeIcon` enum for MIME type to SF Symbol mapping
- Adds `FileTypeIconView` for displaying sized, colored file icons
- Adds `AttachmentFileIconView` for complete attachment display with filename and size
- Adds `Attachment` extensions for easy icon access

## Implementation Details
**Supported file types:**
| Category | MIME Types | SF Symbol |
|----------|------------|-----------|
| PDF | application/pdf | doc.fill |
| Word | msword, docx | doc.text.fill |
| Excel | ms-excel, xlsx | tablecells.fill |
| PowerPoint | ms-powerpoint, pptx | rectangle.split.3x3.fill |
| Archives | zip, rar, 7z, gzip, tar | doc.zipper |
| Audio | audio/* | waveform |
| Video | video/* | film |
| Images | image/* | photo |
| Code | json, xml, js, html, css | chevron.left.forwardslash.chevron.right |
| Text | text/* | doc.plaintext.fill |
| Unknown | - | doc.fill (fallback) |

**Color coding:**
- Red: PDF
- Blue: Word documents
- Green: Spreadsheets, Images
- Orange: Presentations
- Purple: Audio
- Pink: Video
- Cyan: Code files
- Brown: Archives

## Test Plan
- [ ] Verify correct icons for common file types
- [ ] Test fallback icon for unknown types
- [ ] Verify colors match file type categories
- [ ] Test icon rendering at various sizes
- [ ] Verify consistency with system appearance (light/dark mode)

Closes DEQ-90

🤖 Generated with [Claude Code](https://claude.com/claude-code)