### PR TITLE
feat: Add download handler for remote-only attachment previews

### DIFF
--- a/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskDetailView+Attachments.swift
@@ -72,7 +72,7 @@ extension TaskDetailView {
         Task {
             await previewCoordinator.preview(
                 attachment: attachment,
-                downloadHandler: nil  // TODO: Add download handler for remote-only attachments
+                downloadHandler: attachmentService?.downloadAttachment(_:)
             )
         }
     }


### PR DESCRIPTION
## Summary

Implements the TODO by passing `AttachmentService.downloadAttachment` as the download handler to the preview coordinator.

## Changes

- Passes `attachmentService?.downloadAttachment(_:)` to `previewCoordinator.preview()`
- Enables automatic download of remote-only attachments before preview
- Service handles fetching from R2, saving to local cache, and updating state

## Behavior

When user taps a remote-only attachment:
1. Preview coordinator checks if file is available locally
2. If not available locally, calls download handler
3. Download handler fetches from R2 and saves to cache
4. Preview displays once download completes
5. Progress indicator shows during download

## Implementation Notes

The `AttachmentService.downloadAttachment(_ attachment: Attachment) async throws -> URL` method was already fully implemented. This PR simply wires it up to the preview flow that was marked as TODO.

## Testing

- [ ] Manual testing: Tap remote-only attachment in task detail view
- [ ] Verify download triggers automatically
- [ ] Verify progress indicator appears
- [ ] Verify preview displays after download
- [ ] Verify downloaded file is cached locally

## Fixes

Closes the TODO comment for download handler in `TaskDetailView+Attachments.swift`