### PR TITLE
feat(DEQ-94): Add cellular upload warning for large files

### DIFF
--- a/Dequeue/Dequeue/Views/Attachment/CellularUploadWarning.swift
+++ b/Dequeue/Dequeue/Views/Attachment/CellularUploadWarning.swift
@@ -26,7 +26,7 @@ final class CellularUploadCoordinator {
     // MARK: - Configuration
 
     /// Minimum file size (in bytes) to trigger cellular warning
-    static let warningThreshold: Int64 = 10 * 1024 * 1024  // 10 MB
+    static let warningThreshold: Int64 = 10 * 1_024 * 1_024  // 10 MB
 
     // MARK: - Properties
 


### PR DESCRIPTION
## Summary
- Adds `CellularUploadCoordinator` for managing large file upload warnings on cellular
- Adds warning dialog with Upload/Wait for WiFi/Cancel options
- Adds WiFi waiting queue for deferred uploads

## Implementation Details
**CellularUploadCoordinator:**
- 10 MB threshold for triggering warning
- `checkUpload(fileSize:, filename:)` - async decision flow
- `queueForWiFi(id:, filename:, fileSize:, fileURL:)` - queue for later
- `getPendingUploadsForWiFi()` - retrieve queue when WiFi connects
- `skipWarningsThisSession` - opt-out for session

**CellularUploadDecision enum:**
| Decision | Behavior |
|----------|----------|
| proceed | Upload immediately on cellular |
| waitForWiFi | Queue and upload when WiFi available |
| cancel | Abort the upload |

**UI Components:**
- `CellularUploadWarningDialog` - alert modifier for warning
- `WiFiWaitingStatusView` - shows queued file count

**Warning triggers when:**
- File size > 10 MB
- Currently on cellular network
- User hasn't opted out for session

## Test Plan
- [ ] Test warning shows for >10MB files on cellular
- [ ] Test no warning for <10MB files
- [ ] Test no warning on WiFi
- [ ] Test "Upload Anyway" proceeds with upload
- [ ] Test "Wait for WiFi" queues upload
- [ ] Test "Cancel" aborts upload
- [ ] Test queued uploads release when WiFi connects
- [ ] Test skip warnings option works for session

Closes DEQ-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)