### PR TITLE
fix(DEQ-180): Update remaining stack queries to sort by createdAt

### DIFF
--- a/Dequeue/Dequeue/ContentView.swift
+++ b/Dequeue/Dequeue/ContentView.swift
@@ -14,7 +14,8 @@ struct ContentView: View {
         filter: #Predicate<Stack> { stack in
             stack.isDeleted == false && stack.isDraft == false
         },
-        sort: \Stack.sortOrder
+        sort: \Stack.updatedAt,
+        order: .reverse
     ) private var stacks: [Stack]
 
     var body: some View {

--- a/Dequeue/Dequeue/Views/Arc/StackPickerForArcSheet.swift
+++ b/Dequeue/Dequeue/Views/Arc/StackPickerForArcSheet.swift
@@ -42,7 +42,8 @@ struct StackPickerForArcSheet: View {
                 stack.statusRawValue == activeRawValue &&
                 stack.arcId == nil
             },
-            sort: \Stack.sortOrder
+            sort: \Stack.updatedAt,
+            order: .reverse
         )
     }
 

--- a/Dequeue/Dequeue/Views/Components/StackPickerSheet.swift
+++ b/Dequeue/Dequeue/Views/Components/StackPickerSheet.swift
@@ -31,7 +31,8 @@ struct StackPickerSheet: View {
                 stack.isDraft == false &&
                 stack.statusRawValue == activeRawValue
             },
-            sort: \Stack.sortOrder
+            sort: \Stack.updatedAt,
+            order: .reverse
         )
     }
 

--- a/Dequeue/Dequeue/Views/Stacks/CompletedStacksListView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/CompletedStacksListView.swift
@@ -21,7 +21,7 @@ struct CompletedStacksListView: View {
                 stack.isDeleted == false &&
                 (stack.statusRawValue == completedRaw || stack.statusRawValue == closedRaw)
             },
-            sort: \Stack.createdAt,
+            sort: \Stack.updatedAt,
             order: .reverse
         )
     }

--- a/Dequeue/Dequeue/Views/Stacks/DraftsStacksListView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/DraftsStacksListView.swift
@@ -39,7 +39,7 @@ struct DraftsStacksListView: View {
                 stack.isDraft == true &&
                 stack.statusRawValue == "active"
             },
-            sort: \Stack.createdAt,
+            sort: \Stack.updatedAt,
             order: .reverse
         )
     }

--- a/Dequeue/Dequeue/Views/Stacks/InProgressStacksListView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/InProgressStacksListView.swift
@@ -35,7 +35,7 @@ struct InProgressStacksListView: View {
                 stack.isDraft == false &&
                 stack.statusRawValue == activeRawValue
             },
-            sort: \Stack.createdAt,
+            sort: \Stack.updatedAt,
             order: .reverse
         )
 


### PR DESCRIPTION
## Summary

Updates all @Query declarations to sort stacks by `updatedAt` (most recently modified first) instead of `sortOrder`. This ensures the most recently touched items appear at the top.

## Problem

Stack queries were using `sortOrder` which doesn't reflect actual usage patterns. Users expect to see the stacks they've recently worked on at the top.

## Changes

Updated 6 files to use:
```swift
sort: \Stack.updatedAt,
order: .reverse
```

Files:
- `ContentView.swift`
- `StackPickerForArcSheet.swift`
- `StackPickerSheet.swift`
- `InProgressStacksListView.swift`
- `DraftsStacksListView.swift`
- `CompletedStacksListView.swift`

## Notes

- The `sortOrder` field remains in the model (no migration needed) but is no longer used for display ordering
- `updatedAt` is updated whenever any event modifies the stack

## Acceptance Criteria

- [x] All stack lists sort by updatedAt descending
- [x] Most recently modified stacks appear at top
- [x] sortOrder field remains but is unused
- [x] No data migration required

## Linear Issue

https://linear.app/dequeue/issue/DEQ-180