### PR TITLE
fix: allow bot actors in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Add `allowed_bots: '*'` to the Claude Code Review workflow to permit PRs created by bots (like Claude) to trigger the code review.

## Problem
PR #201 failed the `claude-review` check with:
```
Prepare step failed with error: Workflow initiated by non-human actor: claude (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

## Fix
Added `allowed_bots: '*'` in the `with:` section of the `anthropics/claude-code-action` step, which allows all bot actors to initiate the workflow.

## Testing
This change will take effect on future PR workflow runs.