### PR TITLE
fix(DEQ-91): Inject AttachmentSettings into environment

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -26,6 +26,7 @@ extension EnvironmentValues {
 @main
 struct DequeueApp: App {
     @State private var authService = ClerkAuthService()
+    @State private var attachmentSettings = AttachmentSettings()
     let sharedModelContainer: ModelContainer
     let syncManager: SyncManager
     let notificationService: NotificationService
@@ -97,6 +98,7 @@ struct DequeueApp: App {
                 .environment(\.authService, authService)
                 .environment(\.clerk, Clerk.shared)
                 .environment(\.syncManager, syncManager)
+                .environment(\.attachmentSettings, attachmentSettings)
                 .applyAppTheme()
                 .task {
                     // Configure error reporting first (runs on background thread)


### PR DESCRIPTION
## Summary
Fixes critical bug where AttachmentSettings was not injected into the app environment, causing each view to receive a new instance instead of sharing a single instance.

## Problem
PR #147 added AttachmentSettings with an environment key, but never injected an instance into the app environment. This caused:
- Every view accessing @Environment got a NEW default instance
- Settings did not persist across navigation
- Multiple instances wrote to UserDefaults independently
- Settings appeared to reset randomly

## Solution
- Added @State private var attachmentSettings = AttachmentSettings() to DequeueApp
- Injected it into the environment

## Impact
- Settings now persist correctly across app navigation
- Single shared instance ensures consistent state
- Follows the same pattern as authService and syncManager

## Testing
- Manual testing: Settings persist across view navigation
- Verify settings changes are reflected in all views
- Confirm UserDefaults writes happen once per change

Fixes critical issue identified in PR #147 reviews.

Refs #147