### PR TITLE
fix: Filter drafts view to exclude completed and promoted stacks

### DIFF
--- a/Dequeue/Dequeue/Services/StackService.swift
+++ b/Dequeue/Dequeue/Services/StackService.swift
@@ -234,8 +234,12 @@ final class StackService {
     }
 
     func getDrafts() throws -> [Stack] {
+        // Only return true drafts: not deleted, marked as draft, AND active status
+        // A draft that was completed or closed should not appear as a draft
         let predicate = #Predicate<Stack> { stack in
-            stack.isDeleted == false && stack.isDraft == true
+            stack.isDeleted == false &&
+            stack.isDraft == true &&
+            stack.statusRawValue == "active"
         }
         let descriptor = FetchDescriptor<Stack>(
             predicate: predicate,


### PR DESCRIPTION
## Summary

Fixes DEQ-195: The Drafts view was showing items that should not appear, including completed stacks and stacks that had been promoted (published) from drafts.

**Root cause:** SwiftData `@Query` predicates can have issues with captured variables, and the original predicate wasn't filtering by the stack's status.

**Changes:**
- Use string literal `"active"` directly in the `@Query` predicate instead of a captured variable
- Add `validDrafts` computed property as a secondary safety filter (defense-in-depth)
- Update `StackService.getDrafts()` to also filter by active status for consistency

## Test plan

- [ ] Create a new draft stack, verify it appears in Drafts tab
- [ ] Publish a draft, verify it no longer appears in Drafts tab
- [ ] Complete a stack, verify it doesn't appear in Drafts tab
- [ ] Delete a draft (swipe-to-delete), verify it's removed from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)