### PR TITLE
fix(DEQ-244): Fix conditional compilation in MainTabView

### DIFF
--- a/Dequeue/Dequeue/Views/App/MainTabView.swift
+++ b/Dequeue/Dequeue/Views/App/MainTabView.swift
@@ -127,18 +127,24 @@ struct MainTabView: View {
                 NavigationLink(value: 0) {
                     Label("Arcs", systemImage: "rays")
                 }
-                .navigationTitle("Dequeue")
-                .listStyle(.sidebar)
-            } detail: {
-                ZStack(alignment: .bottom) {
-                    detailContentForSelection
-                        .frame(maxHeight: .infinity, alignment: .top)
-                    floatingBanners
+                NavigationLink(value: 1) {
+                    Label("Stacks", systemImage: "square.stack.3d.up")
+                }
+                NavigationLink(value: 2) {
+                    Label("Activity", systemImage: "clock.arrow.circlepath")
+                }
+                NavigationLink(value: 3) {
+                    Label("Settings", systemImage: "gear")
                 }
             }
-        } else {
-            // Fallback for older iOS
-            iPhoneTabViewLayout
+            .navigationTitle("Dequeue")
+            .listStyle(.sidebar)
+        } detail: {
+            ZStack(alignment: .bottom) {
+                detailContentForSelection
+                    .frame(maxHeight: .infinity, alignment: .top)
+                floatingBanners
+            }
         }
         #else
         EmptyView()


### PR DESCRIPTION
Fixes build failures in PRs #260, #259, #255 caused by PR #256 merge.

**Problem:** PR #256 (iPad split view) merged with conditional compilation wrapping property declarations instead of being inside property bodies.

**Root Cause:** Swift doesn't allow `#if` to conditionally include/exclude property declarations at type member level.

**Fix:** Moved `#if os(iOS)` blocks inside property bodies:
- `iPhoneTabViewLayout`
- `iPadSplitViewLayout`  
- `detailContentForSelection`
- `floatingBanners`

Properties now exist on all platforms, with platform-specific implementations inside.

**Impact:** Unblocks all 3 open PRs (#260, #259, #255) which can rebase after this merges.