### PR TITLE
feat(DEQ-54): Add AI delegation fields to QueueTask

### DIFF
--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -28,6 +28,11 @@ final class QueueTask {
     var updatedAt: Date
     var isDeleted: Bool
 
+    // AI delegation fields (DEQ-54)
+    var delegatedToAI: Bool
+    var aiAgentId: String?
+    var aiDelegatedAt: Date?
+
     // Sync fields
     var userId: String?
     var deviceId: String?
@@ -60,6 +65,9 @@ final class QueueTask {
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         isDeleted: Bool = false,
+        delegatedToAI: Bool = false,
+        aiAgentId: String? = nil,
+        aiDelegatedAt: Date? = nil,
         userId: String? = nil,
         deviceId: String? = nil,
         syncState: SyncState = .pending,
@@ -85,6 +93,9 @@ final class QueueTask {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.isDeleted = isDeleted
+        self.delegatedToAI = delegatedToAI
+        self.aiAgentId = aiAgentId
+        self.aiDelegatedAt = aiDelegatedAt
         self.userId = userId
         self.deviceId = deviceId
         self.syncState = syncState

--- a/Dequeue/Dequeue/Sync/ProjectorService.swift
+++ b/Dequeue/Dequeue/Sync/ProjectorService.swift
@@ -1047,6 +1047,9 @@ enum ProjectorService {
                 priority: payload.priority,
                 sortOrder: payload.sortOrder,
                 lastActiveTime: payload.lastActiveTime,
+                delegatedToAI: payload.delegatedToAI ?? false,
+                aiAgentId: payload.aiAgentId,
+                aiDelegatedAt: payload.aiDelegatedAt,
                 syncState: .synced,
                 lastSyncedAt: Date()
             )
@@ -2325,6 +2328,14 @@ enum ProjectorService {
         task.startTime = payload.startTime
         task.dueTime = payload.dueTime
         task.lastActiveTime = payload.lastActiveTime
+        
+        // Update AI delegation fields (DEQ-54)
+        if let delegatedToAI = payload.delegatedToAI {
+            task.delegatedToAI = delegatedToAI
+        }
+        task.aiAgentId = payload.aiAgentId
+        task.aiDelegatedAt = payload.aiDelegatedAt
+        
         task.updatedAt = eventTimestamp  // LWW: Use event timestamp for determinism
         task.syncState = .synced
         task.lastSyncedAt = Date()


### PR DESCRIPTION
## Summary

Adds foundation for AI task delegation by adding tracking fields to the QueueTask model.

## Changes

### Model Fields (QueueTask)
- `delegatedToAI: Bool` - Whether task is delegated to AI (default: false)
- `aiAgentId: String?` - ID of the AI agent handling the task
- `aiDelegatedAt: Date?` - When task was delegated

### Event Payload (TaskEventPayload)
- Added AI delegation fields to payload
- Encoding/decoding handles Int64 timestamp conversion
- Optional fields for backward compatibility

### Projector (ProjectorService)
- `applyTaskCreated`: Sets AI fields from payload
- `updateTask`: Updates AI fields when present

## Migration Strategy

**No migration needed** - New fields are optional with safe defaults:
- `delegatedToAI` defaults to false
- `aiAgentId` and `aiDelegatedAt` are optional

Existing tasks will have `delegatedToAI=false` automatically.

## Next Steps

This enables:
- **DEQ-56**: Add `task.delegatedToAI` event type
- **DEQ-55**: Add `actorType` to event metadata
- **DEQ-58**: Add UI for AI delegation status

## Testing

- [ ] Unit tests for AI field serialization
- [ ] Projector tests for AI field handling
- [ ] Manual testing with AI delegation flow

---

**Time**: 15 minutes
**Risk**: Low (optional fields, backward compatible)