### PR TITLE
fix: Use explicit scale=1.0 in UIGraphicsImageRenderer for consistent thumbnail dimensions

### DIFF
--- a/Dequeue/Dequeue/Services/ThumbnailGenerator.swift
+++ b/Dequeue/Dequeue/Services/ThumbnailGenerator.swift
@@ -164,7 +164,10 @@ actor ThumbnailGenerator {
         let targetSize = calculateTargetSize(for: originalSize)
 
         // Create resized image using UIGraphicsImageRenderer for efficiency
-        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        // Use scale=1.0 to ensure consistent output regardless of device scale (1x, 2x, 3x)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
         let resizedImage = renderer.image { _ in
             image.draw(in: CGRect(origin: .zero, size: targetSize))
         }

--- a/Dequeue/DequeueTests/ThumbnailGeneratorTests.swift
+++ b/Dequeue/DequeueTests/ThumbnailGeneratorTests.swift
@@ -323,7 +323,10 @@ struct ThumbnailGeneratorTests {
     private func createTestImage(width: Int, height: Int) -> PlatformImage {
         #if canImport(UIKit)
         let size = CGSize(width: width, height: height)
-        let renderer = UIGraphicsImageRenderer(size: size)
+        // Use scale=1.0 for consistent test behavior across devices
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
         return renderer.image { context in
             UIColor.blue.setFill()
             context.fill(CGRect(origin: .zero, size: size))


### PR DESCRIPTION
## Summary

Fixes failing unit tests in ThumbnailGeneratorTests:
- `thumbnailRespectsMaxDimension()`
- `smallImagesNotUpscaled()`

## Problem

`UIGraphicsImageRenderer` uses the device's screen scale (2x or 3x) by default. This caused generated thumbnail images to have pixel dimensions that differed from their logical point dimensions. When thumbnails were saved as JPEG and reloaded, the scale metadata was lost, causing the reloaded image's `.size` property to return pixel dimensions instead of point dimensions.

For example, on a 2x device:
- Request: 100x80 points
- Renderer creates: 200x160 pixels (at 2x scale)
- After JPEG save/load: Image reports 200x160 as its `.size` ❌

## Solution

Explicitly set `scale=1.0` in `UIGraphicsImageRendererFormat` for both:
1. `ThumbnailGenerator.resizeAndCompress()` - production code
2. `ThumbnailGeneratorTests.createTestImage()` - test helper

This ensures output dimensions match requested point dimensions consistently across all devices.

## Testing

- [x] Fixes two specific failing tests
- [x] All existing tests continue to pass
- [x] Works consistently on 1x, 2x, and 3x displays