### PR TITLE
Add test coverage for DeepLinkManager and ErrorReportingService

### DIFF
--- a/Dequeue/DequeueTests/DeepLinkManagerTests.swift
+++ b/Dequeue/DequeueTests/DeepLinkManagerTests.swift
@@ -1,0 +1,253 @@
+//
+//  DeepLinkManagerTests.swift
+//  DequeueTests
+//
+//  Tests for DeepLinkDestination and deep link notification handling
+//
+
+import XCTest
+@testable import Dequeue
+
+@MainActor
+final class DeepLinkManagerTests: XCTestCase {
+
+    // MARK: - DeepLinkDestination Init - Happy Path
+
+    func testInitWithValidStackDestination() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-123",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+
+        XCTAssertNotNil(destination)
+        XCTAssertEqual(destination?.parentId, "stack-123")
+        XCTAssertEqual(destination?.parentType, .stack)
+    }
+
+    func testInitWithValidTaskDestination() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "task-456",
+            NotificationConstants.UserInfoKey.parentType: "task"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+
+        XCTAssertNotNil(destination)
+        XCTAssertEqual(destination?.parentId, "task-456")
+        XCTAssertEqual(destination?.parentType, .task)
+    }
+
+    func testInitWithValidArcDestination() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "arc-789",
+            NotificationConstants.UserInfoKey.parentType: "arc"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+
+        XCTAssertNotNil(destination)
+        XCTAssertEqual(destination?.parentId, "arc-789")
+        XCTAssertEqual(destination?.parentType, .arc)
+    }
+
+    // MARK: - DeepLinkDestination Init - All ParentType Variants
+
+    func testInitWithAllParentTypes() {
+        for parentType in ParentType.allCases {
+            let userInfo: [AnyHashable: Any] = [
+                NotificationConstants.UserInfoKey.parentId: "id-\(parentType.rawValue)",
+                NotificationConstants.UserInfoKey.parentType: parentType.rawValue
+            ]
+
+            let destination = DeepLinkDestination(userInfo: userInfo)
+
+            XCTAssertNotNil(destination, "Should create destination for parentType: \(parentType.rawValue)")
+            XCTAssertEqual(destination?.parentType, parentType)
+            XCTAssertEqual(destination?.parentId, "id-\(parentType.rawValue)")
+        }
+    }
+
+    // MARK: - DeepLinkDestination Init - Failure Cases
+
+    func testInitWithEmptyUserInfo() {
+        let destination = DeepLinkDestination(userInfo: [:])
+        XCTAssertNil(destination, "Should return nil for empty userInfo")
+    }
+
+    func testInitWithMissingParentId() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil when parentId is missing")
+    }
+
+    func testInitWithMissingParentType() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-123"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil when parentType is missing")
+    }
+
+    func testInitWithInvalidParentType() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: "invalid_type"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil for invalid parentType raw value")
+    }
+
+    func testInitWithWrongTypeForParentId() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: 12345,  // Int instead of String
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil when parentId is not a String")
+    }
+
+    func testInitWithWrongTypeForParentType() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: 42  // Int instead of String
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil when parentType is not a String")
+    }
+
+    func testInitWithNilValuesInUserInfo() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: NSNull(),
+            NotificationConstants.UserInfoKey.parentType: NSNull()
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Should return nil when values are NSNull")
+    }
+
+    func testInitWithEmptyStringParentId() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        // Empty string is a valid String, so init should succeed
+        // (business logic validation is separate from parsing)
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNotNil(destination, "Empty string parentId should still parse successfully")
+        XCTAssertEqual(destination?.parentId, "")
+    }
+
+    func testInitWithEmptyStringParentType() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: ""
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "Empty string parentType should fail ParentType(rawValue:)")
+    }
+
+    func testInitWithExtraKeysInUserInfo() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-123",
+            NotificationConstants.UserInfoKey.parentType: "stack",
+            NotificationConstants.UserInfoKey.reminderId: "reminder-456",
+            "extraKey": "extraValue"
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNotNil(destination, "Extra keys in userInfo should be ignored")
+        XCTAssertEqual(destination?.parentId, "stack-123")
+        XCTAssertEqual(destination?.parentType, .stack)
+    }
+
+    func testInitWithCaseSensitiveParentType() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: "Stack"  // Capital S
+        ]
+
+        let destination = DeepLinkDestination(userInfo: userInfo)
+        XCTAssertNil(destination, "ParentType raw value is case-sensitive; 'Stack' should fail")
+    }
+
+    // MARK: - Equatable Conformance
+
+    func testEqualDestinations() {
+        let userInfo: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-123",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        let destination1 = DeepLinkDestination(userInfo: userInfo)
+        let destination2 = DeepLinkDestination(userInfo: userInfo)
+
+        XCTAssertEqual(destination1, destination2)
+    }
+
+    func testUnequalDestinationsDifferentId() {
+        let userInfo1: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-123",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+        let userInfo2: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "stack-456",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+
+        let destination1 = DeepLinkDestination(userInfo: userInfo1)
+        let destination2 = DeepLinkDestination(userInfo: userInfo2)
+
+        XCTAssertNotEqual(destination1, destination2)
+    }
+
+    func testUnequalDestinationsDifferentType() {
+        let userInfo1: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: "stack"
+        ]
+        let userInfo2: [AnyHashable: Any] = [
+            NotificationConstants.UserInfoKey.parentId: "id-123",
+            NotificationConstants.UserInfoKey.parentType: "task"
+        ]
+
+        let destination1 = DeepLinkDestination(userInfo: userInfo1)
+        let destination2 = DeepLinkDestination(userInfo: userInfo2)
+
+        XCTAssertNotEqual(destination1, destination2)
+    }
+
+    // MARK: - Notification Name
+
+    func testReminderNotificationTappedName() {
+        let name = Notification.Name.reminderNotificationTapped
+        XCTAssertEqual(name.rawValue, "com.dequeue.reminderNotificationTapped")
+    }
+
+    func testNotificationNameIsStable() {
+        // Ensure the notification name doesn't accidentally change
+        // (it may be used as a string in other parts of the codebase)
+        let name1 = Notification.Name.reminderNotificationTapped
+        let name2 = Notification.Name.reminderNotificationTapped
+        XCTAssertEqual(name1, name2)
+    }
+
+    // MARK: - UserInfo Key Constants
+
+    func testUserInfoKeyConstants() {
+        // Verify the key strings match expected values used in notification payloads
+        XCTAssertEqual(NotificationConstants.UserInfoKey.parentId, "parentId")
+        XCTAssertEqual(NotificationConstants.UserInfoKey.parentType, "parentType")
+        XCTAssertEqual(NotificationConstants.UserInfoKey.reminderId, "reminderId")
+    }
+}

--- a/Dequeue/DequeueTests/ErrorReportingServiceTests.swift
+++ b/Dequeue/DequeueTests/ErrorReportingServiceTests.swift
@@ -1,0 +1,336 @@
+//
+//  ErrorReportingServiceTests.swift
+//  DequeueTests
+//
+//  Tests for ErrorReportingService - error truncation, logging extensions,
+//  and configuration behavior in test environments
+//
+
+import XCTest
+@testable import Dequeue
+
+@MainActor
+final class ErrorReportingServiceTests: XCTestCase {
+
+    // MARK: - truncateErrorMessage - Under Limit
+
+    func testTruncateShortMessage() {
+        let message = "Short error"
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertEqual(result, message, "Short messages should pass through unchanged")
+    }
+
+    func testTruncateEmptyMessage() {
+        let result = ErrorReportingService.truncateErrorMessage("")
+        XCTAssertEqual(result, "", "Empty string should pass through unchanged")
+    }
+
+    func testTruncateExactly500Characters() {
+        let message = String(repeating: "a", count: 500)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertEqual(result, message, "Exactly 500 character message should not be truncated")
+        XCTAssertEqual(result.count, 500)
+    }
+
+    func testTruncateAt499Characters() {
+        let message = String(repeating: "b", count: 499)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertEqual(result, message, "499 character message should not be truncated")
+    }
+
+    // MARK: - truncateErrorMessage - Over Limit
+
+    func testTruncateAt501Characters() {
+        let message = String(repeating: "c", count: 501)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.hasSuffix("...[truncated]"), "Truncated message should end with truncation indicator")
+        XCTAssertEqual(result.count, 500, "Truncated message should be exactly 500 characters")
+    }
+
+    func testTruncateLongMessage() {
+        let message = String(repeating: "x", count: 2000)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.hasSuffix("...[truncated]"))
+        XCTAssertEqual(result.count, 500)
+    }
+
+    func testTruncateVeryLongMessage() {
+        let message = String(repeating: "z", count: 100_000)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.hasSuffix("...[truncated]"))
+        XCTAssertEqual(result.count, 500)
+    }
+
+    func testTruncatePreservesPrefix() {
+        let prefix = "ERROR: Something went wrong in "
+        let message = prefix + String(repeating: "d", count: 500)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+
+        // The truncated message should start with the same prefix
+        XCTAssertTrue(result.hasPrefix(prefix), "Truncation should preserve the beginning of the message")
+        XCTAssertTrue(result.hasSuffix("...[truncated]"))
+    }
+
+    func testTruncateWithUnicodeCharacters() {
+        // Unicode characters (emoji) that are single Character values in Swift
+        let message = String(repeating: "🔥", count: 501)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.hasSuffix("...[truncated]"))
+        XCTAssertEqual(result.count, 500)
+    }
+
+    func testTruncateWithMultibyteCharacters() {
+        // Mix of ASCII and multi-byte characters
+        let message = "Error: " + String(repeating: "日本語", count: 200)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.count <= 500)
+        if message.count > 500 {
+            XCTAssertTrue(result.hasSuffix("...[truncated]"))
+        }
+    }
+
+    func testTruncationIndicatorContent() {
+        // Verify the truncation indicator is what we expect
+        let message = String(repeating: "a", count: 501)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertTrue(result.hasSuffix("...[truncated]"))
+        // The non-truncated portion should be 500 - "...[truncated]".count = 486 characters
+        let indicatorLength = "...[truncated]".count  // 14
+        let contentLength = 500 - indicatorLength  // 486
+        let content = String(result.prefix(contentLength))
+        XCTAssertEqual(content, String(repeating: "a", count: contentLength))
+    }
+
+    // MARK: - truncateErrorMessage - Boundary Values
+
+    func testTruncateMessageOfLengthEqualToMaxMinusIndicator() {
+        // 486 characters = 500 - "...[truncated]".count
+        // This is under the limit, should not be truncated
+        let indicatorLength = "...[truncated]".count
+        let message = String(repeating: "e", count: 500 - indicatorLength)
+        let result = ErrorReportingService.truncateErrorMessage(message)
+        XCTAssertEqual(result, message, "Message shorter than max should not be truncated")
+        XCTAssertFalse(result.contains("[truncated]"))
+    }
+
+    // MARK: - Logging Extension Methods (Smoke Tests)
+
+    // These methods call through to the private `log()` which early-returns
+    // when Sentry is not configured (test environment). We verify they don't crash.
+
+    func testLogSyncStartDoesNotCrash() {
+        // Should not crash even without Sentry configured
+        ErrorReportingService.logSyncStart(syncId: "test-sync-1", trigger: "manual")
+    }
+
+    func testLogSyncCompleteDoesNotCrash() {
+        ErrorReportingService.logSyncComplete(
+            syncId: "test-sync-1",
+            duration: 1.5,
+            itemsUploaded: 10,
+            itemsDownloaded: 5
+        )
+    }
+
+    func testLogSyncFailureWithInternetReachable() {
+        let error = NSError(domain: "test", code: 500, userInfo: [
+            NSLocalizedDescriptionKey: "Internal Server Error"
+        ])
+        ErrorReportingService.logSyncFailure(
+            syncId: "test-sync-2",
+            duration: 0.5,
+            error: error,
+            failureReason: "Server returned 500",
+            internetReachable: true
+        )
+    }
+
+    func testLogSyncFailureWithoutInternet() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [
+            NSLocalizedDescriptionKey: "The Internet connection appears to be offline."
+        ])
+        ErrorReportingService.logSyncFailure(
+            syncId: "test-sync-3",
+            duration: 0.1,
+            error: error,
+            failureReason: "No internet connection",
+            internetReachable: false
+        )
+    }
+
+    func testLogAPIResponseSuccess() {
+        ErrorReportingService.logAPIResponse(
+            endpoint: "/api/v1/stacks",
+            statusCode: 200,
+            responseSize: 1024
+        )
+    }
+
+    func testLogAPIResponseClientError() {
+        ErrorReportingService.logAPIResponse(
+            endpoint: "/api/v1/stacks",
+            statusCode: 404,
+            responseSize: 128,
+            error: "Not Found"
+        )
+    }
+
+    func testLogAPIResponseServerError() {
+        ErrorReportingService.logAPIResponse(
+            endpoint: "/api/v1/sync",
+            statusCode: 500,
+            responseSize: nil,
+            error: "Internal Server Error"
+        )
+    }
+
+    func testLogAPIResponseWithNilResponseSize() {
+        ErrorReportingService.logAPIResponse(
+            endpoint: "/api/v1/tasks",
+            statusCode: 204,
+            responseSize: nil
+        )
+    }
+
+    func testLogAPIResponseWithLongErrorMessage() {
+        let longError = String(repeating: "Error detail. ", count: 100)
+        ErrorReportingService.logAPIResponse(
+            endpoint: "/api/v1/sync",
+            statusCode: 500,
+            responseSize: 0,
+            error: longError
+        )
+    }
+
+    func testLogAppLaunchCold() {
+        ErrorReportingService.logAppLaunch(isWarmLaunch: false)
+    }
+
+    func testLogAppLaunchWarm() {
+        ErrorReportingService.logAppLaunch(isWarmLaunch: true)
+    }
+
+    func testLogAppForeground() {
+        ErrorReportingService.logAppForeground()
+    }
+
+    func testLogAppBackground() {
+        ErrorReportingService.logAppBackground(pendingSyncItems: 5)
+    }
+
+    func testLogAppBackgroundWithZeroPendingItems() {
+        ErrorReportingService.logAppBackground(pendingSyncItems: 0)
+    }
+
+    // MARK: - Core Logging Methods (Smoke Tests)
+
+    func testLogDebugDoesNotCrash() {
+        ErrorReportingService.logDebug("Test debug message")
+    }
+
+    func testLogInfoDoesNotCrash() {
+        ErrorReportingService.logInfo("Test info message")
+    }
+
+    func testLogWarningDoesNotCrash() {
+        ErrorReportingService.logWarning("Test warning message")
+    }
+
+    func testLogErrorDoesNotCrash() {
+        ErrorReportingService.logError("Test error message")
+    }
+
+    func testLogWithAttributesDoesNotCrash() {
+        ErrorReportingService.logDebug("Test with attributes", attributes: [
+            "key1": "value1",
+            "key2": 42,
+            "key3": true
+        ])
+    }
+
+    func testLogWithEmptyAttributesDoesNotCrash() {
+        ErrorReportingService.logInfo("Test with empty attributes", attributes: [:])
+    }
+
+    // MARK: - Error Capture (Smoke Tests)
+
+    func testCaptureErrorDoesNotCrash() {
+        let error = NSError(domain: "test", code: 42, userInfo: nil)
+        ErrorReportingService.capture(error: error)
+    }
+
+    func testCaptureErrorWithContextDoesNotCrash() {
+        let error = NSError(domain: "test", code: 42, userInfo: nil)
+        ErrorReportingService.capture(error: error, context: [
+            "operation": "sync",
+            "retryCount": 3
+        ])
+    }
+
+    func testCaptureMessageDoesNotCrash() {
+        ErrorReportingService.capture(message: "Test message")
+    }
+
+    // MARK: - User Context (Smoke Tests)
+
+    func testSetUserDoesNotCrash() {
+        ErrorReportingService.setUser(id: "user-123", email: "test@example.com")
+    }
+
+    func testSetUserWithoutEmailDoesNotCrash() {
+        ErrorReportingService.setUser(id: "user-123")
+    }
+
+    func testClearUserDoesNotCrash() {
+        ErrorReportingService.clearUser()
+    }
+
+    // MARK: - Breadcrumbs (Smoke Tests)
+
+    func testAddBreadcrumbDoesNotCrash() {
+        ErrorReportingService.addBreadcrumb(
+            category: "test",
+            message: "Test breadcrumb"
+        )
+    }
+
+    func testAddBreadcrumbWithDataDoesNotCrash() {
+        ErrorReportingService.addBreadcrumb(
+            category: "navigation",
+            message: "Navigated to stack detail",
+            data: ["stackId": "stack-123"]
+        )
+    }
+
+    // MARK: - API Response Status Code Ranges
+
+    func testLogAPIResponseBoundaryStatusCodes() {
+        // Test boundary values for status code ranges
+        // 200 range boundary
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 200, responseSize: 0)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 299, responseSize: 0)
+
+        // 400 range boundary
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 400, responseSize: 0)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 499, responseSize: 0)
+
+        // 500 range boundary
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 500, responseSize: 0)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 599, responseSize: 0)
+
+        // Outside defined ranges (e.g., 300, 600) - should not log (no crash)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 301, responseSize: 0)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 600, responseSize: 0)
+        ErrorReportingService.logAPIResponse(endpoint: "/test", statusCode: 100, responseSize: 0)
+    }
+
+    // MARK: - Configuration Constants
+
+    func testTracePropagationTargetsIncludesExpectedHosts() {
+        let targets = Configuration.tracePropagationTargets
+        XCTAssertTrue(targets.contains("api.dequeue.app"))
+        XCTAssertTrue(targets.contains("sync.ardonos.com"))
+        XCTAssertTrue(targets.contains("localhost"))
+        XCTAssertTrue(targets.contains("127.0.0.1"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for two previously untested services:

### DeepLinkManagerTests (20 tests)
Tests `DeepLinkDestination` failable initializer and related types:
- **Happy path**: Valid stack, task, and arc destinations; all `ParentType` variants via `CaseIterable`
- **Failure cases**: Missing keys, wrong value types (Int instead of String), invalid raw values, `NSNull`, empty strings, case sensitivity
- **Equatable conformance**: Equal and unequal destination comparisons
- **Constants**: `Notification.Name.reminderNotificationTapped` and `NotificationConstants.UserInfoKey` values

### ErrorReportingServiceTests (30+ tests)
Tests error truncation logic, logging extensions, and crash safety:
- **`truncateErrorMessage`**: Boundary values (499, 500, 501 chars), unicode/multibyte characters, prefix preservation, truncation indicator format
- **Logging extensions (smoke tests)**: `logSyncStart/Complete/Failure`, `logAPIResponse` (all status code ranges), `logAppLaunch/Foreground/Background`
- **Core log methods**: debug/info/warning/error with and without attributes
- **Error capture, user context, breadcrumbs**: Verify no crash when Sentry is unconfigured (test environment)
- **Configuration**: Trace propagation targets validation

### Notes
- Uses XCTest framework with `@MainActor` annotation (required by Swift 6 strict concurrency)
- No Xcode project file changes needed (uses `PBXFileSystemSynchronizedRootGroup`)
- All tests pass locally, lint clean