### PR TITLE
fix: Use Xcode 26.2 and specify project path for builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  XCODE_VERSION: "16.2"
+  XCODE_VERSION: "26.2"
 
 jobs:
   # Wait for version bump to complete if triggered by a regular push
@@ -60,6 +60,7 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild archive \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -configuration Release \
             -archivePath $RUNNER_TEMP/Dequeue-iOS.xcarchive \
@@ -136,6 +137,7 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild archive \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -configuration Release \
             -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
@@ -216,6 +218,7 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild archive \
+            -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -configuration Release \
             -archivePath $RUNNER_TEMP/Dequeue-visionOS.xcarchive \


### PR DESCRIPTION
## Summary
Fixes the release workflow that was failing with two issues:

1. **Project not found** - xcodebuild couldn't find the project because it's in `Dequeue/` subdirectory
2. **iOS SDK not installed** - Xcode 16.2 doesn't have iOS 26.0 SDK; need Xcode 26.2

## Changes
- `XCODE_VERSION`: 16.2 → 26.2
- Added `-project Dequeue/Dequeue.xcodeproj` to all xcodebuild archive commands

## Test Plan
- [ ] Merge and verify workflow succeeds on push to main
- [ ] Or trigger manually via workflow_dispatch after merge

Relates to DEQ-210

🤖 Generated with [Claude Code](https://claude.com/claude-code)