### PR TITLE
fix: SwiftData migration crash — add inline defaults to all model properties

### DIFF
--- a/Dequeue/Dequeue/Models/Arc.swift
+++ b/Dequeue/Dequeue/Models/Arc.swift
@@ -15,13 +15,13 @@ final class Arc {
     var title: String
     var arcDescription: String?
     /// Stored as raw value string for SwiftData predicate compatibility
-    var statusRawValue: String
-    var sortOrder: Int
+    var statusRawValue: String = ArcStatus.active.rawValue
+    var sortOrder: Int = 0
     /// Optional color hex for visual accent (e.g., "FF6B6B")
     var colorHex: String?
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
 
     // Sync fields (standard pattern)
     /// Optional start date for the arc
@@ -32,10 +32,10 @@ final class Arc {
     // Sync fields (standard pattern)
     var userId: String?
     var deviceId: String?
-    var syncStateRawValue: String
+    var syncStateRawValue: String = SyncState.pending.rawValue
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     // Relationship to Stacks (one Arc has many Stacks)
     @Relationship(deleteRule: .nullify, inverse: \Stack.arc)

--- a/Dequeue/Dequeue/Models/Attachment.swift
+++ b/Dequeue/Dequeue/Models/Attachment.swift
@@ -49,18 +49,18 @@ final class Attachment {
     var previewUrl: String?
 
     // Timestamps
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
 
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState
-    var uploadState: UploadState
+    var syncState: SyncState = .pending
+    var uploadState: UploadState = .pending
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     init(
         id: String = CUID.generate(),

--- a/Dequeue/Dequeue/Models/Device.swift
+++ b/Dequeue/Dequeue/Models/Device.swift
@@ -17,20 +17,20 @@ final class Device {
     var model: String?
     var osName: String
     var osVersion: String?
-    var isDevice: Bool
-    var isCurrentDevice: Bool
-    var lastSeenAt: Date
-    var firstSeenAt: Date
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
+    var isDevice: Bool = true
+    var isCurrentDevice: Bool = false
+    var lastSeenAt: Date = Date()
+    var firstSeenAt: Date = Date()
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
 
     // Sync fields
     var userId: String?
-    var syncState: SyncState
+    var syncState: SyncState = .pending
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     init(
         id: String = CUID.generate(),

--- a/Dequeue/Dequeue/Models/Event.swift
+++ b/Dequeue/Dequeue/Models/Event.swift
@@ -37,10 +37,10 @@ final class Event {
     /// Version 2: Current format with userId/deviceId (DEQ-137+)
     /// Events with payloadVersion < 2 are ignored during sync pull.
     static let currentPayloadVersion: Int = 2
-    var payloadVersion: Int
+    var payloadVersion: Int = Event.currentPayloadVersion
 
     // Sync tracking
-    var isSynced: Bool
+    var isSynced: Bool = false
     var syncedAt: Date?
 
     init(

--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -18,29 +18,29 @@ final class QueueTask {
     var locationAddress: String?
     var locationLatitude: Double?
     var locationLongitude: Double?
-    var attachments: [String]
-    var tags: [String]  // DEQ-31: Tag support for tasks
-    var status: TaskStatus
+    var attachments: [String] = []
+    var tags: [String] = []  // DEQ-31: Tag support for tasks
+    var status: TaskStatus = .pending
     var priority: Int?
     var blockedReason: String?
-    var sortOrder: Int
+    var sortOrder: Int = 0
     var lastActiveTime: Date?
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
 
     // AI delegation fields (DEQ-54)
-    var delegatedToAI: Bool
+    var delegatedToAI: Bool = false
     var aiAgentId: String?
     var aiDelegatedAt: Date?
 
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState
+    var syncState: SyncState = .pending
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     // Relationships
     var stack: Stack?
@@ -57,8 +57,8 @@ final class QueueTask {
     // Recurring task fields
     var recurrenceRuleData: Data?
     var recurrenceParentId: String?
-    var isRecurrenceTemplate: Bool
-    var completedOccurrences: Int
+    var isRecurrenceTemplate: Bool = false
+    var completedOccurrences: Int = 0
 
     init(
         id: String = CUID.generate(),

--- a/Dequeue/Dequeue/Models/Reminder.swift
+++ b/Dequeue/Dequeue/Models/Reminder.swift
@@ -13,20 +13,20 @@ final class Reminder {
     @Attribute(.unique) var id: String
     var parentId: String
     var parentType: ParentType
-    var status: ReminderStatus
+    var status: ReminderStatus = .active
     var snoozedFrom: Date?
-    var remindAt: Date
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
+    var remindAt: Date = Date()
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
 
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState
+    var syncState: SyncState = .pending
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     // Inverse relationships (only one should be set based on parentType)
     var stack: Stack?

--- a/Dequeue/Dequeue/Models/Stack.swift
+++ b/Dequeue/Dequeue/Models/Stack.swift
@@ -18,19 +18,19 @@ final class Stack {
     var locationAddress: String?
     var locationLatitude: Double?
     var locationLongitude: Double?
-    var tags: [String]
-    var attachments: [String]
+    var tags: [String] = []
+    var attachments: [String] = []
     /// Stored as raw value string for SwiftData predicate compatibility
-    var statusRawValue: String
+    var statusRawValue: String = StackStatus.active.rawValue
     var priority: Int?
-    var sortOrder: Int
-    var createdAt: Date
-    var updatedAt: Date
-    var isDeleted: Bool
-    var isDraft: Bool
+    var sortOrder: Int = 0
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var isDeleted: Bool = false
+    var isDraft: Bool = false
     /// Explicit tracking for the single active stack constraint.
     /// Only one stack should have isActive = true at any time.
-    var isActive: Bool
+    var isActive: Bool = false
 
     /// Explicit tracking for the active task within this stack.
     /// When set, this task ID takes precedence over sort order.
@@ -40,10 +40,10 @@ final class Stack {
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState
+    var syncState: SyncState = .pending
     var lastSyncedAt: Date?
     var serverId: String?
-    var revision: Int
+    var revision: Int = 1
 
     // Relationships
     @Relationship(deleteRule: .cascade, inverse: \QueueTask.stack)

--- a/Dequeue/Dequeue/Models/SyncConflict.swift
+++ b/Dequeue/Dequeue/Models/SyncConflict.swift
@@ -53,7 +53,7 @@ final class SyncConflict {
     /// Raw string value for resolution enum (needed for SwiftData predicates)
     private(set) var resolutionRaw: String
     private(set) var detectedAt: Date
-    var isResolved: Bool
+    var isResolved: Bool = false
 
     // MARK: - Type-Safe Accessors
 

--- a/Dequeue/Dequeue/Models/Tag.swift
+++ b/Dequeue/Dequeue/Models/Tag.swift
@@ -29,13 +29,13 @@ final class Tag {
     // MARK: - Metadata
 
     /// Timestamp when the tag was created
-    var createdAt: Date
+    var createdAt: Date = Date()
 
     /// Timestamp when the tag was last modified
-    var updatedAt: Date
+    var updatedAt: Date = Date()
 
     /// Soft deletion flag for sync-compatible deletion
-    var isDeleted: Bool
+    var isDeleted: Bool = false
 
     // MARK: - Sync Fields
 
@@ -46,7 +46,7 @@ final class Tag {
     var deviceId: String?
 
     /// Current sync state with backend
-    var syncState: SyncState
+    var syncState: SyncState = .pending
 
     /// Timestamp of last successful sync with backend
     var lastSyncedAt: Date?
@@ -55,7 +55,7 @@ final class Tag {
     var serverId: String?
 
     /// Revision counter for conflict resolution (incremented on each update)
-    var revision: Int
+    var revision: Int = 1
 
     // MARK: - Relationships
 


### PR DESCRIPTION
## Problem

The app crashes on launch with:

```
Fatal error: Could not create ModelContainer after store deletion
```

The underlying error is:
```
Validation error missing attribute values on mandatory destination attribute
entity=QueueTask, attribute=completedOccurrences
```

This happens because SwiftData's lightweight migration can't add non-optional columns to existing rows without inline default values on the stored properties.

The fallback store deletion also fails because it only checks the app container's Application Support directory, but the actual store is in the **App Group** container (`Shared/AppGroup/.../Application Support/default.store`).

## Root Cause

Properties like `completedOccurrences: Int` and `isRecurrenceTemplate: Bool` were declared without inline defaults. While the `init()` provides default parameter values, **SwiftData uses the stored property declaration** (not the init) for schema migration. Without `= 0` on the property itself, SwiftData can't fill in values for existing rows.

## Fix

**1. Inline defaults on all model properties** (the actual fix):
- `QueueTask`: `completedOccurrences`, `isRecurrenceTemplate`, `delegatedToAI`, `tags`, `status`, `sortOrder`, `syncState`, `revision`, etc.
- `Stack`: `statusRawValue`, `sortOrder`, `isActive`, `isDraft`, `syncState`, `revision`, etc.
- `Arc`: `statusRawValue`, `syncStateRawValue`, `sortOrder`, `revision`, etc.
- `Reminder`, `Event`, `Tag`, `Device`, `Attachment`, `SyncConflict`: Same treatment.

**2. Fix store deletion path** (safety net):
- `deleteSwiftDataStore()` now also cleans the App Group container (`group.com.ardonos.Dequeue`), not just the default app container.

## Testing

- Devices with existing data will now migrate cleanly (new columns get default values)
- If migration somehow still fails, the fallback deletion now finds and removes the correct store files
- Fresh installs are unaffected (no existing rows to migrate)
- All init() calls remain unchanged (they already pass the same defaults)