### PR TITLE
feat: Implement attachment deletion in TaskDetailView

### DIFF
--- a/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
@@ -78,7 +78,25 @@ extension TaskDetailView {
     }
 
     func handleDeleteAttachment(_ attachment: Attachment) {
-        // TODO: Delete attachment (will be implemented with AttachmentService integration)
+        guard let service = attachmentService else {
+            errorMessage = "Attachment service not available"
+            showError = true
+            return
+        }
+
+        Task {
+            do {
+                try await service.deleteAttachment(attachment)
+            } catch {
+                errorMessage = "Failed to delete attachment: \(error.localizedDescription)"
+                showError = true
+                ErrorReportingService.capture(error: error, context: [
+                    "view": "TaskDetailView",
+                    "action": "handleDeleteAttachment",
+                    "attachmentId": attachment.id
+                ])
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the TODO for `handleDeleteAttachment` by calling `AttachmentService.deleteAttachment()`.

## Changes

- Wires up `handleDeleteAttachment` to call `service.deleteAttachment()`
- Service handles:
  - Soft delete (sets `isDeleted = true`)
  - Updates sync state to `.pending`
  - Records `attachment.removed` event for sync
  - Cleans up local file
- Adds error handling with user feedback via error alert

## Implementation Notes

The `AttachmentService.deleteAttachment()` method was already fully implemented, this PR just connects it to the UI handler that was marked as TODO.

## Testing

- [ ] Manual testing: Delete attachment from task detail view
- [ ] Verify attachment is soft-deleted (marked as deleted, not removed from DB)
- [ ] Verify sync event is created
- [ ] Verify local file is cleaned up

## Fixes

Closes the TODO comment in `TaskDetailView+Attachments.swift`