### PR TITLE
fix: iOS compatibility for iPad split view selection

### DIFF
--- a/Dequeue/Dequeue/Views/App/MainTabView.swift
+++ b/Dequeue/Dequeue/Views/App/MainTabView.swift
@@ -120,8 +120,8 @@ struct MainTabView: View {
 
     /// iPad split view layout with sidebar navigation (DEQ-51)
     private var iPadSplitViewLayout: some View {
-        NavigationSplitView {
-            List(selection: $selectedTab) {
+        NavigationSplitView(columnVisibility: .constant(.all)) {
+            List {
                 NavigationLink(value: 0) {
                     Label("Arcs", systemImage: "rays")
                 }


### PR DESCRIPTION
## Problem
PR #256 (DEQ-51) introduced iPad split view with `List(selection:)` which is unavailable in iOS, breaking ALL PR builds.

## Solution
- Remove `selection:` parameter from List (not needed with NavigationLink)
- Add `columnVisibility` to ensure sidebar visibility
- NavigationLink(value:) handles selection automatically

## Impact
Unblocks ALL open PRs (#261, #260, #259, #255)

## Related
- Fixes build failures in main branch
- Must merge before any other PRs can proceed