### PR TITLE
feat: Use dequeue-api for API key management

### DIFF
--- a/Dequeue/Dequeue/Configuration.swift
+++ b/Dequeue/Dequeue/Configuration.swift
@@ -35,10 +35,19 @@ enum Configuration {
     /// Distributed tracing targets - only send trace headers to our own backend
     /// This enables connecting mobile traces to backend traces in Sentry
     static let tracePropagationTargets: [String] = [
+        "api.dequeue.app",
         "sync.ardonos.com",
         "localhost",
         "127.0.0.1"
     ]
+
+    // MARK: - Dequeue API
+
+    /// Base URL for the Dequeue API (API key management, etc.)
+    static let dequeueAPIBaseURL: URL = {
+        // swiftlint:disable:next force_unwrapping
+        return URL(string: "https://api.dequeue.app/v1")!
+    }()
 
     // MARK: - Sync Backend
 

--- a/Dequeue/Dequeue/Services/APIKeyService.swift
+++ b/Dequeue/Dequeue/Services/APIKeyService.swift
@@ -81,7 +81,7 @@ enum APIKeyError: LocalizedError {
 
 // MARK: - API Key Service
 
-/// Service for managing API keys via the stacks-sync API
+/// Service for managing API keys via the Dequeue API
 /// Network-only service - does not use @MainActor per CLAUDE.md guidelines
 /// (only services interacting with SwiftData ModelContext should use @MainActor)
 final class APIKeyService {
@@ -147,7 +147,7 @@ final class APIKeyService {
     func listAPIKeys() async throws -> [APIKey] {
         let token = try await authService.getAuthToken()
 
-        let url = Configuration.syncAPIBaseURL
+        let url = Configuration.dequeueAPIBaseURL
             .appendingPathComponent("api-keys")
 
         var request = URLRequest(url: url)
@@ -193,7 +193,7 @@ final class APIKeyService {
 
         let token = try await authService.getAuthToken()
 
-        let url = Configuration.syncAPIBaseURL
+        let url = Configuration.dequeueAPIBaseURL
             .appendingPathComponent("api-keys")
 
         let requestBody = CreateAPIKeyRequest(name: name, scopes: scopes)
@@ -235,7 +235,7 @@ final class APIKeyService {
     func revokeAPIKey(id: String) async throws {
         let token = try await authService.getAuthToken()
 
-        let url = Configuration.syncAPIBaseURL
+        let url = Configuration.dequeueAPIBaseURL
             .appendingPathComponent("api-keys")
             .appendingPathComponent(id)
 


### PR DESCRIPTION
## Summary
Switch API key management from stacks-sync to dequeue-api.

## Changes
- Add `dequeueAPIBaseURL` pointing to `https://api.dequeue.app/v1`
- Update `APIKeyService` to use the new endpoint
- Add api.dequeue.app to Sentry trace propagation targets

## Dependencies
Requires backend PR: https://github.com/DequeueApp/dequeue-api/pull/35

## Testing
- [ ] List API keys
- [ ] Create API key
- [ ] Revoke API key

## Notes
The auth token (Clerk JWT) is already being used, so no authentication changes were needed. The response format uses camelCase which matches our existing models.