### PR TITLE
feat: webhook management client with delivery logs and test delivery

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -134,6 +134,7 @@ struct DequeueApp: App {
                 .environment(\.searchService, SearchService(authService: authService))
                 .environment(\.statsService, StatsService(authService: authService))
                 .environment(\.exportService, ExportService(authService: authService))
+                .environment(\.webhookService, WebhookService(authService: authService))
                 .applyAppTheme()
                 .task {
                     // Configure error reporting first (runs on background thread)

--- a/Dequeue/Dequeue/Services/WebhookService.swift
+++ b/Dequeue/Dequeue/Services/WebhookService.swift
@@ -1,0 +1,413 @@
+//
+//  WebhookService.swift
+//  Dequeue
+//
+//  Client for webhook management endpoints:
+//  - GET /v1/webhooks (list)
+//  - POST /v1/webhooks (create)
+//  - GET /v1/webhooks/{id} (get)
+//  - PATCH /v1/webhooks/{id} (update)
+//  - DELETE /v1/webhooks/{id} (delete)
+//  - POST /v1/webhooks/{id}/rotate-secret (rotate)
+//  - GET /v1/webhooks/{id}/deliveries (delivery logs)
+//  - POST /v1/webhooks/{id}/test (test delivery)
+//
+
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.dequeue", category: "WebhookService")
+
+// MARK: - Webhook Models
+
+/// A webhook configuration
+struct Webhook: Codable, Sendable, Identifiable {
+    let id: String
+    let url: String
+    let events: [String]
+    let secret: String?         // Only on create
+    let secretPrefix: String?   // On list/get
+    let status: String
+    let createdAt: Int64
+    let lastDeliveryAt: Int64?
+    let lastDeliveryStatus: String?
+
+    var createdAtDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1_000.0)
+    }
+
+    var lastDeliveryAtDate: Date? {
+        guard let lastDeliveryAt else { return nil }
+        return Date(timeIntervalSince1970: Double(lastDeliveryAt) / 1_000.0)
+    }
+
+    var isActive: Bool { status == "active" }
+}
+
+/// Paginated webhook list response
+struct WebhookListResponse: Codable, Sendable {
+    let data: [Webhook]
+    let pagination: PaginationInfo
+}
+
+/// A single webhook delivery log entry
+struct WebhookDelivery: Codable, Sendable, Identifiable {
+    let id: String
+    let webhookId: String
+    let eventType: String
+    let eventId: String
+    let status: String
+    let attempts: Int
+    let lastResponseStatus: Int?
+    let lastResponseBody: String?
+    let lastError: String?
+    let createdAt: Int64
+    let completedAt: Int64?
+    let nextRetryAt: Int64?
+    let lastAttemptAt: Int64?
+
+    var createdAtDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1_000.0)
+    }
+
+    var completedAtDate: Date? {
+        guard let completedAt else { return nil }
+        return Date(timeIntervalSince1970: Double(completedAt) / 1_000.0)
+    }
+
+    var nextRetryAtDate: Date? {
+        guard let nextRetryAt else { return nil }
+        return Date(timeIntervalSince1970: Double(nextRetryAt) / 1_000.0)
+    }
+
+    var lastAttemptAtDate: Date? {
+        guard let lastAttemptAt else { return nil }
+        return Date(timeIntervalSince1970: Double(lastAttemptAt) / 1_000.0)
+    }
+
+    /// Whether the delivery succeeded
+    var isSuccess: Bool { status == "delivered" }
+
+    /// Whether the delivery is still pending/retrying
+    var isPending: Bool { status == "pending" || status == "retrying" }
+
+    /// Whether the delivery failed permanently
+    var isFailed: Bool { status == "failed" }
+}
+
+/// Paginated delivery list response
+struct WebhookDeliveryListResponse: Codable, Sendable {
+    let data: [WebhookDelivery]
+    let pagination: PaginationInfo
+}
+
+/// Result of a test webhook delivery
+struct WebhookTestResult: Codable, Sendable {
+    let success: Bool
+    let responseStatus: Int?
+    let responseBody: String?
+    let error: String?
+    let durationMs: Int64
+    let deliveredAt: Int64
+
+    var deliveredAtDate: Date {
+        Date(timeIntervalSince1970: Double(deliveredAt) / 1_000.0)
+    }
+}
+
+/// Result of rotating a webhook secret
+struct WebhookRotateSecretResult: Codable, Sendable {
+    let id: String
+    let secret: String
+    let rotatedAt: Int64
+
+    var rotatedAtDate: Date {
+        Date(timeIntervalSince1970: Double(rotatedAt) / 1_000.0)
+    }
+}
+
+/// Shared pagination info (used across multiple endpoints)
+struct PaginationInfo: Codable, Sendable {
+    let nextCursor: String?
+    let hasMore: Bool
+    let limit: Int
+}
+
+/// Create webhook request body
+struct CreateWebhookRequest: Codable, Sendable {
+    let url: String
+    let events: [String]
+    let secret: String?
+}
+
+/// Update webhook request body
+struct UpdateWebhookRequest: Codable, Sendable {
+    let url: String?
+    let events: [String]?
+    let status: String?
+}
+
+// MARK: - Webhook Error
+
+enum WebhookError: LocalizedError {
+    case notAuthenticated
+    case invalidResponse
+    case webhookNotFound
+    case invalidURL
+    case serverError(statusCode: Int, message: String?)
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "You must be signed in to manage webhooks."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case .webhookNotFound:
+            return "Webhook not found."
+        case .invalidURL:
+            return "Invalid webhook URL."
+        case let .serverError(statusCode, message):
+            if let message {
+                return "Server error (\(statusCode)): \(message)"
+            }
+            return "Server error: \(statusCode)"
+        case let .networkError(error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Webhook Service
+
+/// Service for managing webhooks and viewing delivery logs via the Dequeue API
+final class WebhookService: @unchecked Sendable {
+    private let authService: any AuthServiceProtocol
+    private let urlSession: URLSession
+
+    init(authService: any AuthServiceProtocol, urlSession: URLSession = .shared) {
+        self.authService = authService
+        self.urlSession = urlSession
+    }
+
+    // MARK: - Webhook CRUD
+
+    /// Lists all webhooks for the authenticated user
+    /// - Parameters:
+    ///   - limit: Maximum results (1-100, default 50)
+    ///   - cursor: Pagination cursor for next page
+    /// - Returns: Paginated webhook list
+    func listWebhooks(limit: Int = 50, cursor: String? = nil) async throws -> WebhookListResponse {
+        let token = try await authService.getAuthToken()
+
+        var components = URLComponents(
+            url: Configuration.dequeueAPIBaseURL.appendingPathComponent("webhooks"),
+            resolvingAgainstBaseURL: true
+        )
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor {
+            queryItems.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components?.queryItems = queryItems
+
+        guard let url = components?.url else {
+            throw WebhookError.invalidResponse
+        }
+
+        let data = try await performGET(url: url, token: token)
+        return try JSONDecoder().decode(WebhookListResponse.self, from: data)
+    }
+
+    /// Creates a new webhook
+    /// - Parameter request: Webhook creation parameters
+    /// - Returns: The created webhook (includes the secret, shown only once)
+    func createWebhook(_ request: CreateWebhookRequest) async throws -> Webhook {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL.appendingPathComponent("webhooks")
+        let body = try JSONEncoder().encode(request)
+        let data = try await performRequest(url: url, method: "POST", token: token, body: body)
+        return try JSONDecoder().decode(Webhook.self, from: data)
+    }
+
+    /// Gets a specific webhook by ID
+    /// - Parameter id: Webhook ID
+    /// - Returns: The webhook details
+    func getWebhook(id: String) async throws -> Webhook {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("webhooks")
+            .appendingPathComponent(id)
+
+        let data = try await performGET(url: url, token: token)
+        return try JSONDecoder().decode(Webhook.self, from: data)
+    }
+
+    /// Updates a webhook
+    /// - Parameters:
+    ///   - id: Webhook ID
+    ///   - request: Fields to update
+    /// - Returns: The updated webhook
+    func updateWebhook(id: String, _ request: UpdateWebhookRequest) async throws -> Webhook {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("webhooks")
+            .appendingPathComponent(id)
+
+        let body = try JSONEncoder().encode(request)
+        let data = try await performRequest(url: url, method: "PATCH", token: token, body: body)
+        return try JSONDecoder().decode(Webhook.self, from: data)
+    }
+
+    /// Deletes a webhook
+    /// - Parameter id: Webhook ID
+    func deleteWebhook(id: String) async throws {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("webhooks")
+            .appendingPathComponent(id)
+
+        _ = try await performRequest(url: url, method: "DELETE", token: token)
+    }
+
+    /// Rotates the signing secret for a webhook
+    /// - Parameter id: Webhook ID
+    /// - Returns: The new secret (shown only once)
+    func rotateSecret(id: String) async throws -> WebhookRotateSecretResult {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("webhooks")
+            .appendingPathComponent(id)
+            .appendingPathComponent("rotate-secret")
+
+        let data = try await performRequest(url: url, method: "POST", token: token)
+        return try JSONDecoder().decode(WebhookRotateSecretResult.self, from: data)
+    }
+
+    // MARK: - Delivery Logs
+
+    /// Lists delivery logs for a specific webhook
+    /// - Parameters:
+    ///   - webhookId: The webhook ID
+    ///   - limit: Maximum results (1-100, default 50)
+    ///   - cursor: Pagination cursor for next page
+    /// - Returns: Paginated delivery list
+    func listDeliveries(
+        webhookId: String, limit: Int = 50, cursor: String? = nil
+    ) async throws -> WebhookDeliveryListResponse {
+        let token = try await authService.getAuthToken()
+
+        var components = URLComponents(
+            url: Configuration.dequeueAPIBaseURL
+                .appendingPathComponent("webhooks")
+                .appendingPathComponent(webhookId)
+                .appendingPathComponent("deliveries"),
+            resolvingAgainstBaseURL: true
+        )
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor {
+            queryItems.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components?.queryItems = queryItems
+
+        guard let url = components?.url else {
+            throw WebhookError.invalidResponse
+        }
+
+        let data = try await performGET(url: url, token: token)
+        return try JSONDecoder().decode(WebhookDeliveryListResponse.self, from: data)
+    }
+
+    // MARK: - Test Delivery
+
+    /// Sends a test event to the webhook and returns the result
+    /// - Parameter webhookId: The webhook ID to test
+    /// - Returns: Test delivery result with response details
+    func testDelivery(webhookId: String) async throws -> WebhookTestResult {
+        let token = try await authService.getAuthToken()
+
+        let url = Configuration.dequeueAPIBaseURL
+            .appendingPathComponent("webhooks")
+            .appendingPathComponent(webhookId)
+            .appendingPathComponent("test")
+
+        let data = try await performRequest(url: url, method: "POST", token: token)
+        return try JSONDecoder().decode(WebhookTestResult.self, from: data)
+    }
+
+    // MARK: - Private Helpers
+
+    private func performGET(url: URL, token: String) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        return try await executeRequest(request)
+    }
+
+    private func performRequest(url: URL, method: String, token: String, body: Data? = nil) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+
+        return try await executeRequest(request)
+    }
+
+    private func executeRequest(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw WebhookError.invalidResponse
+            }
+
+            // 204 No Content (e.g., successful delete)
+            if httpResponse.statusCode == 204 {
+                return Data()
+            }
+
+            if httpResponse.statusCode == 401 {
+                throw WebhookError.notAuthenticated
+            }
+
+            if httpResponse.statusCode == 404 {
+                throw WebhookError.webhookNotFound
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let errorMessage = (try? JSONDecoder().decode([String: String].self, from: data))?["error"]
+                throw WebhookError.serverError(statusCode: httpResponse.statusCode, message: errorMessage)
+            }
+
+            return data
+        } catch let error as WebhookError {
+            throw error
+        } catch {
+            throw WebhookError.networkError(error)
+        }
+    }
+}
+
+// MARK: - Environment Key
+
+private struct WebhookServiceKey: EnvironmentKey {
+    static let defaultValue: WebhookService? = nil
+}
+
+extension EnvironmentValues {
+    var webhookService: WebhookService? {
+        get { self[WebhookServiceKey.self] }
+        set { self[WebhookServiceKey.self] = newValue }
+    }
+}

--- a/Dequeue/Dequeue/Views/Settings/SettingsView.swift
+++ b/Dequeue/Dequeue/Views/Settings/SettingsView.swift
@@ -29,6 +29,7 @@ struct SettingsView: View {
                 accountSection
                 preferencesSection
                 dataSection
+                integrationsSection
                 aboutSection
                 advancedSection
                 if developerModeEnabled {
@@ -127,6 +128,16 @@ struct SettingsView: View {
                 ExportView()
             } label: {
                 Label("Export Data", systemImage: "square.and.arrow.up")
+            }
+        }
+    }
+
+    private var integrationsSection: some View {
+        Section("Integrations") {
+            NavigationLink {
+                WebhooksView()
+            } label: {
+                Label("Webhooks", systemImage: "antenna.radiowaves.left.and.right")
             }
         }
     }

--- a/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
+++ b/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
@@ -1,0 +1,681 @@
+//
+//  WebhooksView.swift
+//  Dequeue
+//
+//  Webhook management UI in Settings: list, create, delete, test, and view delivery logs.
+//
+
+import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "com.dequeue", category: "WebhooksView")
+
+// MARK: - Webhooks List View
+
+struct WebhooksView: View {
+    @Environment(\.webhookService) private var webhookService
+
+    @State private var webhooks: [Webhook] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var showCreateSheet = false
+    @State private var testingWebhookId: String?
+    @State private var testResult: WebhookTestResult?
+    @State private var showTestResult = false
+
+    var body: some View {
+        List {
+            if isLoading && webhooks.isEmpty {
+                ProgressView("Loading webhooks...")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            } else if webhooks.isEmpty {
+                ContentUnavailableView {
+                    Label("No Webhooks", systemImage: "antenna.radiowaves.left.and.right")
+                } description: {
+                    Text("Webhooks let you receive real-time notifications when tasks or stacks change.")
+                } actions: {
+                    Button("Create Webhook") {
+                        showCreateSheet = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                ForEach(webhooks) { webhook in
+                    NavigationLink {
+                        WebhookDetailView(webhook: webhook, onDelete: {
+                            webhooks.removeAll { $0.id == webhook.id }
+                        })
+                    } label: {
+                        WebhookRow(webhook: webhook)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Webhooks")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .refreshable {
+            await loadWebhooks()
+        }
+        .task {
+            await loadWebhooks()
+        }
+        .sheet(isPresented: $showCreateSheet) {
+            CreateWebhookView { newWebhook in
+                webhooks.insert(newWebhook, at: 0)
+            }
+        }
+        .alert("Error", isPresented: .init(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func loadWebhooks() async {
+        guard let webhookService else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let response = try await webhookService.listWebhooks()
+            webhooks = response.data
+        } catch {
+            logger.error("Failed to load webhooks: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Webhook Row
+
+struct WebhookRow: View {
+    let webhook: Webhook
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(webhook.url)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+
+                Spacer()
+
+                statusBadge
+            }
+
+            HStack(spacing: 8) {
+                Label("\(webhook.events.count) event\(webhook.events.count == 1 ? "" : "s")",
+                      systemImage: "bell")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let lastDelivery = webhook.lastDeliveryAtDate {
+                    Text("Last delivery \(lastDelivery, style: .relative) ago")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        Text(webhook.status.capitalized)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(webhook.isActive ? Color.green.opacity(0.15) : Color.secondary.opacity(0.15))
+            )
+            .foregroundStyle(webhook.isActive ? .green : .secondary)
+    }
+}
+
+// MARK: - Webhook Detail View
+
+struct WebhookDetailView: View {
+    @Environment(\.webhookService) private var webhookService
+    @Environment(\.dismiss) private var dismiss
+
+    let webhook: Webhook
+    let onDelete: () -> Void
+
+    @State private var deliveries: [WebhookDelivery] = []
+    @State private var isLoadingDeliveries = false
+    @State private var isTesting = false
+    @State private var isDeleting = false
+    @State private var testResult: WebhookTestResult?
+    @State private var showTestResult = false
+    @State private var showDeleteConfirmation = false
+    @State private var errorMessage: String?
+    @State private var nextCursor: String?
+    @State private var hasMore = false
+
+    var body: some View {
+        List {
+            // Webhook Info Section
+            Section("Configuration") {
+                LabeledContent("URL", value: webhook.url)
+                LabeledContent("Status", value: webhook.status.capitalized)
+                LabeledContent("Events") {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        ForEach(webhook.events, id: \.self) { event in
+                            Text(event)
+                                .font(.caption)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.accentColor.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
+                if let prefix = webhook.secretPrefix {
+                    LabeledContent("Secret", value: "\(prefix)...")
+                }
+                LabeledContent("Created", value: webhook.createdAtDate.formatted(.dateTime.month().day().year()))
+            }
+
+            // Actions Section
+            Section("Actions") {
+                Button {
+                    Task { await sendTest() }
+                } label: {
+                    HStack {
+                        Label("Send Test Event", systemImage: "paperplane")
+                        Spacer()
+                        if isTesting {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isTesting)
+
+                Button(role: .destructive) {
+                    showDeleteConfirmation = true
+                } label: {
+                    HStack {
+                        Label("Delete Webhook", systemImage: "trash")
+                        Spacer()
+                        if isDeleting {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isDeleting)
+            }
+
+            // Delivery Logs Section
+            Section("Recent Deliveries") {
+                if isLoadingDeliveries && deliveries.isEmpty {
+                    ProgressView("Loading deliveries...")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                } else if deliveries.isEmpty {
+                    Text("No deliveries yet")
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                } else {
+                    ForEach(deliveries) { delivery in
+                        NavigationLink {
+                            DeliveryDetailView(delivery: delivery)
+                        } label: {
+                            DeliveryRow(delivery: delivery)
+                        }
+                    }
+
+                    if hasMore {
+                        Button("Load More") {
+                            Task { await loadMoreDeliveries() }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Webhook")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task {
+            await loadDeliveries()
+        }
+        .alert("Test Result", isPresented: $showTestResult) {
+            Button("OK") { testResult = nil }
+        } message: {
+            if let result = testResult {
+                if result.success {
+                    Text("✅ Success! Response: \(result.responseStatus ?? 0) in \(result.durationMs)ms")
+                } else if let error = result.error {
+                    Text("❌ Failed: \(error)")
+                } else {
+                    Text("❌ Failed with status \(result.responseStatus ?? 0)")
+                }
+            }
+        }
+        .confirmationDialog("Delete Webhook?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                Task { await deleteWebhook() }
+            }
+        } message: {
+            Text("This will permanently delete this webhook and stop all future deliveries.")
+        }
+        .alert("Error", isPresented: .init(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func loadDeliveries() async {
+        guard let webhookService else { return }
+        isLoadingDeliveries = true
+        defer { isLoadingDeliveries = false }
+
+        do {
+            let response = try await webhookService.listDeliveries(webhookId: webhook.id, limit: 20)
+            deliveries = response.data
+            nextCursor = response.pagination.nextCursor
+            hasMore = response.pagination.hasMore
+        } catch {
+            logger.error("Failed to load deliveries: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadMoreDeliveries() async {
+        guard let webhookService, let cursor = nextCursor else { return }
+
+        do {
+            let response = try await webhookService.listDeliveries(webhookId: webhook.id, limit: 20, cursor: cursor)
+            deliveries.append(contentsOf: response.data)
+            nextCursor = response.pagination.nextCursor
+            hasMore = response.pagination.hasMore
+        } catch {
+            logger.error("Failed to load more deliveries: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func sendTest() async {
+        guard let webhookService else { return }
+        isTesting = true
+        defer { isTesting = false }
+
+        do {
+            testResult = try await webhookService.testDelivery(webhookId: webhook.id)
+            showTestResult = true
+            // Reload deliveries to show the test delivery
+            await loadDeliveries()
+        } catch {
+            logger.error("Test delivery failed: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func deleteWebhook() async {
+        guard let webhookService else { return }
+        isDeleting = true
+        defer { isDeleting = false }
+
+        do {
+            try await webhookService.deleteWebhook(id: webhook.id)
+            onDelete()
+            dismiss()
+        } catch {
+            logger.error("Failed to delete webhook: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Delivery Row
+
+struct DeliveryRow: View {
+    let delivery: WebhookDelivery
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                statusIcon
+                Text(delivery.eventType)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Text(delivery.createdAtDate, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                if let status = delivery.lastResponseStatus {
+                    Text("HTTP \(status)")
+                        .font(.caption)
+                        .foregroundStyle(statusColor)
+                }
+
+                if delivery.attempts > 1 {
+                    Text("\(delivery.attempts) attempts")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if delivery.isPending {
+                    Text("Pending")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        Group {
+            if delivery.isSuccess {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if delivery.isPending {
+                Image(systemName: "clock.fill")
+                    .foregroundStyle(.orange)
+            } else {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+        .font(.subheadline)
+    }
+
+    private var statusColor: Color {
+        if delivery.isSuccess { return .green }
+        if delivery.isPending { return .orange }
+        return .red
+    }
+}
+
+// MARK: - Delivery Detail View
+
+struct DeliveryDetailView: View {
+    let delivery: WebhookDelivery
+
+    var body: some View {
+        List {
+            Section("Overview") {
+                LabeledContent("Event", value: delivery.eventType)
+                LabeledContent("Status", value: delivery.status.capitalized)
+                LabeledContent("Attempts", value: "\(delivery.attempts)")
+                LabeledContent("Created", value: delivery.createdAtDate.formatted(.dateTime))
+                if let completed = delivery.completedAtDate {
+                    LabeledContent("Completed", value: completed.formatted(.dateTime))
+                }
+                if let nextRetry = delivery.nextRetryAtDate {
+                    LabeledContent("Next Retry", value: nextRetry.formatted(.dateTime))
+                }
+                if let lastAttempt = delivery.lastAttemptAtDate {
+                    LabeledContent("Last Attempt", value: lastAttempt.formatted(.dateTime))
+                }
+            }
+
+            if let status = delivery.lastResponseStatus {
+                Section("Response") {
+                    LabeledContent("HTTP Status", value: "\(status)")
+
+                    if let body = delivery.lastResponseBody, !body.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Response Body")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(body)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+            }
+
+            if let error = delivery.lastError {
+                Section("Error") {
+                    Text(error)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
+            }
+
+            Section("IDs") {
+                LabeledContent("Delivery ID") {
+                    Text(delivery.id)
+                        .font(.system(.caption2, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+                LabeledContent("Event ID") {
+                    Text(delivery.eventId)
+                        .font(.system(.caption2, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+                LabeledContent("Webhook ID") {
+                    Text(delivery.webhookId)
+                        .font(.system(.caption2, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .navigationTitle("Delivery")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}
+
+// MARK: - Create Webhook View
+
+struct CreateWebhookView: View {
+    @Environment(\.webhookService) private var webhookService
+    @Environment(\.dismiss) private var dismiss
+
+    let onCreate: (Webhook) -> Void
+
+    @State private var url = ""
+    @State private var selectedEvents: Set<String> = []
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+    @State private var createdSecret: String?
+    @State private var showSecret = false
+
+    private let availableEvents = [
+        "task.created",
+        "task.updated",
+        "task.completed",
+        "task.deleted",
+        "stack.created",
+        "stack.updated",
+        "stack.deleted"
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                endpointSection
+                eventsSection
+                secretSection
+            }
+            .navigationTitle("New Webhook")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    confirmButton
+                }
+            }
+            .alert("Error", isPresented: .init(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private var endpointSection: some View {
+        Section("Endpoint") {
+            TextField("https://example.com/webhook", text: $url)
+                .textContentType(.URL)
+                #if os(iOS)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                #endif
+                .autocorrectionDisabled()
+        }
+    }
+
+    private var eventsSection: some View {
+        Section("Events") {
+            ForEach(Array(availableEvents), id: \.self) { (event: String) in
+                eventRow(event)
+            }
+            toggleAllButton
+        }
+    }
+
+    private func eventRow(_ event: String) -> some View {
+        Button {
+            if selectedEvents.contains(event) {
+                selectedEvents.remove(event)
+            } else {
+                selectedEvents.insert(event)
+            }
+        } label: {
+            HStack {
+                Text(event)
+                    .foregroundStyle(.primary)
+                Spacer()
+                if selectedEvents.contains(event) {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+        }
+    }
+
+    private var toggleAllButton: some View {
+        Button(selectedEvents.count == availableEvents.count ? "Deselect All" : "Select All") {
+            if selectedEvents.count == availableEvents.count {
+                selectedEvents.removeAll()
+            } else {
+                selectedEvents = Set(availableEvents)
+            }
+        }
+        .font(.caption)
+    }
+
+    @ViewBuilder
+    private var secretSection: some View {
+        if let secret = createdSecret {
+            Section("Signing Secret") {
+                secretContent(secret)
+            }
+        }
+    }
+
+    private func secretContent(_ secret: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Save this secret now — it won't be shown again.")
+                .font(.caption)
+                .foregroundStyle(.orange)
+
+            HStack {
+                Group {
+                    if showSecret {
+                        Text(secret)
+                    } else {
+                        Text(String(repeating: "•", count: 32))
+                    }
+                }
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+
+                Spacer()
+
+                Button {
+                    showSecret.toggle()
+                } label: {
+                    Image(systemName: showSecret ? "eye.slash" : "eye")
+                }
+            }
+
+            Button {
+                copyToClipboard(secret)
+            } label: {
+                Label("Copy to Clipboard", systemImage: "doc.on.doc")
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func copyToClipboard(_ text: String) {
+        #if os(iOS)
+        UIPasteboard.general.string = text
+        #elseif os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
+    }
+
+    @ViewBuilder
+    private var confirmButton: some View {
+        if createdSecret != nil {
+            Button("Done") { dismiss() }
+        } else {
+            Button("Create") {
+                Task { await createWebhook() }
+            }
+            .disabled(url.isEmpty || selectedEvents.isEmpty || isCreating)
+        }
+    }
+
+    private func createWebhook() async {
+        guard let webhookService else { return }
+        isCreating = true
+        defer { isCreating = false }
+
+        do {
+            let request = CreateWebhookRequest(
+                url: url.trimmingCharacters(in: .whitespacesAndNewlines),
+                events: Array(selectedEvents).sorted(),
+                secret: nil
+            )
+            let webhook = try await webhookService.createWebhook(request)
+            createdSecret = webhook.secret
+            onCreate(webhook)
+        } catch {
+            logger.error("Failed to create webhook: \(error)")
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Dequeue/DequeueTests/WebhookServiceTests.swift
+++ b/Dequeue/DequeueTests/WebhookServiceTests.swift
@@ -1,0 +1,530 @@
+//
+//  WebhookServiceTests.swift
+//  DequeueTests
+//
+//  Tests for WebhookService - webhook management and delivery log client
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Mock URL Protocol for Webhook Tests
+
+private final class WebhookMockURLProtocolStorage: @unchecked Sendable {
+    static let shared = WebhookMockURLProtocolStorage()
+    private let lock = NSLock()
+    private var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { lock.lock(); defer { lock.unlock() }; return handler }
+        set { lock.lock(); defer { lock.unlock() }; handler = newValue }
+    }
+}
+
+private final class WebhookMockURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = WebhookMockURLProtocolStorage.shared.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "WebhookMock", code: -1))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [WebhookMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+// MARK: - Webhook Service Tests
+
+@Suite("WebhookService")
+@MainActor
+struct WebhookServiceTests {
+    let mockAuth = MockAuthService()
+    let session: URLSession
+    let service: WebhookService
+
+    init() {
+        mockAuth.mockSignIn()
+        session = makeMockSession()
+        service = WebhookService(authService: mockAuth, urlSession: session)
+    }
+
+    // MARK: - List Webhooks
+
+    @Test("List webhooks returns parsed response")
+    func listWebhooksSuccess() async throws {
+        let json = """
+        {
+            "data": [
+                {
+                    "id": "wh_abc123",
+                    "url": "https://example.com/webhook",
+                    "events": ["task.created", "task.updated"],
+                    "secretPrefix": "whsec_abc",
+                    "status": "active",
+                    "createdAt": 1708300000000,
+                    "lastDeliveryAt": 1708310000000,
+                    "lastDeliveryStatus": "delivered"
+                }
+            ],
+            "pagination": {
+                "nextCursor": null,
+                "hasMore": false,
+                "limit": 50
+            }
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "GET")
+            #expect(request.url?.path.contains("webhooks") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.listWebhooks()
+        #expect(result.data.count == 1)
+        #expect(result.data[0].id == "wh_abc123")
+        #expect(result.data[0].url == "https://example.com/webhook")
+        #expect(result.data[0].events.count == 2)
+        #expect(result.data[0].isActive == true)
+        #expect(result.data[0].secretPrefix == "whsec_abc")
+        #expect(result.pagination.hasMore == false)
+    }
+
+    @Test("List webhooks with empty result")
+    func listWebhooksEmpty() async throws {
+        let json = """
+        {
+            "data": [],
+            "pagination": {"nextCursor": null, "hasMore": false, "limit": 50}
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.listWebhooks()
+        #expect(result.data.isEmpty)
+    }
+
+    @Test("List webhooks passes pagination cursor")
+    func listWebhooksWithCursor() async throws {
+        let json = """
+        {
+            "data": [],
+            "pagination": {"nextCursor": null, "hasMore": false, "limit": 20}
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.url?.query?.contains("cursor=abc123") == true)
+            #expect(request.url?.query?.contains("limit=20") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        _ = try await service.listWebhooks(limit: 20, cursor: "abc123")
+    }
+
+    // MARK: - Create Webhook
+
+    @Test("Create webhook returns webhook with secret")
+    func createWebhookSuccess() async throws {
+        let json = """
+        {
+            "id": "wh_new123",
+            "url": "https://example.com/hook",
+            "events": ["task.created"],
+            "secret": "whsec_full_secret_shown_once",
+            "status": "active",
+            "createdAt": 1708300000000
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "POST")
+            let body = try JSONDecoder().decode(CreateWebhookRequest.self, from: request.httpBody!)
+            #expect(body.url == "https://example.com/hook")
+            #expect(body.events == ["task.created"])
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 201,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.createWebhook(
+            CreateWebhookRequest(url: "https://example.com/hook", events: ["task.created"], secret: nil)
+        )
+        #expect(result.id == "wh_new123")
+        #expect(result.secret == "whsec_full_secret_shown_once")
+    }
+
+    // MARK: - Get Webhook
+
+    @Test("Get webhook by ID")
+    func getWebhookSuccess() async throws {
+        let json = """
+        {
+            "id": "wh_get123",
+            "url": "https://example.com/hook",
+            "events": ["task.created", "stack.deleted"],
+            "secretPrefix": "whsec_get",
+            "status": "active",
+            "createdAt": 1708300000000
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "GET")
+            #expect(request.url?.path.hasSuffix("wh_get123") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.getWebhook(id: "wh_get123")
+        #expect(result.id == "wh_get123")
+        #expect(result.events.count == 2)
+    }
+
+    // MARK: - Delete Webhook
+
+    @Test("Delete webhook succeeds with 204")
+    func deleteWebhookSuccess() async throws {
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "DELETE")
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 204,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        try await service.deleteWebhook(id: "wh_del123")
+    }
+
+    @Test("Delete webhook throws not found for 404")
+    func deleteWebhookNotFound() async throws {
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 404,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, "{}".data(using: .utf8)!)
+        }
+
+        await #expect(throws: WebhookError.self) {
+            try await service.deleteWebhook(id: "wh_missing")
+        }
+    }
+
+    // MARK: - Rotate Secret
+
+    @Test("Rotate secret returns new secret")
+    func rotateSecretSuccess() async throws {
+        let json = """
+        {
+            "id": "wh_rot123",
+            "secret": "whsec_new_rotated_secret",
+            "rotatedAt": 1708310000000
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path.contains("rotate-secret") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.rotateSecret(id: "wh_rot123")
+        #expect(result.secret == "whsec_new_rotated_secret")
+        #expect(result.id == "wh_rot123")
+    }
+
+    // MARK: - List Deliveries
+
+    @Test("List deliveries returns parsed delivery logs")
+    func listDeliveriesSuccess() async throws {
+        let json = """
+        {
+            "data": [
+                {
+                    "id": "del_abc123",
+                    "webhookId": "wh_abc123",
+                    "eventType": "task.created",
+                    "eventId": "evt_xyz789",
+                    "status": "delivered",
+                    "attempts": 1,
+                    "lastResponseStatus": 200,
+                    "lastResponseBody": "OK",
+                    "createdAt": 1708310000000,
+                    "completedAt": 1708310001000,
+                    "lastAttemptAt": 1708310001000
+                },
+                {
+                    "id": "del_def456",
+                    "webhookId": "wh_abc123",
+                    "eventType": "task.updated",
+                    "eventId": "evt_uvw123",
+                    "status": "failed",
+                    "attempts": 3,
+                    "lastResponseStatus": 500,
+                    "lastError": "Internal Server Error",
+                    "createdAt": 1708309000000,
+                    "completedAt": 1708309500000,
+                    "lastAttemptAt": 1708309500000
+                }
+            ],
+            "pagination": {
+                "nextCursor": "cursor_next",
+                "hasMore": true,
+                "limit": 20
+            }
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "GET")
+            #expect(request.url?.path.contains("deliveries") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.listDeliveries(webhookId: "wh_abc123", limit: 20)
+        #expect(result.data.count == 2)
+        #expect(result.data[0].id == "del_abc123")
+        #expect(result.data[0].isSuccess == true)
+        #expect(result.data[0].isPending == false)
+        #expect(result.data[0].lastResponseStatus == 200)
+        #expect(result.data[1].id == "del_def456")
+        #expect(result.data[1].isFailed == true)
+        #expect(result.data[1].attempts == 3)
+        #expect(result.data[1].lastError == "Internal Server Error")
+        #expect(result.pagination.hasMore == true)
+        #expect(result.pagination.nextCursor == "cursor_next")
+    }
+
+    @Test("List deliveries with empty result")
+    func listDeliveriesEmpty() async throws {
+        let json = """
+        {
+            "data": [],
+            "pagination": {"nextCursor": null, "hasMore": false, "limit": 50}
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.listDeliveries(webhookId: "wh_abc123")
+        #expect(result.data.isEmpty)
+    }
+
+    @Test("List deliveries for nonexistent webhook returns 404")
+    func listDeliveriesNotFound() async throws {
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 404,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, "{}".data(using: .utf8)!)
+        }
+
+        await #expect(throws: WebhookError.self) {
+            try await service.listDeliveries(webhookId: "wh_missing")
+        }
+    }
+
+    // MARK: - Test Delivery
+
+    @Test("Test delivery returns success result")
+    func testDeliverySuccess() async throws {
+        let json = """
+        {
+            "success": true,
+            "responseStatus": 200,
+            "responseBody": "OK",
+            "durationMs": 142,
+            "deliveredAt": 1708310000000
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path.contains("test") == true)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.testDelivery(webhookId: "wh_abc123")
+        #expect(result.success == true)
+        #expect(result.responseStatus == 200)
+        #expect(result.responseBody == "OK")
+        #expect(result.durationMs == 142)
+    }
+
+    @Test("Test delivery returns failure result")
+    func testDeliveryFailure() async throws {
+        let json = """
+        {
+            "success": false,
+            "error": "connection refused",
+            "durationMs": 5001,
+            "deliveredAt": 1708310000000
+        }
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let result = try await service.testDelivery(webhookId: "wh_abc123")
+        #expect(result.success == false)
+        #expect(result.error == "connection refused")
+        #expect(result.responseStatus == nil)
+    }
+
+    // MARK: - Error Handling
+
+    @Test("Server error returns typed error")
+    func serverError() async throws {
+        let json = """
+        {"error": "Rate limit exceeded"}
+        """
+
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 429,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        await #expect(throws: WebhookError.self) {
+            try await service.listWebhooks()
+        }
+    }
+
+    @Test("Auth error when not signed in")
+    func authError() async throws {
+        WebhookMockURLProtocolStorage.shared.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 401,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (response, "{}".data(using: .utf8)!)
+        }
+
+        await #expect(throws: WebhookError.self) {
+            try await service.listWebhooks()
+        }
+    }
+
+    // MARK: - Model Tests
+
+    @Test("Webhook model computed properties")
+    func webhookModelProperties() {
+        let webhook = Webhook(
+            id: "wh_1",
+            url: "https://example.com",
+            events: ["task.created"],
+            secret: nil,
+            secretPrefix: "whsec_",
+            status: "active",
+            createdAt: 1708300000000,
+            lastDeliveryAt: 1708310000000,
+            lastDeliveryStatus: "delivered"
+        )
+        #expect(webhook.isActive == true)
+        #expect(webhook.lastDeliveryAtDate != nil)
+        #expect(webhook.createdAtDate.timeIntervalSince1970 > 0)
+    }
+
+    @Test("WebhookDelivery model computed properties")
+    func deliveryModelProperties() {
+        let delivered = WebhookDelivery(
+            id: "del_1", webhookId: "wh_1", eventType: "task.created",
+            eventId: "evt_1", status: "delivered", attempts: 1,
+            lastResponseStatus: 200, lastResponseBody: "OK", lastError: nil,
+            createdAt: 1708300000000, completedAt: 1708300001000,
+            nextRetryAt: nil, lastAttemptAt: 1708300001000
+        )
+        #expect(delivered.isSuccess == true)
+        #expect(delivered.isPending == false)
+        #expect(delivered.isFailed == false)
+
+        let pending = WebhookDelivery(
+            id: "del_2", webhookId: "wh_1", eventType: "task.updated",
+            eventId: "evt_2", status: "pending", attempts: 0,
+            lastResponseStatus: nil, lastResponseBody: nil, lastError: nil,
+            createdAt: 1708300000000, completedAt: nil,
+            nextRetryAt: 1708300060000, lastAttemptAt: nil
+        )
+        #expect(pending.isSuccess == false)
+        #expect(pending.isPending == true)
+        #expect(pending.isFailed == false)
+        #expect(pending.nextRetryAtDate != nil)
+
+        let failed = WebhookDelivery(
+            id: "del_3", webhookId: "wh_1", eventType: "stack.deleted",
+            eventId: "evt_3", status: "failed", attempts: 5,
+            lastResponseStatus: 500, lastResponseBody: nil,
+            lastError: "Internal Server Error",
+            createdAt: 1708300000000, completedAt: 1708300300000,
+            nextRetryAt: nil, lastAttemptAt: 1708300300000
+        )
+        #expect(failed.isSuccess == false)
+        #expect(failed.isPending == false)
+        #expect(failed.isFailed == true)
+    }
+}


### PR DESCRIPTION
## Summary

Full iOS client for webhook management, delivery logs, and test delivery — completing the iOS integration for the webhook endpoints added in dequeue-api PR #108 (delivery logs) and PR #110 (test delivery).

## New Services

- **WebhookService**: Full CRUD (list, create, get, update, delete) + secret rotation + delivery log listing + test delivery
- All models match the API response schema exactly (Webhook, WebhookDelivery, WebhookTestResult, etc.)
- Environment key integration for dependency injection

## New Views

- **WebhooksView**: Lists all webhooks with status badges (active/paused), event count, last delivery time
- **WebhookDetailView**: Shows webhook config, actions (test delivery, delete), and paginated delivery log
- **DeliveryDetailView**: Full delivery inspection — status, HTTP response, error details, IDs
- **CreateWebhookView**: Form with URL input, multi-select event picker, one-time secret display with copy
- **DeliveryRow**: Compact list row with green/orange/red status icons

## Settings Integration

- New **Integrations** section in Settings (between Data and About)
- Webhooks link with antenna icon

## Tests (17 tests)

- List webhooks (success, empty, pagination cursor)
- Create webhook with secret
- Get webhook by ID
- Delete webhook (success, 404)
- Rotate secret
- List deliveries (success, empty, 404)
- Test delivery (success, failure)
- Server/auth error handling
- Model computed properties (Webhook, WebhookDelivery)

## Depends On

- API endpoints from dequeue-api PR #113 (combined PR, awaiting CI fix)
- iOS clients gracefully handle missing endpoints (network error shown)

## Verification

- ✅ Production build passes (macOS)
- ✅ SwiftLint clean (0 violations)
- ✅ All 17 service tests pass