### PR TITLE
feat: Automate TestFlight builds on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,92 +4,278 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      build_number_increment:
-        description: 'Increment build number by'
-        required: false
-        default: '1'
 
 concurrency:
   group: release
   cancel-in-progress: false
 
+env:
+  XCODE_VERSION: "16.2"
+
 jobs:
-  testflight:
-    name: Deploy to TestFlight
+  # Wait for version bump to complete if triggered by a regular push
+  wait-for-version-bump:
+    name: Wait for Version Bump
+    runs-on: ubuntu-latest
+    # Skip if this is the version bump commit itself, or if manually triggered
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - name: Wait for version-bump workflow
+        id: check
+        run: |
+          # Give version-bump workflow time to start and complete
+          echo "Waiting for version-bump workflow to complete..."
+          sleep 30
+          echo "should_build=true" >> $GITHUB_OUTPUT
+
+  build-ios:
+    name: Build iOS
     runs-on: macos-15
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[release]')
+    needs: wait-for-version-bump
+    if: needs.wait-for-version-bump.outputs.should_build == 'true'
 
     steps:
-      - name: Checkout
+      - name: Checkout (latest after version bump)
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
-      - name: Install Apple Certificate
+      - name: Setup App Store Connect API Key
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: |
-          # Create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # Import certificate from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-
-          # Create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # Import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-      - name: Install Provisioning Profile
-        env:
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8
 
       - name: Build Archive
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild archive \
             -scheme Dequeue \
             -configuration Release \
-            -archivePath $RUNNER_TEMP/Dequeue.xcarchive \
-            -destination 'generic/platform=iOS'
+            -archivePath $RUNNER_TEMP/Dequeue-iOS.xcarchive \
+            -destination 'generic/platform=iOS' \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
 
       - name: Export IPA
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/Dequeue.xcarchive \
-            -exportPath $RUNNER_TEMP/export \
-            -exportOptionsPlist ExportOptions.plist
+            -archivePath $RUNNER_TEMP/Dequeue-iOS.xcarchive \
+            -exportPath $RUNNER_TEMP/export-ios \
+            -exportOptionsPlist ci/ExportOptions-iOS.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
 
       - name: Upload to TestFlight
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcrun notarytool store-credentials "AC_PASSWORD" \
+            --key ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            --key-id $APP_STORE_CONNECT_API_KEY_ID \
+            --issuer $APP_STORE_CONNECT_API_ISSUER_ID
+
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export-ios/Dequeue.ipa" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Upload dSYMs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dSYMs-iOS
+          path: $RUNNER_TEMP/Dequeue-iOS.xcarchive/dSYMs
+          retention-days: 30
+
+  build-macos:
+    name: Build macOS
+    runs-on: macos-15
+    needs: wait-for-version-bump
+    if: needs.wait-for-version-bump.outputs.should_build == 'true'
+
+    steps:
+      - name: Checkout (latest after version bump)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: |
-          # Create API key file
           mkdir -p ~/.appstoreconnect/private_keys
           echo -n "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8
 
-          # Upload using xcrun
+      - name: Build Archive
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcodebuild archive \
+            -scheme Dequeue \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
+            -destination 'generic/platform=macOS' \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
+
+      - name: Export App
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
+            -exportPath $RUNNER_TEMP/export-macos \
+            -exportOptionsPlist ci/ExportOptions-macOS.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
+
+      - name: Upload to TestFlight
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          # Find the .pkg or .app file
+          EXPORT_FILE=$(find $RUNNER_TEMP/export-macos -name "*.pkg" -o -name "*.app" | head -1)
+
+          if [[ "$EXPORT_FILE" == *.app ]]; then
+            # If it's an .app, we need to create a .pkg for upload
+            productbuild --component "$EXPORT_FILE" /Applications "$RUNNER_TEMP/export-macos/Dequeue.pkg"
+            EXPORT_FILE="$RUNNER_TEMP/export-macos/Dequeue.pkg"
+          fi
+
           xcrun altool --upload-app \
-            --type ios \
-            --file "$RUNNER_TEMP/export/Dequeue.ipa" \
+            --type macos \
+            --file "$EXPORT_FILE" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Upload dSYMs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dSYMs-macOS
+          path: $RUNNER_TEMP/Dequeue-macOS.xcarchive/dSYMs
+          retention-days: 30
+
+  build-visionos:
+    name: Build visionOS
+    runs-on: macos-15
+    needs: wait-for-version-bump
+    if: needs.wait-for-version-bump.outputs.should_build == 'true'
+
+    steps:
+      - name: Checkout (latest after version bump)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8
+
+      - name: Build Archive
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcodebuild archive \
+            -scheme Dequeue \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/Dequeue-visionOS.xcarchive \
+            -destination 'generic/platform=visionOS' \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
+
+      - name: Export IPA
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/Dequeue-visionOS.xcarchive \
+            -exportPath $RUNNER_TEMP/export-visionos \
+            -exportOptionsPlist ci/ExportOptions-visionOS.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
+
+      - name: Upload to TestFlight
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export-visionos/Dequeue.ipa" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Upload dSYMs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dSYMs-visionOS
+          path: $RUNNER_TEMP/Dequeue-visionOS.xcarchive/dSYMs
+          retention-days: 30
+
+  sentry-release:
+    name: Create Sentry Release
+    runs-on: ubuntu-latest
+    needs: [build-ios, build-macos, build-visionos]
+    if: always() && (needs.build-ios.result == 'success' || needs.build-macos.result == 'success' || needs.build-visionos.result == 'success')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download all dSYMs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dSYMs-*
+          path: ${{ runner.temp }}/dSYMs
+          merge-multiple: true
 
       - name: Create Sentry Release
         uses: getsentry/action-release@v1
@@ -101,7 +287,13 @@ jobs:
           environment: production
           version: ${{ github.sha }}
 
-      - name: Cleanup Keychain
-        if: always()
+      - name: Upload dSYMs to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+          # Install sentry-cli
+          curl -sL https://sentry.io/get-cli/ | bash
+
+          # Upload dSYMs
+          sentry-cli debug-files upload --org $SENTRY_ORG --project dequeue-ios ${{ runner.temp }}/dSYMs || true

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ iOSInjectionProject/
 *.moved-aside
 *.hmap
 *.ipa
+*.pkg
 *.dSYM.zip
 *.dSYM
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,15 @@ do {
 
 ## Git Workflow
 
+### CRITICAL: Always Start From Main
+**Before starting ANY new work, you MUST:**
+1. `git fetch origin`
+2. `git checkout main`
+3. `git pull origin main`
+4. Create a new branch from this fresh main: `git checkout -b <branch-name>`
+
+**NEVER make changes on an existing feature branch for unrelated work.** If you're on branch `deq-123/some-feature` and asked to do something unrelated, you MUST switch to main first and create a new branch.
+
 ### Branching Strategy
 - We follow **trunk-based development** with short-lived feature branches
 - Branch names MUST include the Linear issue ID

--- a/ci/ExportOptions-iOS.plist
+++ b/ci/ExportOptions-iOS.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>9HE7YP99YB</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>

--- a/ci/ExportOptions-macOS.plist
+++ b/ci/ExportOptions-macOS.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>9HE7YP99YB</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>

--- a/ci/ExportOptions-visionOS.plist
+++ b/ci/ExportOptions-visionOS.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>9HE7YP99YB</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Automates TestFlight distribution on every merge to main
- Builds iOS, macOS, and visionOS in parallel
- Uses automatic code signing with App Store Connect API key (no manual certificates)
- Uploads dSYMs to Sentry for crash symbolication

## Prerequisites (Manual Steps Required)
Before merging, complete these one-time setup steps:

1. **Register app in App Store Connect** (if not done)
2. **Create App Store Connect API Key**:
   - App Store Connect → Users and Access → Integrations → App Store Connect API
   - Generate key with "App Manager" access
   - Download the `.p8` file (only downloadable once!)
3. **Add GitHub Secrets**:
   - `APP_STORE_CONNECT_API_KEY_ID` - Key ID from the table
   - `APP_STORE_CONNECT_API_ISSUER_ID` - Issuer ID from top of page
   - `APP_STORE_CONNECT_API_KEY_BASE64` - Run: `base64 -i AuthKey_XXX.p8`

## Files Changed
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replaced with multi-platform workflow |
| `.gitignore` | Added `*.pkg` |
| `CLAUDE.md` | Added "always start from main" rule |
| `ci/ExportOptions-*.plist` | New export configs for each platform |

## How It Works After Merge
1. PR merges to `main`
2. `version-bump.yml` increments build number
3. `release.yml` builds iOS, macOS, visionOS in parallel
4. Each uploads to TestFlight
5. Sentry release created with dSYMs

## Test Plan
- [ ] Add GitHub secrets listed above
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify all three platform jobs succeed
- [ ] Check TestFlight for new builds

Closes DEQ-210

🤖 Generated with [Claude Code](https://claude.com/claude-code)