### PR TITLE
fix: Add missing inverse relationships for Reminder model

### DIFF
--- a/Dequeue/Dequeue/Models/Arc.swift
+++ b/Dequeue/Dequeue/Models/Arc.swift
@@ -36,7 +36,7 @@ final class Arc {
     var stacks: [Stack] = []
 
     // Relationship to Reminders (Arc can have reminders)
-    @Relationship(deleteRule: .cascade)
+    @Relationship(deleteRule: .cascade, inverse: \Reminder.arc)
     var reminders: [Reminder] = []
 
     // MARK: - Computed Properties

--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -38,7 +38,7 @@ final class QueueTask {
     // Relationships
     var stack: Stack?
 
-    @Relationship(deleteRule: .cascade)
+    @Relationship(deleteRule: .cascade, inverse: \Reminder.task)
     var reminders: [Reminder] = []
 
     init(

--- a/Dequeue/Dequeue/Models/Reminder.swift
+++ b/Dequeue/Dequeue/Models/Reminder.swift
@@ -28,6 +28,11 @@ final class Reminder {
     var serverId: String?
     var revision: Int
 
+    // Inverse relationships (only one should be set based on parentType)
+    var stack: Stack?
+    var task: QueueTask?
+    var arc: Arc?
+
     init(
         id: String = CUID.generate(),
         parentId: String,

--- a/Dequeue/Dequeue/Models/Stack.swift
+++ b/Dequeue/Dequeue/Models/Stack.swift
@@ -49,7 +49,7 @@ final class Stack {
     @Relationship(deleteRule: .cascade, inverse: \QueueTask.stack)
     var tasks: [QueueTask] = []
 
-    @Relationship(deleteRule: .cascade)
+    @Relationship(deleteRule: .cascade, inverse: \Reminder.stack)
     var reminders: [Reminder] = []
 
     @Relationship(deleteRule: .nullify)


### PR DESCRIPTION
## Summary
- Fixed crash: `NSInternalInconsistencyException: Unable to resolve conflict: relationship "reminders" (on entity "Stack") does not have an inverse`
- Added inverse relationship properties (`stack`, `task`, `arc`) to the `Reminder` model
- Updated relationship declarations on `Stack`, `QueueTask`, and `Arc` to specify their inverses

## Root Cause
SwiftData requires all relationships to have defined inverses. The `reminders` relationship on `Stack`, `QueueTask`, and `Arc` was declared with `@Relationship(deleteRule: .cascade)` but without specifying the inverse, causing the runtime crash during sync conflict resolution.

## Test plan
- [x] Build succeeds on macOS
- [ ] Verify app launches without crash
- [ ] Verify reminders still work correctly (create, snooze, dismiss)
- [ ] Verify sync conflict resolution no longer crashes

🤖 Generated with [Claude Code](https://claude.ai/code)