### PR TITLE
Revert: fix(ci): install iOS platform on macos-15 with Xcode 26 (#219)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         working-directory: Dequeue
 
   # Build jobs run in parallel after lint passes
-  # Uses macos-15 with Xcode 26 - must install iOS platform first
   build-ios:
     name: Build iOS
     runs-on: macos-15
@@ -39,42 +38,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.app
-          xcodebuild -version
-
-      - name: Install iOS Platform
-        run: |
-          # Check if iOS platform is available
-          echo "Checking available platforms..."
-          xcodebuild -showsdks | grep -i ios || true
-          
-          # Download iOS platform if not installed
-          echo "Downloading iOS platform (this may take a few minutes)..."
-          xcodebuild -downloadPlatform iOS || true
-          
-          # List available runtimes
-          echo "Available runtimes:"
-          xcrun simctl list runtimes
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
       - name: Create iOS Simulator
         run: |
-          # List available device types
-          echo "Available device types:"
-          xcrun simctl list devicetypes | grep -i iphone | head -10
-          
-          # List available runtimes
-          echo "Available runtimes:"
-          xcrun simctl list runtimes | grep -i ios
-          
-          # Create iPhone 16 Pro simulator using available runtime
-          RUNTIME=$(xcrun simctl list runtimes | grep -i "iOS" | tail -1 | grep -oE 'com.apple.CoreSimulator.SimRuntime.[^ ]+')
-          echo "Using runtime: $RUNTIME"
-          xcrun simctl create "iPhone 16 Pro CI" "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro" "$RUNTIME" 2>/dev/null || true
-          
-          # List created devices
-          echo "Available devices:"
-          xcrun simctl list devices available | grep -i "iphone 16"
+          # Create iPhone 16 simulator if it doesn't exist
+          xcrun simctl create "iPhone 16" "com.apple.CoreSimulator.SimDeviceType.iPhone-16" "com.apple.CoreSimulator.SimRuntime.iOS-18-1" 2>/dev/null || true
+          # Verify it exists
+          xcrun simctl list devices available | grep "iPhone 16"
 
       - name: Cache Swift packages
         uses: actions/cache@v4
@@ -88,17 +59,10 @@ jobs:
 
       - name: Build for iOS
         run: |
-          # Find a working simulator
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro CI" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16" | head -1 | grep -oE '[A-F0-9-]{36}')
-          
-          echo "Using device ID: $DEVICE_ID"
-          
           xcodebuild build \
             -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO
 
@@ -134,23 +98,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.app
-          xcodebuild -version
-
-      - name: Install iOS Platform
-        run: |
-          echo "Downloading iOS platform..."
-          xcodebuild -downloadPlatform iOS || true
-          echo "Available runtimes:"
-          xcrun simctl list runtimes
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
       - name: Create iOS Simulator
         run: |
-          RUNTIME=$(xcrun simctl list runtimes | grep -i "iOS" | tail -1 | grep -oE 'com.apple.CoreSimulator.SimRuntime.[^ ]+')
-          echo "Using runtime: $RUNTIME"
-          xcrun simctl create "iPhone 16 Pro CI" "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro" "$RUNTIME" 2>/dev/null || true
-          xcrun simctl list devices available | grep -i "iphone 16"
+          # Create iPhone 16 simulator if it doesn't exist
+          xcrun simctl create "iPhone 16" "com.apple.CoreSimulator.SimDeviceType.iPhone-16" "com.apple.CoreSimulator.SimRuntime.iOS-18-1" 2>/dev/null || true
+          # Verify it exists
+          xcrun simctl list devices available | grep "iPhone 16"
 
       - name: Cache Swift packages
         uses: actions/cache@v4
@@ -164,16 +119,10 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro CI" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16" | head -1 | grep -oE '[A-F0-9-]{36}')
-          
-          echo "Using device ID: $DEVICE_ID"
-          
           xcodebuild test \
             -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -only-testing:DequeueTests \
             -resultBundlePath UnitTestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO
@@ -196,23 +145,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.app
-          xcodebuild -version
-
-      - name: Install iOS Platform
-        run: |
-          echo "Downloading iOS platform..."
-          xcodebuild -downloadPlatform iOS || true
-          echo "Available runtimes:"
-          xcrun simctl list runtimes
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
       - name: Create iOS Simulator
         run: |
-          RUNTIME=$(xcrun simctl list runtimes | grep -i "iOS" | tail -1 | grep -oE 'com.apple.CoreSimulator.SimRuntime.[^ ]+')
-          echo "Using runtime: $RUNTIME"
-          xcrun simctl create "iPhone 16 Pro CI" "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro" "$RUNTIME" 2>/dev/null || true
-          xcrun simctl list devices available | grep -i "iphone 16"
+          # Create iPhone 16 simulator if it doesn't exist
+          xcrun simctl create "iPhone 16" "com.apple.CoreSimulator.SimDeviceType.iPhone-16" "com.apple.CoreSimulator.SimRuntime.iOS-18-1" 2>/dev/null || true
+          # Verify it exists
+          xcrun simctl list devices available | grep "iPhone 16"
 
       - name: Cache Swift packages
         uses: actions/cache@v4
@@ -226,23 +166,17 @@ jobs:
 
       - name: Boot Simulator
         run: |
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro CI" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16 Pro" | head -1 | grep -oE '[A-F0-9-]{36}') || \
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16" | head -1 | grep -oE '[A-F0-9-]{36}')
-          
-          echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
-          
           # Pre-boot the simulator to avoid timeout issues
-          xcrun simctl boot "$DEVICE_ID" || true
+          xcrun simctl boot "iPhone 16 Pro" || true
           # Wait for simulator to be ready
-          xcrun simctl bootstatus "$DEVICE_ID" -b
+          xcrun simctl bootstatus "iPhone 16 Pro" -b
 
       - name: Run UI Tests
         run: |
           xcodebuild test \
             -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -only-testing:DequeueUITests \
             -resultBundlePath UITestResults.xcresult \
             -parallel-testing-enabled NO \


### PR DESCRIPTION
**URGENT: Fixes broken main branch**

Reverts PR #219 which was incorrectly merged with failing CI.

This was my mistake - I merged a PR that didn't have passing CI, violating trunk-based development rules. Main branch has been broken since the merge.

The original CI fix approach (downloading iOS platform on every run) needs more investigation.