### PR TITLE
fix: Wire up attachment preview for tap interaction

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+Attachments.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+Attachments.swift
@@ -92,8 +92,12 @@ extension StackEditorView {
     }
 
     func handleAttachmentTap(_ attachment: Attachment) {
-        // TODO: Open file viewer/preview
-        // For now, this is a placeholder - will be implemented in DEQ-85 (Attachment preview/viewer)
+        Task {
+            await previewCoordinator.preview(
+                attachment: attachment,
+                downloadHandler: nil  // TODO: Add download handler for remote-only attachments
+            )
+        }
     }
 
     func handleDeleteAttachment(_ attachment: Attachment) {

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -110,6 +110,7 @@ struct StackEditorView: View {
     @State var selectedReminderForEdit: Reminder?
     @State var showDeleteReminderConfirmation = false
     @State var reminderToDelete: Reminder?
+    @State var previewCoordinator = AttachmentPreviewCoordinator()
 
     // MARK: - Computed Properties
 
@@ -316,6 +317,7 @@ struct StackEditorView: View {
                     showError = true
                 }
             )
+            .attachmentPreview(coordinator: previewCoordinator)
             // Prevent swipe-to-dismiss when there's unsaved content
             .interactiveDismissDisabled(hasUnsavedContent)
             #if os(iOS)

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
@@ -69,7 +69,12 @@ extension TaskDetailView {
     }
 
     func handleAttachmentTap(_ attachment: Attachment) {
-        // TODO: Open file viewer/preview (will be implemented in DEQ-85)
+        Task {
+            await previewCoordinator.preview(
+                attachment: attachment,
+                downloadHandler: nil  // TODO: Add download handler for remote-only attachments
+            )
+        }
     }
 
     func handleDeleteAttachment(_ attachment: Attachment) {

--- a/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView.swift
@@ -41,6 +41,7 @@ struct TaskDetailView: View {
     @State private var selectedReminderForEdit: Reminder?
     @State private var showDeleteReminderConfirmation = false
     @State private var reminderToDelete: Reminder?
+    @State var previewCoordinator = AttachmentPreviewCoordinator()
 
     var body: some View {
         List {
@@ -174,6 +175,7 @@ struct TaskDetailView: View {
                 showError = true
             }
         )
+        .attachmentPreview(coordinator: previewCoordinator)
     }
 
     // MARK: - Sections


### PR DESCRIPTION
## Summary
- Connects the existing AttachmentPreviewCoordinator to StackEditorView and TaskDetailView
- Tapping an attachment now opens Quick Look preview (iOS) or QLPreviewPanel (macOS)
- Previously tapping an attachment with a green checkmark did nothing

## Changes
- Add `previewCoordinator` @State to both StackEditorView and TaskDetailView
- Add `.attachmentPreview()` modifier to both views
- Implement `handleAttachmentTap()` to use the coordinator

## Test plan
- [ ] Add an attachment to a Stack, verify tapping it opens Quick Look
- [ ] Add an attachment to a Task, verify tapping it opens Quick Look
- [ ] Test on both iOS and macOS if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)