### PR TITLE
feat: search, stats, and export client for iOS

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -131,6 +131,9 @@ struct DequeueApp: App {
                 .environment(\.clerk, Clerk.shared)
                 .environment(\.syncManager, syncManager)
                 .environment(\.attachmentSettings, attachmentSettings)
+                .environment(\.searchService, SearchService(authService: authService))
+                .environment(\.statsService, StatsService(authService: authService))
+                .environment(\.exportService, ExportService(authService: authService))
                 .applyAppTheme()
                 .task {
                     // Configure error reporting first (runs on background thread)

--- a/Dequeue/Dequeue/Services/ExportService.swift
+++ b/Dequeue/Dequeue/Services/ExportService.swift
@@ -1,0 +1,224 @@
+//
+//  ExportService.swift
+//  Dequeue
+//
+//  Client for the data export endpoint (GET /v1/export)
+//
+
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.dequeue", category: "ExportService")
+
+// MARK: - Export Models
+
+/// Complete data export from the API
+struct ExportResponse: Codable, Sendable {
+    let exportedAt: Int64 // Unix milliseconds
+    let version: String   // Export format version
+    let arcs: [ArcExport]
+    let stacks: [StackExport]
+    let tasks: [TaskExport]
+    let tags: [TagExport]
+    let reminders: [ReminderExport]
+
+    var exportedAtDate: Date {
+        Date(timeIntervalSince1970: Double(exportedAt) / 1_000.0)
+    }
+
+    /// Total number of items in the export
+    var totalItems: Int {
+        arcs.count + stacks.count + tasks.count + tags.count + reminders.count
+    }
+}
+
+/// Arc data in the export
+struct ArcExport: Codable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let description: String?
+    let status: String
+    let colorHex: String?
+    let sortOrder: Int
+    let stackCount: Int
+    let completedStackCount: Int
+    let createdAt: Int64
+    let updatedAt: Int64
+    let completedAt: Int64?
+}
+
+/// Stack data in the export
+struct StackExport: Codable, Sendable, Identifiable {
+    let id: String
+    let arcId: String?
+    let title: String
+    let status: String
+    let sortOrder: Int
+    let taskCount: Int
+    let completedTaskCount: Int
+    let tags: [String]
+    let isActive: Bool
+    let activeTaskId: String?
+    let createdAt: Int64
+    let updatedAt: Int64
+}
+
+/// Task data in the export
+struct TaskExport: Codable, Sendable, Identifiable {
+    let id: String
+    let stackId: String
+    let title: String
+    let notes: String?
+    let status: String
+    let priority: Int
+    let sortOrder: Int
+    let isActive: Bool
+    let dueAt: Int64?
+    let blockedReason: String?
+    let parentTaskId: String?
+    let createdAt: Int64
+    let updatedAt: Int64
+    let completedAt: Int64?
+}
+
+/// Tag data in the export
+struct TagExport: Codable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    let colorHex: String?
+    let createdAt: Int64
+    let updatedAt: Int64
+}
+
+/// Reminder data in the export
+struct ReminderExport: Codable, Sendable, Identifiable {
+    let id: String
+    let parentType: String // "stack" or "arc"
+    let parentId: String
+    let remindAt: Int64
+    let createdAt: Int64
+    let updatedAt: Int64
+
+    var remindAtDate: Date {
+        Date(timeIntervalSince1970: Double(remindAt) / 1_000.0)
+    }
+}
+
+// MARK: - Export Error
+
+enum ExportError: LocalizedError {
+    case notAuthenticated
+    case invalidResponse
+    case serverError(statusCode: Int, message: String?)
+    case networkError(Error)
+    case fileWriteError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "You must be signed in to export data."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case let .serverError(statusCode, message):
+            if let message {
+                return "Server error (\(statusCode)): \(message)"
+            }
+            return "Server error: \(statusCode)"
+        case let .networkError(error):
+            return "Network error: \(error.localizedDescription)"
+        case let .fileWriteError(error):
+            return "Failed to save export: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Export Service
+
+/// Service for exporting user data via the Dequeue API
+/// Network-only service - does not use @MainActor
+final class ExportService: @unchecked Sendable {
+    private let authService: any AuthServiceProtocol
+    private let urlSession: URLSession
+
+    init(authService: any AuthServiceProtocol, urlSession: URLSession = .shared) {
+        self.authService = authService
+        self.urlSession = urlSession
+    }
+
+    /// Fetches all user data as a structured export
+    /// - Returns: Complete export response
+    func exportData() async throws -> ExportResponse {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("export")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        logger.debug("Exporting data from: \(url.absoluteString)")
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ExportError.invalidResponse
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let errorMessage = (try? JSONDecoder().decode([String: String].self, from: data))?["error"]
+                throw ExportError.serverError(statusCode: httpResponse.statusCode, message: errorMessage)
+            }
+
+            let export = try JSONDecoder().decode(ExportResponse.self, from: data)
+            logger.info("Export complete: \(export.totalItems) total items")
+            return export
+        } catch let error as ExportError {
+            throw error
+        } catch {
+            throw ExportError.networkError(error)
+        }
+    }
+
+    /// Exports data and saves to a temporary JSON file for sharing
+    /// - Returns: URL of the saved file
+    func exportToFile() async throws -> URL {
+        let export = try await exportData()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(export)
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss"
+        let timestamp = dateFormatter.string(from: Date())
+        let filename = "dequeue-export-\(timestamp).json"
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(filename)
+
+        do {
+            try data.write(to: fileURL)
+            logger.info("Export saved to: \(fileURL.path)")
+            return fileURL
+        } catch {
+            throw ExportError.fileWriteError(error)
+        }
+    }
+}
+
+// MARK: - Environment Key
+
+private struct ExportServiceKey: EnvironmentKey {
+    static let defaultValue: ExportService? = nil
+}
+
+extension EnvironmentValues {
+    var exportService: ExportService? {
+        get { self[ExportServiceKey.self] }
+        set { self[ExportServiceKey.self] = newValue }
+    }
+}

--- a/Dequeue/Dequeue/Services/SearchService.swift
+++ b/Dequeue/Dequeue/Services/SearchService.swift
@@ -1,0 +1,215 @@
+//
+//  SearchService.swift
+//  Dequeue
+//
+//  Client for the unified search endpoint (GET /v1/search)
+//
+
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.dequeue", category: "SearchService")
+
+// MARK: - Search Models
+
+/// A single search result that can be either a task or a stack
+struct SearchResultItem: Identifiable, Codable, Sendable {
+    let type: String // "task" or "stack"
+    let task: SearchTask?
+    let stack: SearchStack?
+
+    var id: String {
+        if let task {
+            return "task-\(task.id)"
+        } else if let stack {
+            return "stack-\(stack.id)"
+        }
+        return UUID().uuidString
+    }
+}
+
+/// Task data returned from search
+struct SearchTask: Codable, Sendable, Identifiable {
+    let id: String
+    let stackId: String
+    let title: String
+    let notes: String?
+    let status: String
+    let priority: Int
+    let sortOrder: Int
+    let isActive: Bool
+    let dueAt: Int64?
+    let blockedReason: String?
+    let parentTaskId: String?
+    let createdAt: Int64
+    let updatedAt: Int64
+    let completedAt: Int64?
+
+    var dueAtDate: Date? {
+        guard let dueAt else { return nil }
+        return Date(timeIntervalSince1970: Double(dueAt) / 1_000.0)
+    }
+
+    var createdAtDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1_000.0)
+    }
+
+    var updatedAtDate: Date {
+        Date(timeIntervalSince1970: Double(updatedAt) / 1_000.0)
+    }
+}
+
+/// Stack data returned from search
+struct SearchStack: Codable, Sendable, Identifiable {
+    let id: String
+    let arcId: String?
+    let title: String
+    let status: String
+    let sortOrder: Int
+    let taskCount: Int
+    let completedTaskCount: Int
+    let isActive: Bool
+    let activeTaskId: String?
+    let createdAt: Int64
+    let updatedAt: Int64
+
+    var createdAtDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1_000.0)
+    }
+
+    var updatedAtDate: Date {
+        Date(timeIntervalSince1970: Double(updatedAt) / 1_000.0)
+    }
+
+    /// Progress as a fraction (0.0 to 1.0)
+    var progress: Double {
+        guard taskCount > 0 else { return 0 }
+        return Double(completedTaskCount) / Double(taskCount)
+    }
+}
+
+/// The complete search response from the API
+struct SearchResponse: Codable, Sendable {
+    let query: String
+    let results: [SearchResultItem]
+    let total: Int
+}
+
+// MARK: - Search Error
+
+enum SearchError: LocalizedError {
+    case notAuthenticated
+    case invalidResponse
+    case emptyQuery
+    case queryTooLong
+    case serverError(statusCode: Int, message: String?)
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "You must be signed in to search."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case .emptyQuery:
+            return "Search query cannot be empty."
+        case .queryTooLong:
+            return "Search query must be 200 characters or fewer."
+        case let .serverError(statusCode, message):
+            if let message {
+                return "Server error (\(statusCode)): \(message)"
+            }
+            return "Server error: \(statusCode)"
+        case let .networkError(error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Search Service
+
+/// Service for searching tasks and stacks via the Dequeue API
+/// Network-only service - does not use @MainActor
+final class SearchService: @unchecked Sendable {
+    private let authService: any AuthServiceProtocol
+    private let urlSession: URLSession
+
+    init(authService: any AuthServiceProtocol, urlSession: URLSession = .shared) {
+        self.authService = authService
+        self.urlSession = urlSession
+    }
+
+    /// Searches across tasks and stacks
+    /// - Parameters:
+    ///   - query: Search text (1-200 characters)
+    ///   - limit: Maximum results per type (1-100, default 20)
+    /// - Returns: Search response with results
+    func search(query: String, limit: Int = 20) async throws -> SearchResponse {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else {
+            throw SearchError.emptyQuery
+        }
+
+        guard trimmed.count <= 200 else {
+            throw SearchError.queryTooLong
+        }
+
+        let token = try await authService.getAuthToken()
+
+        var components = URLComponents(
+            url: Configuration.dequeueAPIBaseURL.appendingPathComponent("search"),
+            resolvingAgainstBaseURL: true
+        )
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: trimmed),
+            URLQueryItem(name: "limit", value: String(limit))
+        ]
+
+        guard let url = components?.url else {
+            throw SearchError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        logger.debug("Searching for: \(trimmed)")
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw SearchError.invalidResponse
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let errorMessage = (try? JSONDecoder().decode([String: String].self, from: data))?["error"]
+                throw SearchError.serverError(statusCode: httpResponse.statusCode, message: errorMessage)
+            }
+
+            let searchResponse = try JSONDecoder().decode(SearchResponse.self, from: data)
+            logger.info("Search returned \(searchResponse.total) results for '\(trimmed)'")
+            return searchResponse
+        } catch let error as SearchError {
+            throw error
+        } catch {
+            throw SearchError.networkError(error)
+        }
+    }
+}
+
+// MARK: - Environment Key
+
+private struct SearchServiceKey: EnvironmentKey {
+    static let defaultValue: SearchService? = nil
+}
+
+extension EnvironmentValues {
+    var searchService: SearchService? {
+        get { self[SearchServiceKey.self] }
+        set { self[SearchServiceKey.self] = newValue }
+    }
+}

--- a/Dequeue/Dequeue/Services/StatsService.swift
+++ b/Dequeue/Dequeue/Services/StatsService.swift
@@ -1,0 +1,150 @@
+//
+//  StatsService.swift
+//  Dequeue
+//
+//  Client for the task statistics endpoint (GET /v1/me/stats)
+//
+
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.dequeue", category: "StatsService")
+
+// MARK: - Stats Models
+
+/// Complete statistics response from the API
+struct StatsResponse: Codable, Sendable {
+    let tasks: TaskStats
+    let priority: PriorityBreakdown
+    let stacks: StackStats
+    let completionStreak: Int
+}
+
+/// Task count statistics
+struct TaskStats: Codable, Sendable {
+    let total: Int
+    let active: Int
+    let completed: Int
+    let overdue: Int
+    let completedToday: Int
+    let completedThisWeek: Int
+    let createdToday: Int
+    let createdThisWeek: Int
+
+    /// Completion rate as a fraction (0.0 to 1.0)
+    var completionRate: Double {
+        guard total > 0 else { return 0 }
+        return Double(completed) / Double(total)
+    }
+}
+
+/// Active tasks broken down by priority level
+struct PriorityBreakdown: Codable, Sendable {
+    let none: Int   // priority = 0
+    let low: Int    // priority = 1
+    let medium: Int // priority = 2
+    let high: Int   // priority = 3
+
+    /// Total active tasks across all priorities
+    var total: Int {
+        none + low + medium + high
+    }
+}
+
+/// Stack and arc count statistics
+struct StackStats: Codable, Sendable {
+    let total: Int
+    let active: Int
+    let totalArcs: Int
+}
+
+// MARK: - Stats Error
+
+enum StatsError: LocalizedError {
+    case notAuthenticated
+    case invalidResponse
+    case serverError(statusCode: Int, message: String?)
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "You must be signed in to view statistics."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case let .serverError(statusCode, message):
+            if let message {
+                return "Server error (\(statusCode)): \(message)"
+            }
+            return "Server error: \(statusCode)"
+        case let .networkError(error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Stats Service
+
+/// Service for fetching task statistics via the Dequeue API
+/// Network-only service - does not use @MainActor
+final class StatsService: @unchecked Sendable {
+    private let authService: any AuthServiceProtocol
+    private let urlSession: URLSession
+
+    init(authService: any AuthServiceProtocol, urlSession: URLSession = .shared) {
+        self.authService = authService
+        self.urlSession = urlSession
+    }
+
+    /// Fetches aggregate statistics for the current user
+    /// - Returns: Complete statistics response
+    func getStats() async throws -> StatsResponse {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("me")
+            .appendingPathComponent("stats")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        logger.debug("Fetching stats from: \(url.absoluteString)")
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw StatsError.invalidResponse
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let errorMessage = (try? JSONDecoder().decode([String: String].self, from: data))?["error"]
+                throw StatsError.serverError(statusCode: httpResponse.statusCode, message: errorMessage)
+            }
+
+            let stats = try JSONDecoder().decode(StatsResponse.self, from: data)
+            logger.info("Fetched stats: \(stats.tasks.total) tasks, \(stats.stacks.total) stacks")
+            return stats
+        } catch let error as StatsError {
+            throw error
+        } catch {
+            throw StatsError.networkError(error)
+        }
+    }
+}
+
+// MARK: - Environment Key
+
+private struct StatsServiceKey: EnvironmentKey {
+    static let defaultValue: StatsService? = nil
+}
+
+extension EnvironmentValues {
+    var statsService: StatsService? {
+        get { self[StatsServiceKey.self] }
+        set { self[StatsServiceKey.self] = newValue }
+    }
+}

--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -109,20 +109,20 @@ private struct ReminderProjection: @preconcurrency Decodable, Sendable {
 // MARK: - WebSocket Stream Messages (DEQ-243)
 
 /// Client request to start streaming events
-private struct SyncStreamRequest: Codable, Sendable {
+struct SyncStreamRequest: Codable, Sendable {
     let type: String // "sync.stream.request"
     let since: String? // RFC3339 timestamp, optional
 }
 
 /// Server response indicating stream start with total event count
-private struct SyncStreamStart: Codable, Sendable {
+struct SyncStreamStart: Codable, Sendable {
     let type: String // "sync.stream.start"
     let totalEvents: Int64
 }
 
 /// Server response containing a batch of events
 /// Note: events are parsed separately using JSONSerialization to match REST API handling
-private struct SyncStreamBatch: Codable, Sendable {
+struct SyncStreamBatch: Codable, Sendable {
     let type: String // "sync.stream.batch"
     // events field handled separately via JSONSerialization
     let batchIndex: Int
@@ -130,14 +130,14 @@ private struct SyncStreamBatch: Codable, Sendable {
 }
 
 /// Server response indicating stream completion
-private struct SyncStreamComplete: Codable, Sendable {
+struct SyncStreamComplete: Codable, Sendable {
     let type: String // "sync.stream.complete"
     let processedEvents: Int64
     let newCheckpoint: String
 }
 
 /// Server response indicating an error occurred during streaming
-private struct SyncStreamError: Codable, Sendable {
+struct SyncStreamError: Codable, Sendable {
     let type: String // "sync.stream.error"
     let error: String
     let code: String?

--- a/Dequeue/Dequeue/Views/App/MainTabView.swift
+++ b/Dequeue/Dequeue/Views/App/MainTabView.swift
@@ -80,7 +80,7 @@ struct MainTabView: View {
         content
             .focusedValue(\.openSettingsAction) {
                 // DEQ-50: Navigate to Settings tab with ⌘,
-                selectedTab = 3
+                selectedTab = 4
             }
         #else
         content
@@ -126,12 +126,15 @@ struct MainTabView: View {
                 StacksView()
                     .tabItem { Label("Stacks", systemImage: "square.stack.3d.up") }
                     .tag(1)
+                SearchView()
+                    .tabItem { Label("Search", systemImage: "magnifyingglass") }
+                    .tag(2)
                 ActivityFeedView()
                     .tabItem { Label("Activity", systemImage: "clock.arrow.circlepath") }
-                    .tag(2)
+                    .tag(3)
                 SettingsView()
                     .tabItem { Label("Settings", systemImage: "gear") }
-                    .tag(3)
+                    .tag(4)
             }
             floatingBanners
         }
@@ -152,9 +155,12 @@ struct MainTabView: View {
                     Label("Stacks", systemImage: "square.stack.3d.up")
                 }
                 NavigationLink(value: 2) {
-                    Label("Activity", systemImage: "clock.arrow.circlepath")
+                    Label("Search", systemImage: "magnifyingglass")
                 }
                 NavigationLink(value: 3) {
+                    Label("Activity", systemImage: "clock.arrow.circlepath")
+                }
+                NavigationLink(value: 4) {
                     Label("Settings", systemImage: "gear")
                 }
             }
@@ -186,8 +192,9 @@ struct MainTabView: View {
         switch selection {
         case 0: ArcsView()
         case 1: StacksView()
-        case 2: ActivityFeedView()
-        case 3: SettingsView()
+        case 2: SearchView()
+        case 3: ActivityFeedView()
+        case 4: SettingsView()
         default: ArcsView()
         }
         #else
@@ -245,8 +252,9 @@ struct MainTabView: View {
                 List(selection: $selectedTab) {
                     NavigationLink(value: 0) { Label("Arcs", systemImage: "rays") }
                     NavigationLink(value: 1) { Label("Stacks", systemImage: "square.stack.3d.up") }
-                    NavigationLink(value: 2) { Label("Activity", systemImage: "clock.arrow.circlepath") }
-                    NavigationLink(value: 3) { Label("Settings", systemImage: "gear") }
+                    NavigationLink(value: 2) { Label("Search", systemImage: "magnifyingglass") }
+                    NavigationLink(value: 3) { Label("Activity", systemImage: "clock.arrow.circlepath") }
+                    NavigationLink(value: 4) { Label("Settings", systemImage: "gear") }
                 }
                 .navigationSplitViewColumnWidth(min: 180, ideal: 200)
             } detail: {
@@ -288,8 +296,9 @@ struct MainTabView: View {
         switch selectedTab {
         case 0: ArcsView()
         case 1: StacksView()
-        case 2: ActivityFeedView()
-        case 3: SettingsView()
+        case 2: SearchView()
+        case 3: ActivityFeedView()
+        case 4: SettingsView()
         default: ArcsView()
         }
     }

--- a/Dequeue/Dequeue/Views/Search/SearchView.swift
+++ b/Dequeue/Dequeue/Views/Search/SearchView.swift
@@ -1,0 +1,280 @@
+//
+//  SearchView.swift
+//  Dequeue
+//
+//  Unified search across tasks and stacks
+//
+
+import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "com.dequeue", category: "SearchView")
+
+struct SearchView: View {
+    @Environment(\.searchService) private var searchService
+    @State private var searchText = ""
+    @State private var results: [SearchResultItem] = []
+    @State private var isSearching = false
+    @State private var errorMessage: String?
+    @State private var hasSearched = false
+    @State private var searchTask: Task<Void, Never>?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if !hasSearched {
+                    emptySearchPrompt
+                } else if isSearching {
+                    searchingIndicator
+                } else if results.isEmpty {
+                    noResultsView
+                } else {
+                    resultsList
+                }
+            }
+            .navigationTitle("Search")
+            .searchable(text: $searchText, prompt: "Search tasks and stacks...")
+            .onChange(of: searchText) { _, newValue in
+                performDebouncedSearch(query: newValue)
+            }
+            .onSubmit(of: .search) {
+                performImmediateSearch()
+            }
+        }
+    }
+
+    // MARK: - Content Views
+
+    private var emptySearchPrompt: some View {
+        ContentUnavailableView {
+            Label("Search Dequeue", systemImage: "magnifyingglass")
+        } description: {
+            Text("Find tasks and stacks by name, notes, or content.")
+        }
+    }
+
+    private var searchingIndicator: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Searching...")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var noResultsView: some View {
+        ContentUnavailableView.search(text: searchText)
+    }
+
+    private var resultsList: some View {
+        List {
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                }
+            }
+
+            let taskResults = results.filter { $0.type == "task" }
+            let stackResults = results.filter { $0.type == "stack" }
+
+            if !taskResults.isEmpty {
+                Section("Tasks (\(taskResults.count))") {
+                    ForEach(taskResults) { result in
+                        if let task = result.task {
+                            TaskSearchRow(task: task)
+                        }
+                    }
+                }
+            }
+
+            if !stackResults.isEmpty {
+                Section("Stacks (\(stackResults.count))") {
+                    ForEach(stackResults) { result in
+                        if let stack = result.stack {
+                            StackSearchRow(stack: stack)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Search Logic
+
+    private func performDebouncedSearch(query: String) {
+        searchTask?.cancel()
+
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            results = []
+            hasSearched = false
+            errorMessage = nil
+            return
+        }
+
+        // Debounce: wait 300ms after typing stops
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            await executeSearch(query: trimmed)
+        }
+    }
+
+    private func performImmediateSearch() {
+        searchTask?.cancel()
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        Task {
+            await executeSearch(query: trimmed)
+        }
+    }
+
+    @MainActor
+    private func executeSearch(query: String) async {
+        guard let searchService else {
+            errorMessage = "Search is not available."
+            return
+        }
+
+        isSearching = true
+        errorMessage = nil
+
+        do {
+            let response = try await searchService.search(query: query)
+            guard !Task.isCancelled else { return }
+            results = response.results
+            hasSearched = true
+        } catch is CancellationError {
+            // Ignore cancellation
+        } catch {
+            logger.error("Search failed: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+            hasSearched = true
+        }
+
+        isSearching = false
+    }
+}
+
+// MARK: - Task Search Row
+
+struct TaskSearchRow: View {
+    let task: SearchTask
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                priorityIndicator
+                Text(task.title)
+                    .font(.body)
+                    .strikethrough(task.status == "completed")
+                    .foregroundStyle(task.status == "completed" ? .secondary : .primary)
+                Spacer()
+                statusBadge
+            }
+
+            if let notes = task.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            HStack {
+                if let dueDate = task.dueAtDate {
+                    Label(dueDate.formatted(date: .abbreviated, time: .shortened), systemImage: "calendar")
+                        .font(.caption2)
+                        .foregroundStyle(dueDate < Date() ? .red : .secondary)
+                }
+
+                Spacer()
+
+                Text(task.updatedAtDate.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var priorityIndicator: some View {
+        switch task.priority {
+        case 3:
+            Image(systemName: "exclamationmark.3")
+                .foregroundStyle(.red)
+                .font(.caption)
+        case 2:
+            Image(systemName: "exclamationmark.2")
+                .foregroundStyle(.orange)
+                .font(.caption)
+        case 1:
+            Image(systemName: "exclamationmark")
+                .foregroundStyle(.blue)
+                .font(.caption)
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        switch task.status {
+        case "completed":
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case "blocked":
+            Image(systemName: "exclamationmark.octagon.fill")
+                .foregroundStyle(.red)
+        default:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Stack Search Row
+
+struct StackSearchRow: View {
+    let stack: SearchStack
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(stack.title)
+                    .font(.body)
+                Spacer()
+                if stack.isActive {
+                    Image(systemName: "bolt.fill")
+                        .foregroundStyle(.yellow)
+                        .font(.caption)
+                }
+            }
+
+            HStack {
+                Label(
+                    "\(stack.completedTaskCount)/\(stack.taskCount) tasks",
+                    systemImage: "checklist"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if stack.taskCount > 0 {
+                    ProgressView(value: stack.progress)
+                        .frame(maxWidth: 60)
+                }
+
+                Spacer()
+
+                Text(stack.updatedAtDate.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview {
+    SearchView()
+}

--- a/Dequeue/Dequeue/Views/Settings/ExportView.swift
+++ b/Dequeue/Dequeue/Views/Settings/ExportView.swift
@@ -1,0 +1,201 @@
+//
+//  ExportView.swift
+//  Dequeue
+//
+//  Data export and backup view
+//
+
+import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "com.dequeue", category: "ExportView")
+
+struct ExportView: View {
+    @Environment(\.exportService) private var exportService
+    @State private var isExporting = false
+    @State private var exportComplete = false
+    @State private var exportedFileURL: URL?
+    @State private var exportSummary: ExportSummary?
+    @State private var errorMessage: String?
+    @State private var showShareSheet = false
+
+    var body: some View {
+        List {
+            infoSection
+            exportSection
+            if let summary = exportSummary {
+                summarySection(summary)
+            }
+        }
+        .navigationTitle("Export Data")
+        .sheet(isPresented: $showShareSheet) {
+            if let url = exportedFileURL {
+                ShareSheet(items: [url])
+            }
+        }
+    }
+
+    // MARK: - Info Section
+
+    private var infoSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Data Export", systemImage: "square.and.arrow.up")
+                    .font(.headline)
+                Text("Export all your data as a JSON file. This includes arcs, stacks, tasks, tags, and reminders.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("Your data stays yours. Export anytime for backup or portability.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Export Section
+
+    private var exportSection: some View {
+        Section {
+            Button {
+                Task { await performExport() }
+            } label: {
+                HStack {
+                    Label("Export to JSON", systemImage: "doc.text")
+                    Spacer()
+                    if isExporting {
+                        ProgressView()
+                    } else if exportComplete {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
+            }
+            .disabled(isExporting)
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if exportComplete, exportedFileURL != nil {
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Label("Share Export File", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+    }
+
+    // MARK: - Summary Section
+
+    private func summarySection(_ summary: ExportSummary) -> some View {
+        Section("Export Summary") {
+            LabeledContent("Arcs", value: "\(summary.arcCount)")
+            LabeledContent("Stacks", value: "\(summary.stackCount)")
+            LabeledContent("Tasks", value: "\(summary.taskCount)")
+            LabeledContent("Tags", value: "\(summary.tagCount)")
+            LabeledContent("Reminders", value: "\(summary.reminderCount)")
+            LabeledContent("Total Items", value: "\(summary.totalItems)")
+            LabeledContent("Exported At", value: summary.exportedAt.formatted())
+        }
+    }
+
+    // MARK: - Export Logic
+
+    @MainActor
+    private func performExport() async {
+        guard let exportService else {
+            errorMessage = "Export is not available."
+            return
+        }
+
+        isExporting = true
+        errorMessage = nil
+        exportComplete = false
+        exportedFileURL = nil
+        exportSummary = nil
+
+        do {
+            let fileURL = try await exportService.exportToFile()
+            // Also get the response for summary
+            let export = try await exportService.exportData()
+
+            exportedFileURL = fileURL
+            exportSummary = ExportSummary(
+                arcCount: export.arcs.count,
+                stackCount: export.stacks.count,
+                taskCount: export.tasks.count,
+                tagCount: export.tags.count,
+                reminderCount: export.reminders.count,
+                totalItems: export.totalItems,
+                exportedAt: export.exportedAtDate
+            )
+            exportComplete = true
+            logger.info("Export completed: \(export.totalItems) items → \(fileURL.lastPathComponent)")
+        } catch {
+            logger.error("Export failed: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+        }
+
+        isExporting = false
+    }
+}
+
+// MARK: - Export Summary
+
+struct ExportSummary {
+    let arcCount: Int
+    let stackCount: Int
+    let taskCount: Int
+    let tagCount: Int
+    let reminderCount: Int
+    let totalItems: Int
+    let exportedAt: Date
+}
+
+// MARK: - Share Sheet
+
+#if os(iOS)
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+#elseif os(macOS)
+struct ShareSheet: View {
+    let items: [Any]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Export Complete")
+                .font(.headline)
+
+            if let url = items.first as? URL {
+                Text(url.lastPathComponent)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: "")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(minWidth: 300)
+    }
+}
+#endif
+
+#Preview {
+    NavigationStack {
+        ExportView()
+    }
+}

--- a/Dequeue/Dequeue/Views/Settings/SettingsView.swift
+++ b/Dequeue/Dequeue/Views/Settings/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
             List {
                 accountSection
                 preferencesSection
+                dataSection
                 aboutSection
                 advancedSection
                 if developerModeEnabled {
@@ -111,6 +112,21 @@ struct SettingsView: View {
                 AppearanceSettingsView()
             } label: {
                 Label("Appearance", systemImage: "paintbrush")
+            }
+        }
+    }
+
+    private var dataSection: some View {
+        Section("Data") {
+            NavigationLink {
+                StatsView()
+            } label: {
+                Label("Statistics", systemImage: "chart.bar")
+            }
+            NavigationLink {
+                ExportView()
+            } label: {
+                Label("Export Data", systemImage: "square.and.arrow.up")
             }
         }
     }

--- a/Dequeue/Dequeue/Views/Stats/StatsView.swift
+++ b/Dequeue/Dequeue/Views/Stats/StatsView.swift
@@ -1,0 +1,368 @@
+//
+//  StatsView.swift
+//  Dequeue
+//
+//  Task statistics dashboard
+//
+
+import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "com.dequeue", category: "StatsView")
+
+struct StatsView: View {
+    @Environment(\.statsService) private var statsService
+    @State private var stats: StatsResponse?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading && stats == nil {
+                    loadingView
+                } else if let stats {
+                    statsContent(stats)
+                } else if let errorMessage {
+                    errorView(errorMessage)
+                } else {
+                    loadingView
+                }
+            }
+            .navigationTitle("Statistics")
+            .refreshable {
+                await loadStats()
+            }
+            .task {
+                await loadStats()
+            }
+        }
+    }
+
+    // MARK: - Loading & Error
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Loading statistics...")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("Unable to Load", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Try Again") {
+                Task { await loadStats() }
+            }
+        }
+    }
+
+    // MARK: - Stats Content
+
+    private func statsContent(_ stats: StatsResponse) -> some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Overview cards
+                overviewSection(stats)
+
+                // Productivity section
+                productivitySection(stats)
+
+                // Priority breakdown
+                prioritySection(stats.priority)
+
+                // Stacks & Arcs section
+                stacksSection(stats.stacks)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Overview Section
+
+    private func overviewSection(_ stats: StatsResponse) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Overview")
+                .font(.headline)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                StatCard(
+                    title: "Total Tasks",
+                    value: "\(stats.tasks.total)",
+                    icon: "list.bullet",
+                    color: .blue
+                )
+                StatCard(
+                    title: "Active",
+                    value: "\(stats.tasks.active)",
+                    icon: "bolt.fill",
+                    color: .green
+                )
+                StatCard(
+                    title: "Completed",
+                    value: "\(stats.tasks.completed)",
+                    icon: "checkmark.circle.fill",
+                    color: .mint
+                )
+                StatCard(
+                    title: "Overdue",
+                    value: "\(stats.tasks.overdue)",
+                    icon: "exclamationmark.triangle.fill",
+                    color: stats.tasks.overdue > 0 ? .red : .gray
+                )
+            }
+        }
+    }
+
+    // MARK: - Productivity Section
+
+    private func productivitySection(_ stats: StatsResponse) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Productivity")
+                .font(.headline)
+
+            VStack(spacing: 8) {
+                // Completion rate
+                HStack {
+                    Text("Completion Rate")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(Int(stats.tasks.completionRate * 100))%")
+                        .font(.headline)
+                        .foregroundStyle(.mint)
+                }
+                ProgressView(value: stats.tasks.completionRate)
+                    .tint(.mint)
+            }
+            .padding()
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            // Streak
+            if stats.completionStreak > 0 {
+                HStack {
+                    Image(systemName: "flame.fill")
+                        .foregroundStyle(.orange)
+                    Text("\(stats.completionStreak)-day streak")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            // Today & This Week
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Today")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text("Created")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text("\(stats.tasks.createdToday)")
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text("Completed")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text("\(stats.tasks.completedToday)")
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("This Week")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text("Created")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text("\(stats.tasks.createdThisWeek)")
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text("Completed")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text("\(stats.tasks.completedThisWeek)")
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    // MARK: - Priority Section
+
+    private func prioritySection(_ priority: PriorityBreakdown) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Priority Breakdown")
+                .font(.headline)
+
+            VStack(spacing: 8) {
+                PriorityRow(label: "High", count: priority.high, total: priority.total, color: .red)
+                PriorityRow(label: "Medium", count: priority.medium, total: priority.total, color: .orange)
+                PriorityRow(label: "Low", count: priority.low, total: priority.total, color: .blue)
+                PriorityRow(label: "None", count: priority.none, total: priority.total, color: .gray)
+            }
+            .padding()
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Stacks Section
+
+    private func stacksSection(_ stacks: StackStats) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Stacks & Arcs")
+                .font(.headline)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                StatCard(
+                    title: "Stacks",
+                    value: "\(stacks.total)",
+                    icon: "square.stack.3d.up",
+                    color: .purple
+                )
+                StatCard(
+                    title: "Active",
+                    value: "\(stacks.active)",
+                    icon: "bolt.fill",
+                    color: .green
+                )
+                StatCard(
+                    title: "Arcs",
+                    value: "\(stacks.totalArcs)",
+                    icon: "rays",
+                    color: .indigo
+                )
+            }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    @MainActor
+    private func loadStats() async {
+        guard let statsService else {
+            errorMessage = "Statistics are not available."
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            stats = try await statsService.getStats()
+        } catch {
+            logger.error("Failed to load stats: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}
+
+// MARK: - Stat Card
+
+struct StatCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(color)
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Priority Row
+
+struct PriorityRow: View {
+    let label: String
+    let count: Int
+    let total: Int
+    let color: Color
+
+    private var fraction: Double {
+        guard total > 0 else { return 0 }
+        return Double(count) / Double(total)
+    }
+
+    var body: some View {
+        HStack {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.subheadline)
+            Spacer()
+            Text("\(count)")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            ProgressView(value: fraction)
+                .frame(maxWidth: 60)
+                .tint(color)
+        }
+    }
+}
+
+#Preview {
+    StatsView()
+}

--- a/Dequeue/DequeueTests/EnvironmentManagerTests.swift
+++ b/Dequeue/DequeueTests/EnvironmentManagerTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Dequeue
 
+@MainActor
 final class EnvironmentManagerTests: XCTestCase {
     var sut: EnvironmentManager!
 

--- a/Dequeue/DequeueTests/ExportServiceTests.swift
+++ b/Dequeue/DequeueTests/ExportServiceTests.swift
@@ -1,0 +1,295 @@
+//
+//  ExportServiceTests.swift
+//  DequeueTests
+//
+//  Tests for ExportService - data export endpoint client
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Mock URL Protocol for Export Tests
+
+private final class ExportMockURLProtocolStorage: @unchecked Sendable {
+    static let shared = ExportMockURLProtocolStorage()
+    private let lock = NSLock()
+    private var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { lock.lock(); defer { lock.unlock() }; return handler }
+        set { lock.lock(); defer { lock.unlock() }; handler = newValue }
+    }
+}
+
+private final class ExportMockURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = ExportMockURLProtocolStorage.shared.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "ExportMock", code: -1))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ExportMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+// MARK: - Export Service Tests
+
+@Suite("ExportService")
+@MainActor
+struct ExportServiceTests {
+    let mockAuth = MockAuthService()
+    let session: URLSession
+
+    init() {
+        mockAuth.mockSignIn()
+        session = makeMockSession()
+    }
+
+    private func makeService() -> ExportService {
+        ExportService(authService: mockAuth, urlSession: session)
+    }
+
+    private func makeResponse(statusCode: Int, json: String) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.dequeue.app/v1/export")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, json.data(using: .utf8)!)
+    }
+
+    // MARK: - Success Cases
+
+    @Test("ExportData returns complete export")
+    func exportDataReturnsAll() async throws {
+        let json = """
+        {
+            "exportedAt": 1708000000000,
+            "version": "1.0",
+            "arcs": [
+                {
+                    "id": "arc-1",
+                    "title": "My Arc",
+                    "status": "active",
+                    "sortOrder": 0,
+                    "stackCount": 3,
+                    "completedStackCount": 1,
+                    "createdAt": 1708000000000,
+                    "updatedAt": 1708000000000
+                }
+            ],
+            "stacks": [
+                {
+                    "id": "stack-1",
+                    "title": "My Stack",
+                    "status": "active",
+                    "sortOrder": 0,
+                    "taskCount": 5,
+                    "completedTaskCount": 2,
+                    "tags": ["tag-1"],
+                    "isActive": true,
+                    "createdAt": 1708000000000,
+                    "updatedAt": 1708000000000
+                }
+            ],
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "stackId": "stack-1",
+                    "title": "My Task",
+                    "status": "active",
+                    "priority": 2,
+                    "sortOrder": 0,
+                    "isActive": true,
+                    "createdAt": 1708000000000,
+                    "updatedAt": 1708000000000
+                }
+            ],
+            "tags": [
+                {
+                    "id": "tag-1",
+                    "name": "Important",
+                    "colorHex": "#FF0000",
+                    "createdAt": 1708000000000,
+                    "updatedAt": 1708000000000
+                }
+            ],
+            "reminders": [
+                {
+                    "id": "rem-1",
+                    "parentType": "stack",
+                    "parentId": "stack-1",
+                    "remindAt": 1709000000000,
+                    "createdAt": 1708000000000,
+                    "updatedAt": 1708000000000
+                }
+            ]
+        }
+        """
+
+        ExportMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.url?.absoluteString.contains("export") == true)
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Bearer ") == true)
+            return self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let export = try await service.exportData()
+
+        #expect(export.version == "1.0")
+        #expect(export.arcs.count == 1)
+        #expect(export.stacks.count == 1)
+        #expect(export.tasks.count == 1)
+        #expect(export.tags.count == 1)
+        #expect(export.reminders.count == 1)
+        #expect(export.totalItems == 5)
+
+        // Verify arc data
+        #expect(export.arcs[0].title == "My Arc")
+        #expect(export.arcs[0].stackCount == 3)
+
+        // Verify stack data
+        #expect(export.stacks[0].title == "My Stack")
+        #expect(export.stacks[0].tags == ["tag-1"])
+
+        // Verify task data
+        #expect(export.tasks[0].title == "My Task")
+        #expect(export.tasks[0].priority == 2)
+
+        // Verify tag data
+        #expect(export.tags[0].name == "Important")
+        #expect(export.tags[0].colorHex == "#FF0000")
+
+        // Verify reminder data
+        #expect(export.reminders[0].parentType == "stack")
+        #expect(export.reminders[0].parentId == "stack-1")
+    }
+
+    @Test("ExportData handles empty export")
+    func exportDataHandlesEmpty() async throws {
+        let json = """
+        {
+            "exportedAt": 1708000000000,
+            "version": "1.0",
+            "arcs": [],
+            "stacks": [],
+            "tasks": [],
+            "tags": [],
+            "reminders": []
+        }
+        """
+
+        ExportMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let export = try await service.exportData()
+
+        #expect(export.arcs.isEmpty)
+        #expect(export.stacks.isEmpty)
+        #expect(export.tasks.isEmpty)
+        #expect(export.tags.isEmpty)
+        #expect(export.reminders.isEmpty)
+        #expect(export.totalItems == 0)
+    }
+
+    @Test("ExportToFile creates JSON file")
+    func exportToFileCreatesFile() async throws {
+        let json = """
+        {
+            "exportedAt": 1708000000000,
+            "version": "1.0",
+            "arcs": [],
+            "stacks": [],
+            "tasks": [],
+            "tags": [],
+            "reminders": []
+        }
+        """
+
+        ExportMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let fileURL = try await service.exportToFile()
+
+        #expect(fileURL.pathExtension == "json")
+        #expect(fileURL.lastPathComponent.hasPrefix("dequeue-export-"))
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        // Verify file content is valid JSON
+        let data = try Data(contentsOf: fileURL)
+        let decoded = try JSONDecoder().decode(ExportResponse.self, from: data)
+        #expect(decoded.version == "1.0")
+
+        // Clean up
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    // MARK: - Error Handling
+
+    @Test("ExportData handles server error")
+    func exportDataHandlesServerError() async {
+        ExportMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 500, json: "{\"error\": \"Export failed\"}")
+        }
+
+        let service = makeService()
+        do {
+            _ = try await service.exportData()
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as ExportError {
+            if case let .serverError(statusCode, message) = error {
+                #expect(statusCode == 500)
+                #expect(message == "Export failed")
+            } else {
+                #expect(Bool(false), "Wrong ExportError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    // MARK: - Model Tests
+
+    @Test("ExportResponse date conversion")
+    func exportResponseDate() {
+        let timestamp: Int64 = 1708000000000
+        let export = ExportResponse(
+            exportedAt: timestamp, version: "1.0",
+            arcs: [], stacks: [], tasks: [], tags: [], reminders: []
+        )
+        #expect(export.exportedAtDate.timeIntervalSince1970 == 1_708_000_000)
+    }
+
+    @Test("ReminderExport date conversion")
+    func reminderExportDate() {
+        let reminder = ReminderExport(
+            id: "r1", parentType: "stack", parentId: "s1",
+            remindAt: 1709000000000, createdAt: 1708000000000, updatedAt: 1708000000000
+        )
+        #expect(reminder.remindAtDate.timeIntervalSince1970 == 1_709_000_000)
+    }
+}

--- a/Dequeue/DequeueTests/SearchServiceTests.swift
+++ b/Dequeue/DequeueTests/SearchServiceTests.swift
@@ -1,0 +1,286 @@
+//
+//  SearchServiceTests.swift
+//  DequeueTests
+//
+//  Tests for SearchService - unified search endpoint client
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Mock URL Protocol for Search Tests
+
+private final class SearchMockURLProtocolStorage: @unchecked Sendable {
+    static let shared = SearchMockURLProtocolStorage()
+    private let lock = NSLock()
+    private var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { lock.lock(); defer { lock.unlock() }; return handler }
+        set { lock.lock(); defer { lock.unlock() }; handler = newValue }
+    }
+}
+
+private final class SearchMockURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = SearchMockURLProtocolStorage.shared.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "SearchMock", code: -1))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SearchMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+// MARK: - Search Service Tests
+
+@Suite("SearchService")
+@MainActor
+struct SearchServiceTests {
+    let mockAuth = MockAuthService()
+    let session: URLSession
+
+    init() {
+        mockAuth.mockSignIn()
+        session = makeMockSession()
+    }
+
+    private func makeService() -> SearchService {
+        SearchService(authService: mockAuth, urlSession: session)
+    }
+
+    private func makeResponse(statusCode: Int, json: String) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.dequeue.app/v1/search")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, json.data(using: .utf8)!)
+    }
+
+    // MARK: - Success Cases
+
+    @Test("Search returns tasks and stacks")
+    func searchReturnsResults() async throws {
+        let json = """
+        {
+            "query": "test",
+            "results": [
+                {
+                    "type": "task",
+                    "task": {
+                        "id": "task-1",
+                        "stackId": "stack-1",
+                        "title": "Test task",
+                        "status": "active",
+                        "priority": 2,
+                        "sortOrder": 0,
+                        "isActive": true,
+                        "createdAt": 1708000000000,
+                        "updatedAt": 1708000000000
+                    }
+                },
+                {
+                    "type": "stack",
+                    "stack": {
+                        "id": "stack-1",
+                        "title": "Test stack",
+                        "status": "active",
+                        "sortOrder": 0,
+                        "taskCount": 3,
+                        "completedTaskCount": 1,
+                        "isActive": true,
+                        "createdAt": 1708000000000,
+                        "updatedAt": 1708000000000
+                    }
+                }
+            ],
+            "total": 2
+        }
+        """
+
+        SearchMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.url?.absoluteString.contains("search") == true)
+            #expect(request.url?.absoluteString.contains("q=test") == true)
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Bearer ") == true)
+            return self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let response = try await service.search(query: "test")
+
+        #expect(response.query == "test")
+        #expect(response.total == 2)
+        #expect(response.results.count == 2)
+        #expect(response.results[0].type == "task")
+        #expect(response.results[0].task?.title == "Test task")
+        #expect(response.results[0].task?.priority == 2)
+        #expect(response.results[1].type == "stack")
+        #expect(response.results[1].stack?.title == "Test stack")
+        #expect(response.results[1].stack?.taskCount == 3)
+        #expect(response.results[1].stack?.progress == 1.0 / 3.0)
+    }
+
+    @Test("Search with custom limit")
+    func searchWithLimit() async throws {
+        let json = """
+        {"query": "test", "results": [], "total": 0}
+        """
+
+        SearchMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.url?.absoluteString.contains("limit=5") == true)
+            return self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        _ = try await service.search(query: "test", limit: 5)
+    }
+
+    @Test("Search returns empty results")
+    func searchEmptyResults() async throws {
+        let json = """
+        {"query": "nonexistent", "results": [], "total": 0}
+        """
+
+        SearchMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let response = try await service.search(query: "nonexistent")
+
+        #expect(response.results.isEmpty)
+        #expect(response.total == 0)
+    }
+
+    // MARK: - Validation
+
+    @Test("Search rejects empty query")
+    func searchRejectsEmptyQuery() async {
+        let service = makeService()
+        do {
+            _ = try await service.search(query: "")
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as SearchError {
+            if case .emptyQuery = error {
+                // Expected
+            } else {
+                #expect(Bool(false), "Wrong SearchError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    @Test("Search rejects whitespace-only query")
+    func searchRejectsWhitespaceQuery() async {
+        let service = makeService()
+        do {
+            _ = try await service.search(query: "   ")
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as SearchError {
+            if case .emptyQuery = error {
+                // Expected
+            } else {
+                #expect(Bool(false), "Wrong SearchError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    @Test("Search rejects query over 200 characters")
+    func searchRejectsLongQuery() async {
+        let service = makeService()
+        let longQuery = String(repeating: "a", count: 201)
+        do {
+            _ = try await service.search(query: longQuery)
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as SearchError {
+            if case .queryTooLong = error {
+                // Expected
+            } else {
+                #expect(Bool(false), "Wrong SearchError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    // MARK: - Error Handling
+
+    @Test("Search handles server error")
+    func searchHandlesServerError() async {
+        SearchMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 500, json: "{\"error\": \"Internal error\"}")
+        }
+
+        let service = makeService()
+        do {
+            _ = try await service.search(query: "test")
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as SearchError {
+            if case let .serverError(statusCode, message) = error {
+                #expect(statusCode == 500)
+                #expect(message == "Internal error")
+            } else {
+                #expect(Bool(false), "Wrong SearchError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    // MARK: - Model Tests
+
+    @Test("SearchTask date conversion")
+    func searchTaskDates() {
+        let task = SearchTask(
+            id: "t1", stackId: "s1", title: "Test", notes: nil,
+            status: "active", priority: 0, sortOrder: 0, isActive: true,
+            dueAt: 1708000000000, blockedReason: nil, parentTaskId: nil,
+            createdAt: 1708000000000, updatedAt: 1708000000000, completedAt: nil
+        )
+        #expect(task.dueAtDate != nil)
+        #expect(task.createdAtDate.timeIntervalSince1970 == 1_708_000_000)
+    }
+
+    @Test("SearchStack progress calculation")
+    func searchStackProgress() {
+        let stack = SearchStack(
+            id: "s1", arcId: nil, title: "Test", status: "active",
+            sortOrder: 0, taskCount: 10, completedTaskCount: 7,
+            isActive: true, activeTaskId: nil,
+            createdAt: 1708000000000, updatedAt: 1708000000000
+        )
+        #expect(stack.progress == 0.7)
+
+        let emptyStack = SearchStack(
+            id: "s2", arcId: nil, title: "Empty", status: "active",
+            sortOrder: 0, taskCount: 0, completedTaskCount: 0,
+            isActive: false, activeTaskId: nil,
+            createdAt: 1708000000000, updatedAt: 1708000000000
+        )
+        #expect(emptyStack.progress == 0.0)
+    }
+}

--- a/Dequeue/DequeueTests/StatsServiceTests.swift
+++ b/Dequeue/DequeueTests/StatsServiceTests.swift
@@ -1,0 +1,239 @@
+//
+//  StatsServiceTests.swift
+//  DequeueTests
+//
+//  Tests for StatsService - task statistics endpoint client
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Mock URL Protocol for Stats Tests
+
+private final class StatsMockURLProtocolStorage: @unchecked Sendable {
+    static let shared = StatsMockURLProtocolStorage()
+    private let lock = NSLock()
+    private var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { lock.lock(); defer { lock.unlock() }; return handler }
+        set { lock.lock(); defer { lock.unlock() }; handler = newValue }
+    }
+}
+
+private final class StatsMockURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = StatsMockURLProtocolStorage.shared.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "StatsMock", code: -1))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StatsMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+// MARK: - Stats Service Tests
+
+@Suite("StatsService")
+@MainActor
+struct StatsServiceTests {
+    let mockAuth = MockAuthService()
+    let session: URLSession
+
+    init() {
+        mockAuth.mockSignIn()
+        session = makeMockSession()
+    }
+
+    private func makeService() -> StatsService {
+        StatsService(authService: mockAuth, urlSession: session)
+    }
+
+    private func makeResponse(statusCode: Int, json: String) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.dequeue.app/v1/me/stats")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, json.data(using: .utf8)!)
+    }
+
+    // MARK: - Success Cases
+
+    @Test("GetStats returns complete statistics")
+    func getStatsReturnsData() async throws {
+        let json = """
+        {
+            "tasks": {
+                "total": 50,
+                "active": 15,
+                "completed": 30,
+                "overdue": 5,
+                "completedToday": 3,
+                "completedThisWeek": 12,
+                "createdToday": 2,
+                "createdThisWeek": 8
+            },
+            "priority": {
+                "none": 5,
+                "low": 3,
+                "medium": 4,
+                "high": 3
+            },
+            "stacks": {
+                "total": 10,
+                "active": 6,
+                "totalArcs": 3
+            },
+            "completionStreak": 7
+        }
+        """
+
+        StatsMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.url?.absoluteString.contains("me/stats") == true)
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Bearer ") == true)
+            return self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let stats = try await service.getStats()
+
+        // Task stats
+        #expect(stats.tasks.total == 50)
+        #expect(stats.tasks.active == 15)
+        #expect(stats.tasks.completed == 30)
+        #expect(stats.tasks.overdue == 5)
+        #expect(stats.tasks.completedToday == 3)
+        #expect(stats.tasks.completedThisWeek == 12)
+        #expect(stats.tasks.createdToday == 2)
+        #expect(stats.tasks.createdThisWeek == 8)
+
+        // Completion rate
+        #expect(stats.tasks.completionRate == 0.6) // 30/50
+
+        // Priority breakdown
+        #expect(stats.priority.none == 5)
+        #expect(stats.priority.low == 3)
+        #expect(stats.priority.medium == 4)
+        #expect(stats.priority.high == 3)
+        #expect(stats.priority.total == 15)
+
+        // Stack stats
+        #expect(stats.stacks.total == 10)
+        #expect(stats.stacks.active == 6)
+        #expect(stats.stacks.totalArcs == 3)
+
+        // Streak
+        #expect(stats.completionStreak == 7)
+    }
+
+    @Test("GetStats handles zero tasks")
+    func getStatsHandlesZeroTasks() async throws {
+        let json = """
+        {
+            "tasks": {
+                "total": 0, "active": 0, "completed": 0, "overdue": 0,
+                "completedToday": 0, "completedThisWeek": 0,
+                "createdToday": 0, "createdThisWeek": 0
+            },
+            "priority": {"none": 0, "low": 0, "medium": 0, "high": 0},
+            "stacks": {"total": 0, "active": 0, "totalArcs": 0},
+            "completionStreak": 0
+        }
+        """
+
+        StatsMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let stats = try await service.getStats()
+
+        #expect(stats.tasks.total == 0)
+        #expect(stats.tasks.completionRate == 0.0)
+        #expect(stats.priority.total == 0)
+    }
+
+    // MARK: - Error Handling
+
+    @Test("GetStats handles server error")
+    func getStatsHandlesServerError() async {
+        StatsMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 500, json: "{\"error\": \"Database unavailable\"}")
+        }
+
+        let service = makeService()
+        do {
+            _ = try await service.getStats()
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as StatsError {
+            if case let .serverError(statusCode, message) = error {
+                #expect(statusCode == 500)
+                #expect(message == "Database unavailable")
+            } else {
+                #expect(Bool(false), "Wrong StatsError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    @Test("GetStats handles unauthorized")
+    func getStatsHandlesUnauthorized() async {
+        StatsMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 401, json: "{\"error\": \"Invalid token\"}")
+        }
+
+        let service = makeService()
+        do {
+            _ = try await service.getStats()
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as StatsError {
+            if case let .serverError(statusCode, _) = error {
+                #expect(statusCode == 401)
+            } else {
+                #expect(Bool(false), "Wrong StatsError case: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Wrong error type: \(error)")
+        }
+    }
+
+    // MARK: - Model Tests
+
+    @Test("TaskStats completionRate calculation")
+    func taskStatsCompletionRate() {
+        let stats = TaskStats(
+            total: 100, active: 20, completed: 80, overdue: 0,
+            completedToday: 5, completedThisWeek: 20,
+            createdToday: 2, createdThisWeek: 10
+        )
+        #expect(stats.completionRate == 0.8)
+    }
+
+    @Test("PriorityBreakdown total calculation")
+    func priorityBreakdownTotal() {
+        let priority = PriorityBreakdown(none: 10, low: 5, medium: 3, high: 2)
+        #expect(priority.total == 20)
+    }
+}

--- a/Dequeue/DequeueTests/SyncManagerWebSocketStreamTests.swift
+++ b/Dequeue/DequeueTests/SyncManagerWebSocketStreamTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("SyncManager WebSocket Stream Tests")
+@MainActor
 struct SyncManagerWebSocketStreamTests {
     
     // MARK: - Message Serialization Tests

--- a/Dequeue/DequeueTests/TagTests.swift
+++ b/Dequeue/DequeueTests/TagTests.swift
@@ -103,9 +103,9 @@ struct TagModelTests {
 
 // MARK: - Tag Service Tests
 
-@Suite("Tag Service Tests", .serialized)
+@Suite("Tag Service Integration Tests", .serialized)
 @MainActor
-struct TagServiceTests {
+struct TagServiceIntegrationTests {
     @Test("createTag creates tag with valid name")
     func createTagWithValidName() async throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)

--- a/Dequeue/DequeueTests/ThumbnailGeneratorTests.swift
+++ b/Dequeue/DequeueTests/ThumbnailGeneratorTests.swift
@@ -81,7 +81,7 @@ struct ThumbnailGeneratorTests {
         #elseif canImport(AppKit)
         let tiffData = testImage.tiffRepresentation!
         let bitmapRep = NSBitmapImageRep(data: tiffData)!
-        let imageData = bitmapRep.representation(using: .png)!
+        let imageData = bitmapRep.representation(using: .png, properties: [:])!
         #endif
 
         let thumbnailData = try await generator.generateThumbnail(

--- a/Dequeue/DequeueUITests/StackCreationUITests.swift
+++ b/Dequeue/DequeueUITests/StackCreationUITests.swift
@@ -87,9 +87,9 @@ final class StackCreationUITests: XCTestCase {
         // Enable "Set as Active Stack" toggle
         let activeToggle = app.switches["setAsActiveToggle"]
         XCTAssertTrue(activeToggle.exists)
-        XCTAssertFalse(activeToggle.isOn)
+        XCTAssertEqual(activeToggle.value as? String, "0")
         activeToggle.tap()
-        XCTAssertTrue(activeToggle.isOn)
+        XCTAssertEqual(activeToggle.value as? String, "1")
 
         app.buttons["createButton"].tap()
 


### PR DESCRIPTION
## Summary

iOS client-side implementation for the new API endpoints created in dequeue-api PRs #103, #104, and #105.

### New Features

**Services:**
- `SearchService` — Client for `GET /v1/search` (unified search across tasks and stacks)
- `StatsService` — Client for `GET /v1/me/stats` (aggregate task statistics)
- `ExportService` — Client for `GET /v1/export` (full data export to JSON file)

**Views:**
- **SearchView** — New Search tab with debounced typeahead, task/stack result cards with priority indicators, status badges, progress bars
- **StatsView** — Statistics dashboard showing overview cards, completion rate, streak, daily/weekly breakdowns, priority distribution, stack/arc counts
- **ExportView** — Data export in Settings with file generation, share sheet (iOS) / Finder reveal (macOS), export summary

**Navigation:**
- Added Search tab between Stacks and Activity (iPhone, iPad sidebar, macOS sidebar)
- Added Data section to Settings (Statistics + Export Data)
- Updated all navigation indexes for the new tab

### Tests (20 total)
- `SearchServiceTests` (8): Success, custom limit, empty results, query validation (empty/whitespace/long), server errors, model date/progress calculations
- `StatsServiceTests` (6): Full stats, zero data edge case, server/auth errors, completion rate & priority total calculations
- `ExportServiceTests` (6): Full export, empty export, file creation + content verification, server errors, model date conversion

### Xcode 26 Compatibility Fixes (pre-existing)
- Added `@MainActor` to `EnvironmentManagerTests` and `SyncManagerWebSocketStreamTests`
- Changed sync stream types from `private` to `internal` for test access
- Fixed duplicate `TagServiceTests` (renamed to `TagServiceIntegrationTests`)
- Fixed `NSBitmapImageRep.representation(using:)` API change
- Fixed `XCUIElement.isOn` removal

### Dependencies
Requires dequeue-api PRs to be merged for endpoints to be available:
- PR #103 (search endpoint)
- PR #104 (stats endpoint)  
- PR #105 (export endpoint)

### Build Status
✅ Production build passes (macOS)
✅ SwiftLint clean (0 issues)
⚠️ CI blocked on GitHub Actions billing