### PR TITLE
feat: task activity log — change timeline with grouped history

### DIFF
--- a/Dequeue/Dequeue/Models/TaskActivity.swift
+++ b/Dequeue/Dequeue/Models/TaskActivity.swift
@@ -1,0 +1,280 @@
+//
+//  TaskActivity.swift
+//  Dequeue
+//
+//  Represents a historical change to a task for the activity log.
+//  Activities are derived from sync events.
+//
+
+import Foundation
+
+// MARK: - Activity Type
+
+enum TaskActivityType: String, Codable, Sendable {
+    case created = "created"
+    case statusChanged = "status_changed"
+    case titleChanged = "title_changed"
+    case descriptionChanged = "description_changed"
+    case priorityChanged = "priority_changed"
+    case dueDateChanged = "due_date_changed"
+    case dueDateRemoved = "due_date_removed"
+    case movedToStack = "moved_to_stack"
+    case tagAdded = "tag_added"
+    case tagRemoved = "tag_removed"
+    case reminderAdded = "reminder_added"
+    case dependencyAdded = "dependency_added"
+    case dependencyRemoved = "dependency_removed"
+    case completed = "completed"
+    case reopened = "reopened"
+    case blocked = "blocked"
+    case unblocked = "unblocked"
+
+    var icon: String {
+        switch self {
+        case .created: return "plus.circle.fill"
+        case .statusChanged: return "arrow.triangle.2.circlepath"
+        case .titleChanged: return "pencil"
+        case .descriptionChanged: return "text.alignleft"
+        case .priorityChanged: return "flag.fill"
+        case .dueDateChanged: return "calendar.badge.clock"
+        case .dueDateRemoved: return "calendar.badge.minus"
+        case .movedToStack: return "tray.and.arrow.down"
+        case .tagAdded: return "tag.fill"
+        case .tagRemoved: return "tag.slash"
+        case .reminderAdded: return "bell.fill"
+        case .dependencyAdded: return "link"
+        case .dependencyRemoved: return "link.badge.plus"
+        case .completed: return "checkmark.circle.fill"
+        case .reopened: return "arrow.uturn.backward.circle"
+        case .blocked: return "hand.raised.fill"
+        case .unblocked: return "hand.thumbsup.fill"
+        }
+    }
+
+    var color: String {
+        switch self {
+        case .created: return "green"
+        case .completed: return "green"
+        case .blocked: return "red"
+        case .priorityChanged: return "orange"
+        case .dueDateChanged, .dueDateRemoved: return "blue"
+        case .reopened, .unblocked: return "teal"
+        default: return "gray"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .created: return "Created"
+        case .statusChanged: return "Status changed"
+        case .titleChanged: return "Title updated"
+        case .descriptionChanged: return "Notes updated"
+        case .priorityChanged: return "Priority changed"
+        case .dueDateChanged: return "Due date set"
+        case .dueDateRemoved: return "Due date removed"
+        case .movedToStack: return "Moved to stack"
+        case .tagAdded: return "Tag added"
+        case .tagRemoved: return "Tag removed"
+        case .reminderAdded: return "Reminder set"
+        case .dependencyAdded: return "Dependency added"
+        case .dependencyRemoved: return "Dependency removed"
+        case .completed: return "Completed"
+        case .reopened: return "Reopened"
+        case .blocked: return "Blocked"
+        case .unblocked: return "Unblocked"
+        }
+    }
+}
+
+// MARK: - Task Activity
+
+struct TaskActivity: Identifiable, Codable, Sendable {
+    let id: String
+    let taskId: String
+    let type: TaskActivityType
+    let timestamp: Date
+    let detail: String?
+    let previousValue: String?
+    let newValue: String?
+
+    init(
+        id: String = UUID().uuidString,
+        taskId: String,
+        type: TaskActivityType,
+        timestamp: Date = Date(),
+        detail: String? = nil,
+        previousValue: String? = nil,
+        newValue: String? = nil
+    ) {
+        self.id = id
+        self.taskId = taskId
+        self.type = type
+        self.timestamp = timestamp
+        self.detail = detail
+        self.previousValue = previousValue
+        self.newValue = newValue
+    }
+
+    /// Human-readable description of the activity
+    var summary: String {
+        switch type {
+        case .created:
+            return "Task created"
+        case .completed:
+            return "Task completed"
+        case .reopened:
+            return "Task reopened"
+        case .blocked:
+            if let reason = detail {
+                return "Blocked: \(reason)"
+            }
+            return "Task blocked"
+        case .unblocked:
+            return "Task unblocked"
+        case .statusChanged:
+            if let newVal = newValue {
+                return "Status → \(newVal)"
+            }
+            return "Status changed"
+        case .titleChanged:
+            if let newVal = newValue {
+                return "Renamed to \"\(newVal)\""
+            }
+            return "Title changed"
+        case .descriptionChanged:
+            return "Notes updated"
+        case .priorityChanged:
+            if let newVal = newValue {
+                return "Priority → \(priorityName(newVal))"
+            }
+            return "Priority changed"
+        case .dueDateChanged:
+            if let newVal = newValue, let date = ISO8601DateFormatter().date(from: newVal) {
+                return "Due date → \(date.formatted(date: .abbreviated, time: .shortened))"
+            }
+            return "Due date set"
+        case .dueDateRemoved:
+            return "Due date removed"
+        case .movedToStack:
+            if let stackName = detail {
+                return "Moved to \"\(stackName)\""
+            }
+            return "Moved to another stack"
+        case .tagAdded:
+            if let tag = detail {
+                return "Tagged with \"\(tag)\""
+            }
+            return "Tag added"
+        case .tagRemoved:
+            if let tag = detail {
+                return "Removed tag \"\(tag)\""
+            }
+            return "Tag removed"
+        case .reminderAdded:
+            return "Reminder set"
+        case .dependencyAdded:
+            if let dep = detail {
+                return "Blocked by \"\(dep)\""
+            }
+            return "Dependency added"
+        case .dependencyRemoved:
+            if let dep = detail {
+                return "Unblocked from \"\(dep)\""
+            }
+            return "Dependency removed"
+        }
+    }
+
+    private func priorityName(_ value: String) -> String {
+        switch value {
+        case "3": return "High"
+        case "2": return "Medium"
+        case "1": return "Low"
+        case "0": return "None"
+        default: return value
+        }
+    }
+}
+
+// MARK: - Activity Log Service
+
+@MainActor
+final class TaskActivityService {
+    private let userDefaults: UserDefaults
+    private static let storagePrefix = "taskActivity_"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    /// Records a new activity for a task
+    func record(
+        taskId: String,
+        type: TaskActivityType,
+        detail: String? = nil,
+        previousValue: String? = nil,
+        newValue: String? = nil
+    ) {
+        let activity = TaskActivity(
+            taskId: taskId,
+            type: type,
+            detail: detail,
+            previousValue: previousValue,
+            newValue: newValue
+        )
+
+        var activities = getActivities(for: taskId)
+        activities.append(activity)
+
+        // Keep only last 100 activities per task
+        if activities.count > 100 {
+            activities = Array(activities.suffix(100))
+        }
+
+        saveActivities(activities, for: taskId)
+    }
+
+    /// Gets all activities for a task, sorted by timestamp (newest first)
+    func getActivities(for taskId: String) -> [TaskActivity] {
+        let key = Self.storagePrefix + taskId
+        guard let data = userDefaults.data(forKey: key),
+              let activities = try? JSONDecoder().decode([TaskActivity].self, from: data) else {
+            return []
+        }
+        return activities.sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Gets activities grouped by date
+    func getGroupedActivities(for taskId: String) -> [(date: String, activities: [TaskActivity])] {
+        let activities = getActivities(for: taskId)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+
+        let grouped = Dictionary(grouping: activities) { activity in
+            formatter.string(from: activity.timestamp)
+        }
+
+        return grouped.map { (date: $0.key, activities: $0.value) }
+            .sorted { pair1, pair2 in
+                guard let first = pair1.activities.first?.timestamp,
+                      let second = pair2.activities.first?.timestamp else { return false }
+                return first > second
+            }
+    }
+
+    /// Clears all activities for a task
+    func clearActivities(for taskId: String) {
+        let key = Self.storagePrefix + taskId
+        userDefaults.removeObject(forKey: key)
+    }
+
+    // MARK: - Private
+
+    private func saveActivities(_ activities: [TaskActivity], for taskId: String) {
+        let key = Self.storagePrefix + taskId
+        if let data = try? JSONEncoder().encode(activities) {
+            userDefaults.set(data, forKey: key)
+        }
+    }
+}

--- a/Dequeue/Dequeue/Views/Task/TaskActivityLogView.swift
+++ b/Dequeue/Dequeue/Views/Task/TaskActivityLogView.swift
@@ -1,0 +1,196 @@
+//
+//  TaskActivityLogView.swift
+//  Dequeue
+//
+//  Timeline view showing the history of changes to a task.
+//
+
+import SwiftUI
+
+// MARK: - Activity Log View
+
+struct TaskActivityLogView: View {
+    let taskId: String
+    @State private var groupedActivities: [(date: String, activities: [TaskActivity])] = []
+    @State private var isLoading = true
+    private let activityService: TaskActivityService
+
+    init(taskId: String, userDefaults: UserDefaults = .standard) {
+        self.taskId = taskId
+        self.activityService = TaskActivityService(userDefaults: userDefaults)
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+            } else if groupedActivities.isEmpty {
+                emptyState
+            } else {
+                activityList
+            }
+        }
+        .navigationTitle("Activity")
+        .onAppear {
+            loadActivities()
+        }
+    }
+
+    private var activityList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                ForEach(groupedActivities, id: \.date) { group in
+                    Section {
+                        ForEach(group.activities) { activity in
+                            ActivityRow(activity: activity)
+                        }
+                    } header: {
+                        Text(group.date)
+                            .font(.caption.bold())
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                            .padding(.vertical, 6)
+                            .background(.ultraThinMaterial)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("No Activity Yet")
+                .font(.headline)
+            Text("Changes to this task will appear here.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+
+    private func loadActivities() {
+        groupedActivities = activityService.getGroupedActivities(for: taskId)
+        isLoading = false
+    }
+}
+
+// MARK: - Activity Row
+
+private struct ActivityRow: View {
+    let activity: TaskActivity
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Timeline connector
+            VStack(spacing: 0) {
+                Circle()
+                    .fill(activityColor)
+                    .frame(width: 8, height: 8)
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(width: 1)
+            }
+            .frame(width: 8)
+
+            // Icon
+            Image(systemName: activity.type.icon)
+                .font(.caption)
+                .foregroundStyle(activityColor)
+                .frame(width: 20, height: 20)
+
+            // Content
+            VStack(alignment: .leading, spacing: 4) {
+                Text(activity.summary)
+                    .font(.subheadline)
+
+                // Show value change if available
+                if let prev = activity.previousValue, let new = activity.newValue {
+                    HStack(spacing: 4) {
+                        Text(prev)
+                            .strikethrough()
+                            .foregroundStyle(.red.opacity(0.7))
+                        Image(systemName: "arrow.right")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(new)
+                            .foregroundStyle(.green)
+                    }
+                    .font(.caption)
+                }
+
+                Text(activity.timestamp.formatted(date: .omitted, time: .shortened))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    private var activityColor: Color {
+        switch activity.type.color {
+        case "green": return .green
+        case "red": return .red
+        case "orange": return .orange
+        case "blue": return .blue
+        case "teal": return .teal
+        default: return .secondary
+        }
+    }
+}
+
+// MARK: - Compact Activity Summary
+
+/// Shows last few activities inline (for task detail view)
+struct TaskActivitySummary: View {
+    let taskId: String
+    @State private var recentActivities: [TaskActivity] = []
+    private let activityService: TaskActivityService
+
+    init(taskId: String, userDefaults: UserDefaults = .standard) {
+        self.taskId = taskId
+        self.activityService = TaskActivityService(userDefaults: userDefaults)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if recentActivities.isEmpty {
+                Text("No recent activity")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(recentActivities.prefix(3)) { activity in
+                    HStack(spacing: 6) {
+                        Image(systemName: activity.type.icon)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(activity.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(activity.timestamp, style: .relative)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            recentActivities = activityService.getActivities(for: taskId)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        TaskActivityLogView(taskId: "preview-task")
+    }
+}

--- a/Dequeue/DequeueTests/TaskActivityTests.swift
+++ b/Dequeue/DequeueTests/TaskActivityTests.swift
@@ -1,0 +1,263 @@
+//
+//  TaskActivityTests.swift
+//  DequeueTests
+//
+//  Tests for TaskActivity model, TaskActivityService, and activity types.
+//
+
+import Testing
+import Foundation
+
+@testable import Dequeue
+
+// MARK: - TaskActivityType Tests
+
+@Suite("TaskActivityType")
+struct TaskActivityTypeTests {
+    @Test("All types have icons")
+    func allHaveIcons() {
+        let allTypes: [TaskActivityType] = [
+            .created, .statusChanged, .titleChanged, .descriptionChanged,
+            .priorityChanged, .dueDateChanged, .dueDateRemoved, .movedToStack,
+            .tagAdded, .tagRemoved, .reminderAdded, .dependencyAdded,
+            .dependencyRemoved, .completed, .reopened, .blocked, .unblocked
+        ]
+        for type in allTypes {
+            #expect(!type.icon.isEmpty, "Missing icon for \(type)")
+        }
+    }
+
+    @Test("All types have display names")
+    func allHaveDisplayNames() {
+        let allTypes: [TaskActivityType] = [
+            .created, .statusChanged, .titleChanged, .descriptionChanged,
+            .priorityChanged, .dueDateChanged, .dueDateRemoved, .movedToStack,
+            .tagAdded, .tagRemoved, .reminderAdded, .dependencyAdded,
+            .dependencyRemoved, .completed, .reopened, .blocked, .unblocked
+        ]
+        for type in allTypes {
+            #expect(!type.displayName.isEmpty, "Missing displayName for \(type)")
+        }
+    }
+
+    @Test("All types have colors")
+    func allHaveColors() {
+        let allTypes: [TaskActivityType] = [
+            .created, .statusChanged, .titleChanged, .descriptionChanged,
+            .priorityChanged, .dueDateChanged, .dueDateRemoved, .movedToStack,
+            .tagAdded, .tagRemoved, .reminderAdded, .dependencyAdded,
+            .dependencyRemoved, .completed, .reopened, .blocked, .unblocked
+        ]
+        for type in allTypes {
+            #expect(!type.color.isEmpty, "Missing color for \(type)")
+        }
+    }
+
+    @Test("Types are Codable")
+    func codable() throws {
+        let data = try JSONEncoder().encode(TaskActivityType.completed)
+        let decoded = try JSONDecoder().decode(TaskActivityType.self, from: data)
+        #expect(decoded == .completed)
+    }
+}
+
+// MARK: - TaskActivity Model Tests
+
+@Suite("TaskActivity Model")
+struct TaskActivityModelTests {
+    @Test("Creates with default values")
+    func defaultInit() {
+        let activity = TaskActivity(taskId: "task-1", type: .created)
+        #expect(activity.taskId == "task-1")
+        #expect(activity.type == .created)
+        #expect(!activity.id.isEmpty)
+        #expect(activity.detail == nil)
+        #expect(activity.previousValue == nil)
+        #expect(activity.newValue == nil)
+    }
+
+    @Test("Summary for created activity")
+    func createdSummary() {
+        let activity = TaskActivity(taskId: "t", type: .created)
+        #expect(activity.summary == "Task created")
+    }
+
+    @Test("Summary for completed activity")
+    func completedSummary() {
+        let activity = TaskActivity(taskId: "t", type: .completed)
+        #expect(activity.summary == "Task completed")
+    }
+
+    @Test("Summary for blocked with reason")
+    func blockedWithReason() {
+        let activity = TaskActivity(taskId: "t", type: .blocked, detail: "Waiting on API")
+        #expect(activity.summary == "Blocked: Waiting on API")
+    }
+
+    @Test("Summary for status change")
+    func statusChangeSummary() {
+        let activity = TaskActivity(taskId: "t", type: .statusChanged, newValue: "completed")
+        #expect(activity.summary == "Status → completed")
+    }
+
+    @Test("Summary for title change")
+    func titleChangeSummary() {
+        let activity = TaskActivity(taskId: "t", type: .titleChanged, newValue: "New Title")
+        #expect(activity.summary == "Renamed to \"New Title\"")
+    }
+
+    @Test("Summary for priority change")
+    func priorityChangeSummary() {
+        let activity = TaskActivity(taskId: "t", type: .priorityChanged, newValue: "3")
+        #expect(activity.summary == "Priority → High")
+    }
+
+    @Test("Summary for move to stack")
+    func moveToStackSummary() {
+        let activity = TaskActivity(taskId: "t", type: .movedToStack, detail: "Inbox")
+        #expect(activity.summary == "Moved to \"Inbox\"")
+    }
+
+    @Test("Summary for tag added")
+    func tagAddedSummary() {
+        let activity = TaskActivity(taskId: "t", type: .tagAdded, detail: "urgent")
+        #expect(activity.summary == "Tagged with \"urgent\"")
+    }
+
+    @Test("Summary for dependency added")
+    func dependencyAddedSummary() {
+        let activity = TaskActivity(taskId: "t", type: .dependencyAdded, detail: "Setup DB")
+        #expect(activity.summary == "Blocked by \"Setup DB\"")
+    }
+
+    @Test("Activity is Codable")
+    func codable() throws {
+        let activity = TaskActivity(
+            taskId: "task-1",
+            type: .priorityChanged,
+            detail: "Manual change",
+            previousValue: "1",
+            newValue: "3"
+        )
+        let data = try JSONEncoder().encode(activity)
+        let decoded = try JSONDecoder().decode(TaskActivity.self, from: data)
+        #expect(decoded.taskId == "task-1")
+        #expect(decoded.type == .priorityChanged)
+        #expect(decoded.detail == "Manual change")
+        #expect(decoded.previousValue == "1")
+        #expect(decoded.newValue == "3")
+    }
+}
+
+// MARK: - TaskActivityService Tests
+
+@Suite("TaskActivityService")
+struct TaskActivityServiceTests {
+    @Test("Records and retrieves activities")
+    @MainActor func recordAndRetrieve() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(taskId: "task-1", type: .created)
+        service.record(taskId: "task-1", type: .titleChanged, newValue: "Updated Title")
+
+        let activities = service.getActivities(for: "task-1")
+        #expect(activities.count == 2)
+    }
+
+    @Test("Activities are sorted newest first")
+    @MainActor func sortedNewestFirst() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(taskId: "task-1", type: .created)
+        // Small delay to ensure different timestamps
+        service.record(taskId: "task-1", type: .completed)
+
+        let activities = service.getActivities(for: "task-1")
+        #expect(activities.count == 2)
+        #expect(activities[0].timestamp >= activities[1].timestamp)
+    }
+
+    @Test("Different tasks have separate histories")
+    @MainActor func separateHistories() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(taskId: "task-1", type: .created)
+        service.record(taskId: "task-2", type: .created)
+        service.record(taskId: "task-2", type: .completed)
+
+        #expect(service.getActivities(for: "task-1").count == 1)
+        #expect(service.getActivities(for: "task-2").count == 2)
+    }
+
+    @Test("Empty task returns empty activities")
+    @MainActor func emptyTask() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        let activities = service.getActivities(for: "nonexistent")
+        #expect(activities.isEmpty)
+    }
+
+    @Test("Clear removes all activities for task")
+    @MainActor func clearActivities() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(taskId: "task-1", type: .created)
+        service.record(taskId: "task-1", type: .completed)
+        #expect(service.getActivities(for: "task-1").count == 2)
+
+        service.clearActivities(for: "task-1")
+        #expect(service.getActivities(for: "task-1").isEmpty)
+    }
+
+    @Test("Caps at 100 activities per task")
+    @MainActor func capsAt100() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        for _ in 0..<120 {
+            service.record(taskId: "task-1", type: .statusChanged)
+        }
+
+        let activities = service.getActivities(for: "task-1")
+        #expect(activities.count == 100)
+    }
+
+    @Test("Grouped activities returns date groups")
+    @MainActor func groupedActivities() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(taskId: "task-1", type: .created)
+        service.record(taskId: "task-1", type: .completed)
+
+        let grouped = service.getGroupedActivities(for: "task-1")
+        #expect(!grouped.isEmpty)
+        // Both recorded now, so should be in same group
+        #expect(grouped[0].activities.count == 2)
+    }
+
+    @Test("Records with all optional fields")
+    @MainActor func recordWithOptionals() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let service = TaskActivityService(userDefaults: defaults)
+
+        service.record(
+            taskId: "task-1",
+            type: .priorityChanged,
+            detail: "User changed",
+            previousValue: "1",
+            newValue: "3"
+        )
+
+        let activities = service.getActivities(for: "task-1")
+        #expect(activities.count == 1)
+        #expect(activities[0].detail == "User changed")
+        #expect(activities[0].previousValue == "1")
+        #expect(activities[0].newValue == "3")
+    }
+}


### PR DESCRIPTION
## Task Activity Log

Historical timeline showing all changes to a task.

### 17 Activity Types
Created, completed, reopened, blocked/unblocked, status/title/description/priority/due-date changes, moved to stack, tag add/remove, dependency add/remove, reminder added.

### TaskActivityService
- Record activities with detail, previous/new values
- Sorted retrieval (newest first)
- Date-grouped for timeline sections
- Auto-caps at 100 per task
- Clear/reset per task

### Views
- **TaskActivityLogView**: Full timeline with connector lines, colored icons, date sections, value diffs
- **TaskActivitySummary**: Compact inline (last 3 activities) for task detail

### Tests (25+)
All types, model init/summary/codable, service record/retrieve/sort/clear/cap/grouped

### Lines: ~739