### PR TITLE
feat: task templates — save and reuse common task patterns

### DIFF
--- a/Dequeue/Dequeue/Services/TaskTemplateService.swift
+++ b/Dequeue/Dequeue/Services/TaskTemplateService.swift
@@ -1,0 +1,304 @@
+//
+//  TaskTemplateService.swift
+//  Dequeue
+//
+//  Save and reuse task templates for common recurring task patterns.
+//  Templates store title, description, priority, tags, and relative dates.
+//
+
+import Combine
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.dequeue", category: "TaskTemplates")
+
+// MARK: - Task Template
+
+/// A reusable task template that can be applied to quickly create tasks
+/// with predefined fields.
+struct TaskTemplate: Codable, Identifiable, Equatable, Sendable {
+    let id: String
+    var name: String
+    var icon: String
+    var title: String
+    var taskDescription: String?
+    var priority: Int?
+    var tags: [String]
+
+    /// Relative due date offset in seconds from creation time.
+    /// e.g., 86400 = 1 day from now, 604800 = 1 week from now
+    var dueDateOffset: TimeInterval?
+
+    /// Relative start date offset in seconds from creation time.
+    var startDateOffset: TimeInterval?
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    /// Whether this is a built-in template (cannot be deleted)
+    var isBuiltIn: Bool
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        icon: String = "doc.text",
+        title: String,
+        taskDescription: String? = nil,
+        priority: Int? = nil,
+        tags: [String] = [],
+        dueDateOffset: TimeInterval? = nil,
+        startDateOffset: TimeInterval? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        isBuiltIn: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.title = title
+        self.taskDescription = taskDescription
+        self.priority = priority
+        self.tags = tags
+        self.dueDateOffset = dueDateOffset
+        self.startDateOffset = startDateOffset
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.isBuiltIn = isBuiltIn
+    }
+}
+
+// MARK: - Template Application Result
+
+/// The result of applying a template, ready to create a task.
+struct TemplateApplicationResult: Equatable, Sendable {
+    let title: String
+    let taskDescription: String?
+    let priority: Int?
+    let tags: [String]
+    let dueTime: Date?
+    let startTime: Date?
+}
+
+// MARK: - Task Template Service
+
+/// Manages task templates: CRUD operations, built-in templates, and persistence.
+@MainActor
+final class TaskTemplateService: ObservableObject {
+
+    @Published private(set) var templates: [TaskTemplate] = []
+
+    private let userDefaults: UserDefaults
+    private let storageKey = "taskTemplates"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        loadTemplates()
+    }
+
+    // MARK: - Public API
+
+    /// Apply a template to generate task fields with resolved dates.
+    func apply(_ template: TaskTemplate, at referenceDate: Date = Date()) -> TemplateApplicationResult {
+        let dueTime = template.dueDateOffset.map { referenceDate.addingTimeInterval($0) }
+        let startTime = template.startDateOffset.map { referenceDate.addingTimeInterval($0) }
+
+        return TemplateApplicationResult(
+            title: template.title,
+            taskDescription: template.taskDescription,
+            priority: template.priority,
+            tags: template.tags,
+            dueTime: dueTime,
+            startTime: startTime
+        )
+    }
+
+    /// Add a new custom template.
+    func add(_ template: TaskTemplate) {
+        templates.append(template)
+        saveTemplates()
+        logger.info("Template added: \(template.name)")
+    }
+
+    /// Update an existing template.
+    func update(_ template: TaskTemplate) {
+        guard let index = templates.firstIndex(where: { $0.id == template.id }) else {
+            logger.warning("Template not found for update: \(template.id)")
+            return
+        }
+        var updated = template
+        updated.updatedAt = Date()
+        templates[index] = updated
+        saveTemplates()
+        logger.info("Template updated: \(template.name)")
+    }
+
+    /// Delete a template (built-in templates cannot be deleted).
+    func delete(_ template: TaskTemplate) {
+        guard !template.isBuiltIn else {
+            logger.warning("Cannot delete built-in template: \(template.name)")
+            return
+        }
+        templates.removeAll { $0.id == template.id }
+        saveTemplates()
+        logger.info("Template deleted: \(template.name)")
+    }
+
+    /// Delete template at index.
+    func delete(at offsets: IndexSet) {
+        let toDelete = offsets.map { templates[$0] }.filter { !$0.isBuiltIn }
+        for template in toDelete {
+            templates.removeAll { $0.id == template.id }
+        }
+        saveTemplates()
+    }
+
+    /// Move templates for reordering.
+    func move(from source: IndexSet, to destination: Int) {
+        // Manual reorder without SwiftUI's Array.move extension
+        let items = source.map { templates[$0] }
+        var newTemplates = templates
+        // Remove from old positions (reverse to keep indices valid)
+        for index in source.sorted().reversed() {
+            newTemplates.remove(at: index)
+        }
+        // Calculate adjusted destination
+        let adjustedDest = min(destination, newTemplates.count)
+        for (offset, item) in items.enumerated() {
+            newTemplates.insert(item, at: adjustedDest + offset)
+        }
+        templates = newTemplates
+        saveTemplates()
+    }
+
+    /// Reset to built-in templates only.
+    func resetToDefaults() {
+        templates = Self.builtInTemplates
+        saveTemplates()
+    }
+
+    /// Create a template from an existing task's fields.
+    func createFromTask(
+        name: String,
+        title: String,
+        description: String?,
+        priority: Int?,
+        tags: [String],
+        dueDateOffset: TimeInterval? = nil,
+        startDateOffset: TimeInterval? = nil,
+        icon: String = "doc.text"
+    ) -> TaskTemplate {
+        let template = TaskTemplate(
+            name: name,
+            icon: icon,
+            title: title,
+            taskDescription: description,
+            priority: priority,
+            tags: tags,
+            dueDateOffset: dueDateOffset,
+            startDateOffset: startDateOffset
+        )
+        add(template)
+        return template
+    }
+
+    // MARK: - Built-in Templates
+
+    static let builtInTemplates: [TaskTemplate] = [
+        TaskTemplate(
+            id: "builtin-daily-standup",
+            name: "Daily Standup",
+            icon: "person.3",
+            title: "Daily standup",
+            taskDescription: "What I did yesterday, what I'm doing today, blockers",
+            priority: 1,
+            tags: ["meetings"],
+            dueDateOffset: 3600, // 1 hour from now
+            isBuiltIn: true
+        ),
+        TaskTemplate(
+            id: "builtin-code-review",
+            name: "Code Review",
+            icon: "eye",
+            title: "Review PR: ",
+            taskDescription: "Check: correctness, tests, style, performance",
+            priority: 2,
+            tags: ["code-review"],
+            dueDateOffset: 86400, // 1 day
+            isBuiltIn: true
+        ),
+        TaskTemplate(
+            id: "builtin-bug-report",
+            name: "Bug Report",
+            icon: "ladybug",
+            title: "Fix: ",
+            taskDescription: """
+            Steps to reproduce:
+            1.
+            2.
+            3.
+
+            Expected behavior:
+
+            Actual behavior:
+            """,
+            priority: 2,
+            tags: ["bug"],
+            isBuiltIn: true
+        ),
+        TaskTemplate(
+            id: "builtin-weekly-review",
+            name: "Weekly Review",
+            icon: "calendar.badge.checkmark",
+            title: "Weekly review",
+            taskDescription: """
+            - Review completed tasks
+            - Review upcoming deadlines
+            - Clear inbox
+            - Plan next week's priorities
+            """,
+            priority: 1,
+            tags: ["review"],
+            dueDateOffset: 604800, // 1 week
+            isBuiltIn: true
+        ),
+        TaskTemplate(
+            id: "builtin-follow-up",
+            name: "Follow Up",
+            icon: "arrow.uturn.right",
+            title: "Follow up: ",
+            priority: 1,
+            tags: ["follow-up"],
+            dueDateOffset: 259200, // 3 days
+            isBuiltIn: true
+        ),
+        TaskTemplate(
+            id: "builtin-quick-task",
+            name: "Quick Task",
+            icon: "bolt",
+            title: "",
+            priority: nil,
+            tags: [],
+            dueDateOffset: nil,
+            isBuiltIn: true
+        )
+    ]
+
+    // MARK: - Persistence
+
+    private func loadTemplates() {
+        if let data = userDefaults.data(forKey: storageKey),
+           let saved = try? JSONDecoder().decode([TaskTemplate].self, from: data) {
+            templates = saved
+        } else {
+            // First launch — use built-in templates
+            templates = Self.builtInTemplates
+            saveTemplates()
+        }
+    }
+
+    private func saveTemplates() {
+        if let data = try? JSONEncoder().encode(templates) {
+            userDefaults.set(data, forKey: storageKey)
+        }
+    }
+}

--- a/Dequeue/Dequeue/Views/Task/TaskTemplatesView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskTemplatesView.swift
@@ -1,0 +1,403 @@
+//
+//  TaskTemplatesView.swift
+//  Dequeue
+//
+//  UI for browsing, creating, and applying task templates.
+//
+
+import SwiftUI
+
+// MARK: - Template Picker Sheet
+
+/// A sheet that displays available templates for quick task creation.
+struct TemplatePickerSheet: View {
+    @StateObject private var templateService = TaskTemplateService()
+    @Environment(\.dismiss) private var dismiss
+
+    let onSelect: (TemplateApplicationResult) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !builtInTemplates.isEmpty {
+                    Section("Built-in") {
+                        ForEach(builtInTemplates) { template in
+                            templateRow(template)
+                        }
+                    }
+                }
+
+                if !customTemplates.isEmpty {
+                    Section("Custom") {
+                        ForEach(customTemplates) { template in
+                            templateRow(template)
+                        }
+                        .onDelete { offsets in
+                            let customOffset = builtInTemplates.count
+                            let adjustedOffsets = IndexSet(offsets.map { $0 + customOffset })
+                            templateService.delete(at: adjustedOffsets)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Templates")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var builtInTemplates: [TaskTemplate] {
+        templateService.templates.filter(\.isBuiltIn)
+    }
+
+    private var customTemplates: [TaskTemplate] {
+        templateService.templates.filter { !$0.isBuiltIn }
+    }
+
+    private func templateRow(_ template: TaskTemplate) -> some View {
+        Button {
+            let result = templateService.apply(template)
+            onSelect(result)
+            dismiss()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: template.icon)
+                    .font(.title3)
+                    .foregroundStyle(.blue)
+                    .frame(width: 32, height: 32)
+                    .background(Color.blue.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.name)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+
+                    if !template.title.isEmpty {
+                        Text(template.title)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if let priority = template.priority {
+                    priorityBadge(priority)
+                }
+
+                if !template.tags.isEmpty {
+                    Text("\(template.tags.count) tags")
+                        .font(.caption2)
+                        .foregroundStyle(.purple)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.purple.opacity(0.1))
+                        .clipShape(Capsule())
+                }
+            }
+        }
+        .accessibilityLabel("\(template.name) template")
+        .accessibilityHint("Double tap to create task from this template")
+    }
+
+    private func priorityBadge(_ priority: Int) -> some View {
+        Text(priorityLabel(priority))
+            .font(.caption2)
+            .foregroundStyle(priorityColor(priority))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(priorityColor(priority).opacity(0.1))
+            .clipShape(Capsule())
+    }
+
+    private func priorityLabel(_ priority: Int) -> String {
+        switch priority {
+        case 3: return "Urgent"
+        case 2: return "High"
+        case 1: return "Medium"
+        default: return "Low"
+        }
+    }
+
+    private func priorityColor(_ priority: Int) -> Color {
+        switch priority {
+        case 3: return .red
+        case 2: return .orange
+        case 1: return .yellow
+        default: return .gray
+        }
+    }
+}
+
+// MARK: - Template Editor
+
+/// View for creating or editing a task template.
+struct TemplateEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var icon: String
+    @State private var title: String
+    @State private var taskDescription: String
+    @State private var priority: Int?
+    @State private var tags: String
+    @State private var hasDueDate: Bool
+    @State private var dueDays: Int
+    @State private var dueHours: Int
+    @State private var hasStartDate: Bool
+    @State private var startDays: Int
+
+    private let isEditing: Bool
+    private let templateId: String
+    let onSave: (TaskTemplate) -> Void
+
+    init(template: TaskTemplate? = nil, onSave: @escaping (TaskTemplate) -> Void) {
+        let tmpl = template
+        _name = State(initialValue: tmpl?.name ?? "")
+        _icon = State(initialValue: tmpl?.icon ?? "doc.text")
+        _title = State(initialValue: tmpl?.title ?? "")
+        _taskDescription = State(initialValue: tmpl?.taskDescription ?? "")
+        _priority = State(initialValue: tmpl?.priority)
+        _tags = State(initialValue: tmpl?.tags.joined(separator: ", ") ?? "")
+        _hasDueDate = State(initialValue: tmpl?.dueDateOffset != nil)
+        _dueDays = State(initialValue: Int((tmpl?.dueDateOffset ?? 0) / 86400))
+        _dueHours = State(initialValue: Int(((tmpl?.dueDateOffset ?? 0).truncatingRemainder(dividingBy: 86400)) / 3600))
+        _hasStartDate = State(initialValue: tmpl?.startDateOffset != nil)
+        _startDays = State(initialValue: Int((tmpl?.startDateOffset ?? 0) / 86400))
+        self.isEditing = tmpl != nil
+        self.templateId = tmpl?.id ?? UUID().uuidString
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Template Info") {
+                    TextField("Template name", text: $name)
+                        .accessibilityIdentifier("templateNameField")
+                    iconPicker
+                }
+
+                Section("Task Fields") {
+                    TextField("Task title", text: $title)
+                        .accessibilityIdentifier("templateTitleField")
+                    TextField("Description (optional)", text: $taskDescription, axis: .vertical)
+                        .lineLimit(3...6)
+                    priorityPicker
+                    TextField("Tags (comma-separated)", text: $tags)
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                }
+
+                Section("Due Date") {
+                    Toggle("Set relative due date", isOn: $hasDueDate)
+                    if hasDueDate {
+                        Stepper("Days: \(dueDays)", value: $dueDays, in: 0...365)
+                        Stepper("Hours: \(dueHours)", value: $dueHours, in: 0...23)
+                    }
+                }
+
+                Section("Start Date") {
+                    Toggle("Set relative start date", isOn: $hasStartDate)
+                    if hasStartDate {
+                        Stepper("Days from now: \(startDays)", value: $startDays, in: 0...365)
+                    }
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Template" : "New Template")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { saveTemplate() }
+                        .disabled(name.isEmpty || title.isEmpty)
+                }
+            }
+        }
+    }
+
+    private var iconPicker: some View {
+        let icons = [
+            "doc.text", "bolt", "person.3", "eye", "ladybug",
+            "calendar.badge.checkmark", "arrow.uturn.right", "star",
+            "phone", "envelope", "cart", "house", "heart",
+            "brain", "book", "wrench.and.screwdriver"
+        ]
+
+        return ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(icons, id: \.self) { iconName in
+                    Button {
+                        icon = iconName
+                    } label: {
+                        Image(systemName: iconName)
+                            .font(.title3)
+                            .frame(width: 40, height: 40)
+                            .background(icon == iconName ? Color.blue.opacity(0.2) : Color.secondary.opacity(0.1))
+                            .foregroundStyle(icon == iconName ? .blue : .secondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var priorityPicker: some View {
+        Picker("Priority", selection: Binding(
+            get: { priority ?? -1 },
+            set: { priority = $0 == -1 ? nil : $0 }
+        )) {
+            Text("None").tag(-1)
+            Text("Low").tag(0)
+            Text("Medium").tag(1)
+            Text("High").tag(2)
+            Text("Urgent").tag(3)
+        }
+    }
+
+    private func saveTemplate() {
+        let parsedTags = tags
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        let dueDateOffset = hasDueDate
+            ? TimeInterval(dueDays * 86400 + dueHours * 3600)
+            : nil
+
+        let startDateOffset = hasStartDate
+            ? TimeInterval(startDays * 86400)
+            : nil
+
+        let template = TaskTemplate(
+            id: templateId,
+            name: name,
+            icon: icon,
+            title: title,
+            taskDescription: taskDescription.isEmpty ? nil : taskDescription,
+            priority: priority,
+            tags: parsedTags,
+            dueDateOffset: dueDateOffset,
+            startDateOffset: startDateOffset
+        )
+
+        onSave(template)
+        dismiss()
+    }
+}
+
+// MARK: - Template Management View
+
+/// Full template management view for settings.
+struct TaskTemplateManagementView: View {
+    @StateObject private var templateService = TaskTemplateService()
+    @State private var showEditor = false
+    @State private var editingTemplate: TaskTemplate?
+
+    var body: some View {
+        List {
+            ForEach(templateService.templates) { template in
+                Button {
+                    editingTemplate = template
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: template.icon)
+                            .font(.title3)
+                            .foregroundStyle(.blue)
+                            .frame(width: 32)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(template.name)
+                                    .foregroundStyle(.primary)
+                                if template.isBuiltIn {
+                                    Text("Built-in")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .padding(.horizontal, 4)
+                                        .padding(.vertical, 1)
+                                        .background(Color.secondary.opacity(0.1))
+                                        .clipShape(Capsule())
+                                }
+                            }
+                            Text(template.title.isEmpty ? "Empty title" : template.title)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+            .onDelete { offsets in
+                templateService.delete(at: offsets)
+            }
+            .onMove { source, destination in
+                templateService.move(from: source, to: destination)
+            }
+        }
+        .navigationTitle("Task Templates")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { EditButton() }
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showEditor = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            TemplateEditorView { template in
+                templateService.add(template)
+            }
+        }
+        .sheet(item: $editingTemplate) { template in
+            TemplateEditorView(template: template) { updated in
+                templateService.update(updated)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Template Picker") {
+    TemplatePickerSheet { result in
+        print("Selected: \(result.title)")
+    }
+}
+
+#Preview("Template Editor") {
+    TemplateEditorView { template in
+        print("Saved: \(template.name)")
+    }
+}
+
+#Preview("Template Management") {
+    NavigationStack {
+        TaskTemplateManagementView()
+    }
+}

--- a/Dequeue/DequeueTests/TaskTemplateServiceTests.swift
+++ b/Dequeue/DequeueTests/TaskTemplateServiceTests.swift
@@ -1,0 +1,302 @@
+//
+//  TaskTemplateServiceTests.swift
+//  DequeueTests
+//
+//  Tests for task template service — CRUD, persistence, and built-in templates.
+//
+
+import XCTest
+@testable import Dequeue
+
+@MainActor
+final class TaskTemplateServiceTests: XCTestCase {
+
+    private var service: TaskTemplateService!
+    private var userDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "TaskTemplateTests-\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        service = TaskTemplateService(userDefaults: userDefaults)
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        service = nil
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State
+
+    func testInitialTemplatesAreBuiltIn() {
+        // Should start with built-in templates
+        XCTAssertFalse(service.templates.isEmpty)
+        XCTAssertTrue(service.templates.allSatisfy(\.isBuiltIn))
+    }
+
+    func testBuiltInTemplatesCount() {
+        XCTAssertEqual(TaskTemplateService.builtInTemplates.count, 6)
+    }
+
+    func testBuiltInTemplateNames() {
+        let names = TaskTemplateService.builtInTemplates.map(\.name)
+        XCTAssertTrue(names.contains("Daily Standup"))
+        XCTAssertTrue(names.contains("Code Review"))
+        XCTAssertTrue(names.contains("Bug Report"))
+        XCTAssertTrue(names.contains("Weekly Review"))
+        XCTAssertTrue(names.contains("Follow Up"))
+        XCTAssertTrue(names.contains("Quick Task"))
+    }
+
+    // MARK: - Add
+
+    func testAddTemplate() {
+        let template = TaskTemplate(
+            name: "Custom Template",
+            title: "Custom task",
+            priority: 2,
+            tags: ["custom"]
+        )
+
+        let countBefore = service.templates.count
+        service.add(template)
+
+        XCTAssertEqual(service.templates.count, countBefore + 1)
+        XCTAssertEqual(service.templates.last?.name, "Custom Template")
+    }
+
+    func testAddTemplatePersists() {
+        let template = TaskTemplate(
+            name: "Persistent Template",
+            title: "Persist this"
+        )
+        service.add(template)
+
+        // Create new service with same UserDefaults
+        let service2 = TaskTemplateService(userDefaults: userDefaults)
+        let found = service2.templates.first { $0.name == "Persistent Template" }
+        XCTAssertNotNil(found)
+    }
+
+    // MARK: - Update
+
+    func testUpdateTemplate() {
+        let template = TaskTemplate(name: "Original", title: "Original title")
+        service.add(template)
+
+        var updated = template
+        updated.name = "Updated"
+        updated.title = "Updated title"
+        service.update(updated)
+
+        let found = service.templates.first { $0.id == template.id }
+        XCTAssertEqual(found?.name, "Updated")
+        XCTAssertEqual(found?.title, "Updated title")
+    }
+
+    func testUpdateNonExistentTemplateDoesNothing() {
+        let countBefore = service.templates.count
+        let template = TaskTemplate(id: "nonexistent", name: "Ghost", title: "Ghost")
+        service.update(template)
+
+        XCTAssertEqual(service.templates.count, countBefore)
+    }
+
+    // MARK: - Delete
+
+    func testDeleteCustomTemplate() {
+        let template = TaskTemplate(name: "Deletable", title: "Delete me")
+        service.add(template)
+
+        let countAfterAdd = service.templates.count
+        service.delete(template)
+
+        XCTAssertEqual(service.templates.count, countAfterAdd - 1)
+        XCTAssertNil(service.templates.first { $0.id == template.id })
+    }
+
+    func testCannotDeleteBuiltInTemplate() {
+        let builtIn = service.templates.first { $0.isBuiltIn }!
+        let countBefore = service.templates.count
+
+        service.delete(builtIn)
+
+        // Built-in template should still be there
+        XCTAssertEqual(service.templates.count, countBefore)
+    }
+
+    // MARK: - Apply
+
+    func testApplyTemplateWithDueDate() {
+        let now = Date()
+        let template = TaskTemplate(
+            name: "Test",
+            title: "Test task",
+            priority: 2,
+            tags: ["work"],
+            dueDateOffset: 86400 // 1 day
+        )
+
+        let result = service.apply(template, at: now)
+
+        XCTAssertEqual(result.title, "Test task")
+        XCTAssertEqual(result.priority, 2)
+        XCTAssertEqual(result.tags, ["work"])
+        XCTAssertNotNil(result.dueTime)
+
+        // Should be approximately 1 day in the future
+        let interval = result.dueTime!.timeIntervalSince(now)
+        XCTAssertEqual(interval, 86400, accuracy: 1)
+    }
+
+    func testApplyTemplateWithoutDueDate() {
+        let template = TaskTemplate(
+            name: "No Date",
+            title: "No date task",
+            dueDateOffset: nil
+        )
+
+        let result = service.apply(template)
+
+        XCTAssertEqual(result.title, "No date task")
+        XCTAssertNil(result.dueTime)
+        XCTAssertNil(result.startTime)
+    }
+
+    func testApplyTemplateWithStartDate() {
+        let now = Date()
+        let template = TaskTemplate(
+            name: "Start Date",
+            title: "With start",
+            startDateOffset: 172800 // 2 days
+        )
+
+        let result = service.apply(template, at: now)
+
+        XCTAssertNotNil(result.startTime)
+        let interval = result.startTime!.timeIntervalSince(now)
+        XCTAssertEqual(interval, 172800, accuracy: 1)
+    }
+
+    func testApplyTemplateWithBothDates() {
+        let now = Date()
+        let template = TaskTemplate(
+            name: "Both Dates",
+            title: "Full date task",
+            dueDateOffset: 604800, // 1 week
+            startDateOffset: 86400 // 1 day
+        )
+
+        let result = service.apply(template, at: now)
+
+        XCTAssertNotNil(result.dueTime)
+        XCTAssertNotNil(result.startTime)
+        XCTAssertTrue(result.startTime! < result.dueTime!)
+    }
+
+    // MARK: - Create From Task
+
+    func testCreateFromTask() {
+        let template = service.createFromTask(
+            name: "From Existing",
+            title: "Existing task title",
+            description: "Some description",
+            priority: 3,
+            tags: ["urgent", "bug"],
+            icon: "ladybug"
+        )
+
+        XCTAssertEqual(template.name, "From Existing")
+        XCTAssertEqual(template.title, "Existing task title")
+        XCTAssertEqual(template.taskDescription, "Some description")
+        XCTAssertEqual(template.priority, 3)
+        XCTAssertEqual(template.tags, ["urgent", "bug"])
+        XCTAssertEqual(template.icon, "ladybug")
+        XCTAssertFalse(template.isBuiltIn)
+
+        // Should be added to templates
+        XCTAssertTrue(service.templates.contains { $0.id == template.id })
+    }
+
+    // MARK: - Reorder
+
+    func testMoveTemplates() {
+        // Add some custom templates
+        let a = TaskTemplate(name: "A", title: "A")
+        let b = TaskTemplate(name: "B", title: "B")
+        service.add(a)
+        service.add(b)
+
+        let lastIndex = service.templates.count - 1
+        // Move last to second-to-last
+        service.move(from: IndexSet(integer: lastIndex), to: lastIndex - 1)
+
+        // B should now be before A
+        let bIndex = service.templates.firstIndex { $0.id == b.id }!
+        let aIndex = service.templates.firstIndex { $0.id == a.id }!
+        XCTAssertTrue(bIndex < aIndex)
+    }
+
+    // MARK: - Reset
+
+    func testResetToDefaults() {
+        // Add custom templates
+        service.add(TaskTemplate(name: "Custom 1", title: "C1"))
+        service.add(TaskTemplate(name: "Custom 2", title: "C2"))
+
+        service.resetToDefaults()
+
+        XCTAssertEqual(service.templates.count, TaskTemplateService.builtInTemplates.count)
+        XCTAssertTrue(service.templates.allSatisfy(\.isBuiltIn))
+    }
+
+    // MARK: - Task Template Model
+
+    func testTaskTemplateEquality() {
+        let a = TaskTemplate(id: "same", name: "A", title: "A")
+        let b = TaskTemplate(id: "same", name: "A", title: "A")
+        XCTAssertEqual(a, b)
+    }
+
+    func testTaskTemplateIdentifiable() {
+        let template = TaskTemplate(id: "test-id", name: "Test", title: "Test")
+        XCTAssertEqual(template.id, "test-id")
+    }
+
+    func testTaskTemplateCodable() throws {
+        let template = TaskTemplate(
+            name: "Codable Test",
+            title: "Test",
+            priority: 2,
+            tags: ["a", "b"],
+            dueDateOffset: 3600
+        )
+
+        let data = try JSONEncoder().encode(template)
+        let decoded = try JSONDecoder().decode(TaskTemplate.self, from: data)
+
+        XCTAssertEqual(decoded.name, template.name)
+        XCTAssertEqual(decoded.title, template.title)
+        XCTAssertEqual(decoded.priority, template.priority)
+        XCTAssertEqual(decoded.tags, template.tags)
+        XCTAssertEqual(decoded.dueDateOffset, template.dueDateOffset)
+    }
+
+    // MARK: - Template Application Result
+
+    func testTemplateApplicationResultEquality() {
+        let a = TemplateApplicationResult(
+            title: "Test", taskDescription: nil, priority: 1,
+            tags: ["a"], dueTime: nil, startTime: nil
+        )
+        let b = TemplateApplicationResult(
+            title: "Test", taskDescription: nil, priority: 1,
+            tags: ["a"], dueTime: nil, startTime: nil
+        )
+        XCTAssertEqual(a, b)
+    }
+}


### PR DESCRIPTION
## Summary

Save and reuse common task patterns with templates. Includes 6 built-in templates and full custom template support.

### 📋 Built-in Templates

| Template | Title | Priority | Tags | Due Date |
|----------|-------|----------|------|----------|
| 🧑‍🤝‍🧑 Daily Standup | "Daily standup" | Medium | meetings | +1 hour |
| 👁️ Code Review | "Review PR: " | High | code-review | +1 day |
| 🐛 Bug Report | "Fix: " (with repro steps) | High | bug | — |
| 📅 Weekly Review | "Weekly review" (with checklist) | Medium | review | +1 week |
| ↩️ Follow Up | "Follow up: " | Medium | follow-up | +3 days |
| ⚡ Quick Task | (empty) | — | — | — |

### 🛠️ Features

**TaskTemplateService:**
- CRUD operations for templates
- Apply template → resolved task fields with computed dates
- Create template from existing task
- Reorder via drag
- Built-in templates protected from deletion
- Persistence via UserDefaults (Codable)
- Reset to defaults

**Template Fields:**
- Name, icon, title, description
- Priority (none/low/medium/high/urgent)
- Tags (comma-separated)
- Relative due date (days + hours from creation)
- Relative start date (days from creation)

### 🎨 Views

**TemplatePickerSheet** — Quick selection during task creation:
- Built-in and Custom sections
- Icon + name + title preview
- Priority and tag badges
- Tap to apply and dismiss

**TemplateEditorView** — Create/edit templates:
- Visual icon picker (16 SF Symbols)
- Priority picker
- Relative date steppers
- Form-based layout

**TaskTemplateManagementView** — Settings integration:
- List with edit/delete/reorder
- Built-in badge indicator
- Add new template button

### 🧪 Testing

- **25+ unit tests** covering CRUD, persistence, apply with dates,
  codable roundtrip, reorder, reset, built-in protection

### Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `TaskTemplateService.swift` | 285 | Service with CRUD + persistence |
| `TaskTemplatesView.swift` | 404 | Picker, editor, management views |
| `TaskTemplateServiceTests.swift` | 320 | Comprehensive test suite |

**Total: 1,009 new lines**