### PR TITLE
fix(macOS): Add proper sheet sizing for picker modals

### DIFF
--- a/Dequeue/Dequeue/Views/Arc/ArcPickerSheet.swift
+++ b/Dequeue/Dequeue/Views/Arc/ArcPickerSheet.swift
@@ -82,6 +82,11 @@ struct ArcPickerSheet: View {
                 )
             }
         }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(minWidth: 400, minHeight: 300)
+        #endif
     }
 
     // MARK: - Empty State

--- a/Dequeue/Dequeue/Views/Arc/ArcSelectionSheet.swift
+++ b/Dequeue/Dequeue/Views/Arc/ArcSelectionSheet.swift
@@ -60,6 +60,11 @@ struct ArcSelectionSheet: View {
                 }
             }
         }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(minWidth: 400, minHeight: 300)
+        #endif
     }
 
     // MARK: - Empty State

--- a/Dequeue/Dequeue/Views/Arc/StackPickerForArcSheet.swift
+++ b/Dequeue/Dequeue/Views/Arc/StackPickerForArcSheet.swift
@@ -85,6 +85,11 @@ struct StackPickerForArcSheet: View {
                 )
             }
         }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(minWidth: 400, minHeight: 300)
+        #endif
     }
 
     // MARK: - Empty State

--- a/Dequeue/Dequeue/Views/Components/StackPickerSheet.swift
+++ b/Dequeue/Dequeue/Views/Components/StackPickerSheet.swift
@@ -74,6 +74,11 @@ struct StackPickerSheet: View {
                 )
             }
         }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(minWidth: 400, minHeight: 300)
+        #endif
     }
 
     // MARK: - Empty State


### PR DESCRIPTION
## Summary

Fixes macOS sheets (like "Add Stack" from Arc editor) appearing collapsed with only the title and Cancel button visible, no list content.

**Root cause:** On macOS, sheets presented with `NavigationStack` and `List` content collapse when the List has no explicit minimum size. iOS handles this automatically with `presentationDetents`, but macOS needs explicit `.frame()` sizing.

**Changes:**
- Added platform-specific sizing to 4 sheet views following the established pattern from `AddTaskSheet`
- iOS: `.presentationDetents([.medium, .large])`
- macOS: `.frame(minWidth: 400, minHeight: 300)`

**Fixed sheets:**
- `StackPickerForArcSheet` - Add Stack to Arc modal (the reported issue)
- `ArcPickerSheet` - Assign Stack to Arc modal
- `ArcSelectionSheet` - Add to Arc during Stack creation
- `StackPickerSheet` - Select Active Stack modal

## Why this keeps happening

New sheet components get added without macOS sizing because iOS testing doesn't reveal the issue. All future sheet views should include this pattern:

```swift
#if os(iOS)
.presentationDetents([.medium, .large])
#else
.frame(minWidth: 400, minHeight: 300)
#endif
```

## Test plan

- [ ] macOS: Open Arc editor → click "Add Stack" → verify list of stacks is visible
- [ ] macOS: Open Stack detail → "Assign to Arc" → verify list is visible
- [ ] iOS: Same flows work with proper presentation detents

🤖 Generated with [Claude Code](https://claude.com/claude-code)