### PR TITLE
fix(sync): Handle WebSocket checkpoint notifications for real-time tag sync (DEQ-214)

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -999,6 +999,21 @@ actor SyncManager {
             return
         }
 
+        // Handle checkpoint notification from server - this signals that new events are available.
+        // The backend sends {"nextCheckpoint":"..."} via pg_notify after inserting events.
+        // We respond by pulling to fetch the new events from other devices.
+        if eventData["nextCheckpoint"] != nil {
+            os_log("[Sync] Received checkpoint notification via WebSocket, triggering pull")
+            do {
+                try await pullEvents()
+            } catch {
+                os_log("[Sync] Pull after WebSocket notification failed: \(error.localizedDescription)")
+                await ErrorReportingService.capture(error: error, context: ["source": "websocket_notification_pull"])
+            }
+            return
+        }
+
+        // Process direct event data (future: server could send full events directly)
         do {
             try await processIncomingEvents([eventData])
         } catch {


### PR DESCRIPTION
## Summary

- Fixes tags (and all entities) not syncing in real-time across devices
- The backend sends `{"nextCheckpoint":"..."}` via WebSocket when new events are inserted
- Previously this notification was incorrectly treated as event data and silently discarded
- Now we detect checkpoint notifications and trigger `pullEvents()` to fetch new events

## Root Cause

The backend's PostgreSQL NOTIFY sends:
```json
{"nextCheckpoint":"2024-01-24T10:30:45.123Z"}
```

But `handleIncomingMessage()` tried to process it as event data with `id`, `type`, `ts`, `payload` fields. When those fields were missing, it logged "Skipping event - missing required fields" and returned without syncing.

## Changes

- Added checkpoint notification detection in `SyncManager.handleIncomingMessage()`
- When a checkpoint notification is received, trigger `pullEvents()` to fetch new events
- Added proper logging for WebSocket notification handling

## Test Plan

- [ ] Create a tag on Device1
- [ ] Verify Device2 receives the tag in real-time (via WebSocket notification → pull)
- [ ] Verify no duplicate tags can be created with the same name
- [ ] Verify existing sync functionality (push/pull) still works

Fixes DEQ-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)