### PR TITLE
fix: Temporarily disable visionOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,8 @@ jobs:
     name: Build visionOS
     runs-on: macos-15
     needs: wait-for-version-bump
-    if: needs.wait-for-version-bump.outputs.should_build == 'true'
+    # Temporarily disabled - visionOS code has platform compatibility issues
+    if: false
 
     steps:
       - name: Checkout (latest after version bump)
@@ -263,8 +264,8 @@ jobs:
   sentry-release:
     name: Create Sentry Release
     runs-on: ubuntu-latest
-    needs: [build-ios, build-macos, build-visionos]
-    if: always() && (needs.build-ios.result == 'success' || needs.build-macos.result == 'success' || needs.build-visionos.result == 'success')
+    needs: [build-ios, build-macos]
+    if: always() && (needs.build-ios.result == 'success' || needs.build-macos.result == 'success')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Temporarily disables visionOS build so iOS and macOS can ship to TestFlight.

## Why
visionOS has platform compatibility issues:
- `glassEffect(_:in:)` is unavailable in visionOS
- `NSColor` not in scope (macOS-only)
- `platformImage` not in scope
- Various other platform-specific API issues

## Changes
- Set `if: false` on build-visionos job
- Removed build-visionos from sentry-release dependencies

## To Re-enable
Once visionOS code compatibility is fixed, change `if: false` back to:
```yaml
if: needs.wait-for-version-bump.outputs.should_build == 'true'
```

Relates to DEQ-210

🤖 Generated with [Claude Code](https://claude.com/claude-code)