### PR TITLE
fix: Use Unix milliseconds for presigned URL timestamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,24 @@ try modelContext.save()
 - Services are actors or have actor isolation where needed for thread safety
 - Views should be thin - just UI logic
 
+### Timestamp Convention (CRITICAL)
+**Always use Unix milliseconds (Int64) for timestamps** - both in API responses and data storage:
+```swift
+// Encoding: Date → Int64 milliseconds
+let timestamp = Int64(date.timeIntervalSince1970 * 1_000)
+
+// Decoding: Int64 milliseconds → Date
+let date = Date(timeIntervalSince1970: Double(timestamp) / 1_000.0)
+```
+
+**Why this matters:**
+- Consistent with event timestamps used throughout the sync system
+- No timezone ambiguity or parsing issues
+- Simple integer comparison and arithmetic
+- Works reliably across client/server boundaries
+
+**NEVER use ISO8601/RFC3339 strings** for timestamps in APIs - only format dates as strings for display to users.
+
 ## Platform Considerations
 
 ### iOS/iPadOS


### PR DESCRIPTION
## Summary
- Updates `PresignedUploadResponse` to decode `expiresAt` as Int64 Unix milliseconds instead of ISO8601 strings
- Aligns with app-wide timestamp convention used throughout the event sync system
- Updates CodingKeys to match server's camelCase JSON keys (`uploadUrl`, `downloadUrl`, `attachmentId`, `expiresAt`)
- Adds better error logging for decode failures with raw response content
- Documents the timestamp convention in CLAUDE.md to prevent future issues

## Context
This fixes the "Received an invalid response from the server" error that occurred when uploading attachments. The root cause was a mismatch between:
1. **Key format**: Client expected snake_case (`upload_url`) but server sent camelCase (`uploadUrl`)
2. **Timestamp format**: Client expected ISO8601 strings but server was sending Unix milliseconds

The Unix milliseconds format is already the standard throughout the app for event timestamps, so this change aligns the presigned URL response with that convention.

## Test plan
- [x] Updated unit tests for new timestamp format
- [x] Verified attachment upload works end-to-end (file confirmed in R2)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)