### PR TITLE
feat(DEQ-29): Add parent task relationship (subtasks)

### DIFF
--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -48,6 +48,9 @@ final class QueueTask {
     @Relationship(deleteRule: .cascade, inverse: \Reminder.task)
     var reminders: [Reminder] = []
 
+    // Parent-child task relationship (DEQ-29: Subtasks)
+    var parentTaskId: String?
+
     init(
         id: String = CUID.generate(),
         title: String,
@@ -76,7 +79,8 @@ final class QueueTask {
         lastSyncedAt: Date? = nil,
         serverId: String? = nil,
         revision: Int = 1,
-        stack: Stack? = nil
+        stack: Stack? = nil,
+        parentTaskId: String? = nil  // DEQ-29: Subtasks
     ) {
         self.id = id
         self.title = title
@@ -106,6 +110,7 @@ final class QueueTask {
         self.serverId = serverId
         self.revision = revision
         self.stack = stack
+        self.parentTaskId = parentTaskId  // DEQ-29
     }
 }
 
@@ -114,5 +119,12 @@ final class QueueTask {
 extension QueueTask {
     var activeReminders: [Reminder] {
         reminders.filter { !$0.isDeleted && $0.status == .active }
+    }
+
+    // DEQ-29: Parent task relationship
+    // Note: These computed properties require ModelContext access
+    // For querying parent/subtasks, use helper methods in TaskService or similar
+    var hasParent: Bool {
+        parentTaskId != nil
     }
 }

--- a/Dequeue/Dequeue/Services/EventService.swift
+++ b/Dequeue/Dequeue/Services/EventService.swift
@@ -709,6 +709,9 @@ struct TaskState: Codable {
     // Tags (DEQ-31)
     let tags: [String]?
 
+    // Parent task relationship (DEQ-29: Subtasks)
+    let parentTaskId: String?
+
     static func from(_ task: QueueTask) -> TaskState {
         TaskState(
             id: task.id,
@@ -727,7 +730,8 @@ struct TaskState: Codable {
             delegatedToAI: task.delegatedToAI,
             aiAgentId: task.aiAgentId,
             aiDelegatedAt: task.aiDelegatedAt.map { Int64($0.timeIntervalSince1970 * 1_000) },
-            tags: task.tags.isEmpty ? nil : task.tags  // DEQ-31
+            tags: task.tags.isEmpty ? nil : task.tags,  // DEQ-31
+            parentTaskId: task.parentTaskId  // DEQ-29: Subtasks
         )
     }
 }
@@ -1235,11 +1239,14 @@ struct TaskEventPayload: Codable {
     // Tags (DEQ-31)
     let tags: [String]?
 
+    // Parent task relationship (DEQ-29: Subtasks)
+    let parentTaskId: String?
+
     enum CodingKeys: String, CodingKey {
         case id, stackId, title, description, status, priority
         case sortOrder, startTime, dueTime, lastActiveTime, deleted, createdAt
         case delegatedToAI, aiAgentId, aiDelegatedAt
-        case tags
+        case tags, parentTaskId
     }
 
     init(from decoder: Decoder) throws {
@@ -1303,6 +1310,9 @@ struct TaskEventPayload: Codable {
         
         // Decode tags (DEQ-31)
         tags = try container.decodeIfPresent([String].self, forKey: .tags)
+
+        // Decode parentTaskId (DEQ-29: Subtasks)
+        parentTaskId = try container.decodeIfPresent(String.self, forKey: .parentTaskId)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -1337,6 +1347,9 @@ struct TaskEventPayload: Codable {
         
         // Encode tags (DEQ-31)
         try container.encodeIfPresent(tags, forKey: .tags)
+
+        // Encode parentTaskId (DEQ-29: Subtasks)
+        try container.encodeIfPresent(parentTaskId, forKey: .parentTaskId)
     }
 }
 

--- a/Dequeue/Dequeue/Sync/ProjectorService.swift
+++ b/Dequeue/Dequeue/Sync/ProjectorService.swift
@@ -1056,7 +1056,8 @@ enum ProjectorService {
                 aiAgentId: payload.aiAgentId,
                 aiDelegatedAt: payload.aiDelegatedAt,
                 syncState: .synced,
-                lastSyncedAt: Date()
+                lastSyncedAt: Date(),
+                parentTaskId: payload.parentTaskId  // DEQ-29: Subtasks
             )
             // Use original createdAt from payload if available, otherwise fall back to event timestamp
             task.createdAt = payload.createdAt ?? event.timestamp
@@ -2376,6 +2377,9 @@ enum ProjectorService {
         if let tags = payload.tags {
             task.tags = tags
         }
+
+        // Update parent task relationship (DEQ-29: Subtasks)
+        task.parentTaskId = payload.parentTaskId
         
         task.updatedAt = eventTimestamp  // LWW: Use event timestamp for determinism
         task.syncState = .synced


### PR DESCRIPTION
## Summary

Implements parent-child task relationships to support subtasks (DEQ-29).

## Changes

### Model Layer
- Added `parentTaskId: String?` field to `QueueTask` model
- Added `hasParent` computed property for quick checks
- Updated init to include parentTaskId parameter

### Sync Layer
- Added `parentTaskId` to `TaskEventPayload` for event processing
- Added `parentTaskId` to `TaskState` for event sourcing
- Updated `ProjectorService.applyTaskCreated` to set parentTaskId
- Updated `ProjectorService.updateTask` to handle parentTaskId updates

### Migration
- SwiftData will automatically handle schema migration for new optional field
- Existing tasks will have `parentTaskId = nil` (no parent)

## Testing Strategy

### Covered in this PR
- [x] Model changes (parentTaskId field)
- [x] Event payload changes (serialization/deserialization)
- [x] Projector service updates (sync processing)

### Future PRs (as noted in DEQ-29)
- [ ] Unit tests for parent-child operations
- [ ] UI for subtask hierarchy display
- [ ] UI for creating/assigning subtasks

## Notes

- UI work is explicitly deferred per DEQ-29 acceptance criteria
- This PR focuses on the data model and sync infrastructure
- Parent-child queries will be handled by services with ModelContext access

## Related

- Closes DEQ-29
- Part of subtasks feature implementation