### PR TITLE
fix: projection sync bugs causing silent fallback to event replay (fixes #298)

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -723,16 +723,17 @@ actor SyncManager {
         // 4. Create Tasks (fetched separately via GET /v1/tasks)
         for taskData in tasks {
             // Look up the parent stack — it should exist from step 3
+            let taskStackId = taskData.stackId
             let stack: Stack?
-            if let cached = stackMap[taskData.stackId] {
+            if let cached = stackMap[taskStackId] {
                 stack = cached
             } else {
-                let fetchDescriptor = FetchDescriptor<Stack>(predicate: #Predicate<Stack> { $0.id == taskData.stackId })
+                let fetchDescriptor = FetchDescriptor<Stack>(predicate: #Predicate<Stack> { $0.id == taskStackId })
                 stack = try context.fetch(fetchDescriptor).first
             }
 
             guard let parentStack = stack else {
-                os_log("[Sync] Skipping task \(taskData.id) - parent stack \(taskData.stackId) not found")
+                os_log("[Sync] Skipping task \(taskData.id) - parent stack \(taskStackId) not found")
                 continue
             }
 


### PR DESCRIPTION
## Problem

The projection-based initial sync (DEQ-230) has 4 bugs that cause it to **always fail silently** and fall back to the slower event replay path. New devices never benefit from projection sync.

Closes #298

## Fixes

### 1. Timestamp type mismatch (Critical)
All projection structs defined timestamp fields as `String`, but the API returns **Unix millisecond `Int64`** values. `JSONDecoder.decode()` fails entirely because it cannot decode `Int64` into `String`.

**Fix:** Changed all timestamp fields to `Int64` and added `dateFromUnixMs()` helper.

### 2. Pagination URL construction
On page 2+, the code used `"\(url)?cursor=\(nextCursor)"` which:
- Uses the `URL` object (not string) causing `URL.description` interpolation
- Always prepends `?cursor=` even if URL already has query params → malformed URLs

**Fix:** Use `URLComponents` to properly add/update the cursor query parameter.

### 3. Tasks not fetched separately
`StackProjection.tasks` expected nested tasks, but `GET /v1/stacks` doesn't include them → always `nil`.

**Fix:** Fetch tasks separately via `GET /v1/tasks` (added in dequeue-api PR #93, now merged). Updated `populateFromProjections` to accept tasks and look up parent stacks by ID with a local cache map.

### 4. Removed parseISO8601 dependency for projection data
All projection timestamp handling now uses `dateFromUnixMs()` directly, avoiding the instance method `parseISO8601` which only handled standard ISO8601 (no fractional seconds).

## Changes Summary
- `SyncManager.swift`: 80 insertions, 49 deletions in 1 file
- All projection struct timestamps: `String` → `Int64`
- New `dateFromUnixMs()` helper (non-isolated, pure function)
- Pagination: `String` interpolation → `URLComponents`
- Tasks: nested in stacks → fetched separately via `GET /v1/tasks`
- `populateFromProjections`: new `tasks` parameter, stack lookup cache

## Dependencies
- **dequeue-api PR #93** (merged ✅): Adds `GET /v1/tasks` and `GET /v1/reminders` endpoints

## Testing
⚠️ Cannot build locally (no Xcode on build machine). Recommend testing:
1. Fresh install → verify projection sync populates all data types
2. Account with >50 items → verify pagination works correctly
3. Verify incremental sync continues working after projection sync