### PR TITLE
fix: Continue fetching events until hasMore is false (DEQ-215)

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -712,8 +712,7 @@ actor SyncManager {
 
         // Log successful pull completion
         let duration = Date().timeIntervalSince(startTime)
-        let durationStr = String(format: "%.2f", duration)
-        os_log("[Sync] Pull completed: syncId=\(syncId), batches=\(batchCount), duration=\(durationStr)s, totalEvents=\(totalEventsDownloaded)")
+        os_log("[Sync] Pull completed: syncId=\(syncId), batches=\(batchCount), events=\(totalEventsDownloaded)")
         await ErrorReportingService.logSyncComplete(
             syncId: syncId,
             duration: duration,


### PR DESCRIPTION
## Summary

Fixes the initial sync only fetching the first batch of ~100 events and stopping, even when the server indicated more events were available.

## Problem

When a fresh device connects, it should fetch all historical events from the server to fully rehydrate. However, the client was:

1. Fetching the first batch of ~100 events
2. Saving the checkpoint
3. **Ignoring the `hasMore: true` field** from the server
4. Marking initial sync as complete

This left new devices appearing empty until the user manually triggered repeated pulls via developer settings.

## Solution

- Add `PullResult` struct to return both `eventsProcessed` and `hasMore`
- Modify `processPullResponse()` to extract and return `hasMore` from the server response  
- Refactor `pullEvents()` to loop while `hasMore` is `true`
- Track total events and batch count across all iterations
- Update checkpoint after each batch to enable proper pagination

## Test Plan

- [ ] Fresh install on a new device - should sync all events automatically
- [ ] Check logs show multiple batches: "Pull batch 1...", "Pull batch 2...", etc.
- [ ] Verify final log shows total events across all batches
- [ ] Existing devices with synced data should continue working normally

## Linear Issue

https://linear.app/dequeue/issue/DEQ-215

🤖 Generated with [Claude Code](https://claude.com/claude-code)