### PR TITLE
fix(sync): integrate NetworkMonitor for automatic reconnection

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -1964,13 +1964,13 @@ actor SyncManager {
         networkMonitorTask?.cancel()
         networkMonitorTask = Task { [weak self] in
             guard let self = self else { return }
-            var wasConnected = NetworkMonitor.shared.isConnected
+            var wasConnected = await NetworkMonitor.shared.isConnected
 
             // Poll for network changes (workaround for @Observable observation in actor)
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
 
-                let isConnected = NetworkMonitor.shared.isConnected
+                let isConnected = await NetworkMonitor.shared.isConnected
                 
                 // Network became available - attempt reconnection if we have credentials and aren't connected
                 if isConnected && !wasConnected {


### PR DESCRIPTION
## Problem

`startNetworkMonitoring()` in SyncManager was a stub function with a TODO comment saying it would integrate NetworkMonitor "when DEQ-47 is merged."

DEQ-47 was merged months ago (PR #70), but the integration was never completed. The function just set `networkMonitorTask = nil`, providing no actual network monitoring.

## Solution

Integrated NetworkMonitor.shared into SyncManager following the same pattern as UploadRetryManager:

1. **Poll NetworkMonitor.shared.isConnected** every 2 seconds (workaround for actor isolation)
2. **Detect network recovery** (offline → online transitions)
3. **Trigger automatic reconnection** via `ensureConnected()` when network becomes available

## Technical Details

- Uses `Task` stored in `networkMonitorTask` (properly cancelled in `disconnect()`)
- Only attempts reconnection if credentials exist (`userId`, `token`, `getTokenFunction`)
- `ensureConnected()` is safe to call repeatedly - it's a no-op if already connected
- Adds logging for debugging network recovery events

## Impact

- WebSocket now automatically reconnects when network recovers from outages
- Improves reliability for users on flaky networks (mobile, WiFi switching)
- Removes outdated TODO technical debt
- No breaking changes - purely additive functionality

## Testing

Manual testing recommended:
1. Connect to sync
2. Disable network (Airplane mode or disconnect WiFi)
3. Wait 5+ seconds
4. Re-enable network
5. Verify WebSocket reconnects automatically within ~2 seconds

## Related

- DEQ-47: Original NetworkMonitor implementation (PR #70)
- UploadRetryManager: Similar network monitoring pattern for reference