### PR TITLE
fix: Stop Clerk token refresh spam when unauthenticated

### DIFF
--- a/Dequeue/Dequeue/Services/AuthService.swift
+++ b/Dequeue/Dequeue/Services/AuthService.swift
@@ -134,6 +134,12 @@ final class ClerkAuthService: AuthServiceProtocol {
             return
         }
 
+        // Avoid spamming Clerk when we know there's no active session
+        // This prevents repeated 401s from /client/sessions/.../tokens
+        guard Clerk.shared.session != nil else {
+            return
+        }
+
         // Capture state before refresh to detect changes
         let wasAuthenticated = isAuthenticated
         let previousUserId = currentUserId


### PR DESCRIPTION
## 🚨 Sentry Error Spike Fix (401 + authentication_invalid)

**Spike source:** dequeue-app
- HTTPClientError 401 (2,700+ events)
- ClerkAPIError(authentication_invalid) (1,900+ events)

These are caused by repeated Clerk token refresh calls with no active session:
`/v1/client/sessions/.../tokens` → 401

## Fix
Add a guard in `refreshSessionInBackground`:
- If `Clerk.shared.session == nil`, return early
- Prevents repeated unauthenticated token refresh calls

## Impact
✅ Stops Sentry error spam
✅ Reduces billing burn
✅ Preserves auth flow when session exists

## Testing
- Minimal change, no UI impact
- Safe guard clause only

## Files
- `Dequeue/Dequeue/Services/AuthService.swift`

---

**Priority:** P0 (billing burn)
