### PR TITLE
fix: Add @MainActor to all test structs for parallel test isolation

### DIFF
--- a/Dequeue/Dequeue/Models/AttachmentSettings.swift
+++ b/Dequeue/Dequeue/Models/AttachmentSettings.swift
@@ -87,26 +87,33 @@ final class AttachmentSettings {
 
     // MARK: - Properties
 
+    /// The UserDefaults instance used for persistence
+    private let defaults: UserDefaults
+
     /// When to automatically download attachments
     var downloadBehavior: AttachmentDownloadBehavior {
         didSet {
-            UserDefaults.standard.set(downloadBehavior.rawValue, forKey: Keys.downloadBehavior)
+            defaults.set(downloadBehavior.rawValue, forKey: Keys.downloadBehavior)
         }
     }
 
     /// Maximum local storage for attachments
     var storageQuota: AttachmentStorageQuota {
         didSet {
-            UserDefaults.standard.set(storageQuota.rawValue, forKey: Keys.storageQuota)
-            UserDefaults.standard.set(true, forKey: Keys.storageQuotaSet)
+            defaults.set(storageQuota.rawValue, forKey: Keys.storageQuota)
+            defaults.set(true, forKey: Keys.storageQuotaSet)
         }
     }
 
     // MARK: - Initialization
 
-    init() {
+    /// Initialize with a specific UserDefaults instance
+    /// - Parameter defaults: The UserDefaults to use for persistence. Defaults to `.standard`.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
         // Load download behavior
-        if let savedBehavior = UserDefaults.standard.string(forKey: Keys.downloadBehavior),
+        if let savedBehavior = defaults.string(forKey: Keys.downloadBehavior),
            let behavior = AttachmentDownloadBehavior(rawValue: savedBehavior) {
             self.downloadBehavior = behavior
         } else {
@@ -114,11 +121,11 @@ final class AttachmentSettings {
         }
 
         // Load storage quota
-        if !UserDefaults.standard.bool(forKey: Keys.storageQuotaSet) {
+        if !defaults.bool(forKey: Keys.storageQuotaSet) {
             // Not set yet, use default
             self.storageQuota = .fiveGB
         } else {
-            let savedQuota = UserDefaults.standard.integer(forKey: Keys.storageQuota)
+            let savedQuota = defaults.integer(forKey: Keys.storageQuota)
             if let quota = AttachmentStorageQuota(rawValue: Int64(savedQuota)) {
                 self.storageQuota = quota
             } else {

--- a/Dequeue/DequeueTests/ActiveStackConstraintTests.swift
+++ b/Dequeue/DequeueTests/ActiveStackConstraintTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Active Stack Constraint Tests")
+@MainActor
 struct ActiveStackConstraintTests {
     // MARK: - Test Helpers
 

--- a/Dequeue/DequeueTests/ActiveTaskTrackingTests.swift
+++ b/Dequeue/DequeueTests/ActiveTaskTrackingTests.swift
@@ -58,6 +58,7 @@ private struct TestContext {
 }
 
 @Suite("Active Task Tracking Tests", .serialized)
+@MainActor
 struct ActiveTaskTrackingTests {
     // MARK: - Stack Model Tests
 

--- a/Dequeue/DequeueTests/ArcServiceTests.swift
+++ b/Dequeue/DequeueTests/ArcServiceTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("ArcService Tests", .serialized)
+@MainActor
 struct ArcServiceTests {
     // MARK: - Test Helpers
 

--- a/Dequeue/DequeueTests/AttachmentServiceTests.swift
+++ b/Dequeue/DequeueTests/AttachmentServiceTests.swift
@@ -46,6 +46,7 @@ private func cleanupTemporaryFile(_ url: URL) {
 }
 
 @Suite("AttachmentService Tests", .serialized)
+@MainActor
 struct AttachmentServiceTests {
     // MARK: - Create Attachment Tests
 

--- a/Dequeue/DequeueTests/DeviceTests.swift
+++ b/Dequeue/DequeueTests/DeviceTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Device Model Tests")
+@MainActor
 struct DeviceTests {
     @Test("Device initializes with required fields")
     func deviceInitializesWithRequiredFields() {

--- a/Dequeue/DequeueTests/DownloadManagerTests.swift
+++ b/Dequeue/DequeueTests/DownloadManagerTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("DownloadManager Tests")
+@MainActor
 struct DownloadManagerTests {
     // MARK: - DownloadProgress Tests
 

--- a/Dequeue/DequeueTests/EventServiceTests.swift
+++ b/Dequeue/DequeueTests/EventServiceTests.swift
@@ -54,6 +54,7 @@ private func makeAttachmentPayload(
 }
 
 @Suite("EventService FetchByIds Tests", .serialized)
+@MainActor
 struct EventServiceFetchByIdsTests {
     @Test("fetchEventsByIds returns events matching provided IDs")
     @MainActor
@@ -174,6 +175,7 @@ struct EventServiceFetchByIdsTests {
 // MARK: - Stack History Tests
 
 @Suite("EventService StackHistory Tests", .serialized)
+@MainActor
 struct EventServiceStackHistoryTests {
     @Test("fetchStackHistoryWithRelated returns stack events")
     @MainActor
@@ -418,6 +420,7 @@ struct EventServiceStackHistoryTests {
 // MARK: - Task History Tests
 
 @Suite("EventService TaskHistory Tests", .serialized)
+@MainActor
 struct EventServiceTaskHistoryTests {
     @Test("fetchTaskHistoryWithRelated returns task events")
     @MainActor

--- a/Dequeue/DequeueTests/NotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/NotificationServiceTests.swift
@@ -142,6 +142,7 @@ private struct TestContext {
 // MARK: - Tests
 
 @Suite("NotificationService Tests", .serialized)
+@MainActor
 struct NotificationServiceTests {
     // MARK: - Permission Tests
 

--- a/Dequeue/DequeueTests/ReminderServiceTests.swift
+++ b/Dequeue/DequeueTests/ReminderServiceTests.swift
@@ -25,6 +25,7 @@ private func makeTestContainer() throws -> ModelContainer {
 }
 
 @Suite("ReminderService Tests", .serialized)
+@MainActor
 struct ReminderServiceTests {
     // MARK: - Create Reminder for Task Tests
 
@@ -432,6 +433,7 @@ struct ReminderServiceTests {
 // MARK: - Query and Event Tests
 
 @Suite("ReminderService Query Tests", .serialized)
+@MainActor
 struct ReminderServiceQueryTests {
     // MARK: - Get Upcoming Reminders Tests
 

--- a/Dequeue/DequeueTests/StackConstraintValidationTests.swift
+++ b/Dequeue/DequeueTests/StackConstraintValidationTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Stack Constraint Validation Tests")
+@MainActor
 struct StackConstraintValidationTests {
     // MARK: - Test Helpers
 

--- a/Dequeue/DequeueTests/StackDetailReadOnlyTests.swift
+++ b/Dequeue/DequeueTests/StackDetailReadOnlyTests.swift
@@ -28,6 +28,7 @@ private func passesCompletedViewFilter(_ stack: Stack) -> Bool {
 }
 
 @Suite("Stack Detail Read-Only Tests", .serialized)
+@MainActor
 struct StackDetailReadOnlyTests {
     // MARK: - Completed Stack Filter Tests
 

--- a/Dequeue/DequeueTests/StackServicePublishDraftTests.swift
+++ b/Dequeue/DequeueTests/StackServicePublishDraftTests.swift
@@ -20,6 +20,7 @@ private struct StackUpdatedPayloadReadable: Decodable {
 }
 
 @Suite("StackService PublishDraft Tests", .serialized)
+@MainActor
 struct StackServicePublishDraftTests {
     // MARK: - Test Helpers
 

--- a/Dequeue/DequeueTests/StackTests.swift
+++ b/Dequeue/DequeueTests/StackTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Stack Model Tests")
+@MainActor
 struct StackTests {
     @Test("Stack initializes with default values")
     func stackInitializesWithDefaults() {

--- a/Dequeue/DequeueTests/TaskServiceTests.swift
+++ b/Dequeue/DequeueTests/TaskServiceTests.swift
@@ -25,6 +25,7 @@ private func makeTestContainer() throws -> ModelContainer {
 }
 
 @Suite("TaskService Tests", .serialized)
+@MainActor
 struct TaskServiceTests {
     // MARK: - Create Task Tests (DEQ-7)
 

--- a/Dequeue/DequeueTests/UndoCompletionManagerTests.swift
+++ b/Dequeue/DequeueTests/UndoCompletionManagerTests.swift
@@ -24,6 +24,7 @@ private func makeTestContainer() throws -> ModelContainer {
 }
 
 @Suite("UndoCompletionManager Tests", .serialized)
+@MainActor
 struct UndoCompletionManagerTests {
     // MARK: - Initial State Tests
 
@@ -336,6 +337,7 @@ struct UndoCompletionManagerTests {
 // MARK: - Stack Completion with Tasks Tests
 
 @Suite("UndoCompletionManager Task Handling Tests", .serialized)
+@MainActor
 struct UndoCompletionManagerTaskTests {
     @Test("Completing stack also completes all pending tasks")
     @MainActor

--- a/Dequeue/DequeueTests/UploadManagerTests.swift
+++ b/Dequeue/DequeueTests/UploadManagerTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("UploadManager Tests")
+@MainActor
 struct UploadManagerTests {
     // MARK: - UploadProgress Tests
 


### PR DESCRIPTION
## Summary
Fixes test failures on PR #223 that were occurring on parallel simulator clones.

## Problem
Tests were failing instantly (0.000 seconds) on some simulator clones while passing on others. This indicated a race condition in parallel test execution with Swift 6 + Swift Testing.

## Root Cause
Tests that use MainActor-isolated types (like SwiftData's `ModelContext`) had `@MainActor` only on individual test methods, not on the test struct itself. This caused:
1. Test struct initialization to run in a non-isolated context
2. Helper functions to run outside MainActor isolation
3. Race conditions when tests ran in parallel across simulator clones

## Solution
1. **Add `@MainActor` to all test struct declarations** that use MainActor-isolated types
2. **Fix `AttachmentSettings` to support dependency injection** of `UserDefaults` for testability
3. **Update `AttachmentSettingsTests`** to use isolated `UserDefaults` per test (no shared global state)
4. **Improve `APIKeyServiceTests`** mock network isolation to avoid handler collisions

## Files Changed
- `AttachmentSettings.swift` - Added `defaults` parameter for DI
- 18 test files - Added `@MainActor` to struct declarations

## Testing
These changes ensure tests run with proper actor isolation, preventing race conditions when executed in parallel across simulator clones.