### PR TITLE
claude/fix-excessive-polling-kATFm

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -1153,7 +1153,9 @@ actor SyncManager {
                     os_log("[Sync] Fallback pull (safety net, every \(self.fallbackPullIntervalMinutes) minutes)")
                     try await self.pullEvents()
                 } catch {
-                    ErrorReportingService.capture(error: error, context: ["source": "fallback_pull"])
+                    await MainActor.run {
+                        ErrorReportingService.capture(error: error, context: ["source": "fallback_pull"])
+                    }
                 }
             }
         }


### PR DESCRIPTION
The sync system was polling the /sync/pull endpoint every 5 seconds even when WebSocket was connected and healthy, wasting network resources and battery.

Changes:
- Split periodic sync into separate push and pull tasks
- Periodic push remains at 5 seconds (cheap - returns early if no events)
- Pull now only happens:
  - On initial connection (one-time)
  - After WebSocket reconnection (to catch missed events)
  - Every 5 minutes as fallback safety net
- WebSocket remains the primary mechanism for real-time sync

This reduces /sync/pull calls from ~720/hour to ~12/hour when WebSocket is healthy.