### PR TITLE
fix: Map existing App Store Connect API secrets

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -66,9 +66,10 @@ jobs:
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          # Map existing secrets to expected names
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
           ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
           CHANGELOG: ${{ github.event.inputs.changelog || 'Bug fixes and improvements' }}
         run: bundle exec fastlane beta


### PR DESCRIPTION
## Summary

Fixes **3 of 7** missing secrets for TestFlight deployment by mapping existing secrets to Fastlane's expected environment variable names.

## Changes

Maps existing GitHub secrets:
- `APP_STORE_CONNECT_API_KEY_ID` → `ASC_KEY_ID`
- `APP_STORE_CONNECT_API_ISSUER_ID` → `ASC_ISSUER_ID`
- `APP_STORE_CONNECT_API_KEY_BASE64` → `ASC_KEY_CONTENT`

## Still Needed (Manual Setup Required)

The following 4 secrets still need to be added manually:
- `MATCH_DEPLOY_KEY` - SSH private key for certificates repo access
- `MATCH_PASSWORD` - Encryption password for Match certificates  
- `MATCH_GIT_URL` - Git URL: `git@github.com:victorquinn/certificates.git`
- `ITC_TEAM_ID` - iTunes Connect Team ID from App Store Connect

See `FASTLANE_SETUP.md` for complete setup instructions.

## Testing

- ✅ Workflow YAML syntax validated
- ⏳ TestFlight deployment will still fail until Match secrets are added

## Fixes

Partially addresses #279 (3/7 secrets fixed)