### PR TITLE
fix: use fully qualified enum names in SwiftData model defaults

### DIFF
--- a/Dequeue/Dequeue/Models/Attachment.swift
+++ b/Dequeue/Dequeue/Models/Attachment.swift
@@ -56,8 +56,8 @@ final class Attachment {
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState = .pending
-    var uploadState: UploadState = .pending
+    var syncState: SyncState = SyncState.pending
+    var uploadState: UploadState = UploadState.pending
     var lastSyncedAt: Date?
     var serverId: String?
     var revision: Int = 1

--- a/Dequeue/Dequeue/Models/Device.swift
+++ b/Dequeue/Dequeue/Models/Device.swift
@@ -27,7 +27,7 @@ final class Device {
 
     // Sync fields
     var userId: String?
-    var syncState: SyncState = .pending
+    var syncState: SyncState = SyncState.pending
     var lastSyncedAt: Date?
     var serverId: String?
     var revision: Int = 1

--- a/Dequeue/Dequeue/Models/QueueTask.swift
+++ b/Dequeue/Dequeue/Models/QueueTask.swift
@@ -20,7 +20,7 @@ final class QueueTask {
     var locationLongitude: Double?
     var attachments: [String] = []
     var tags: [String] = []  // DEQ-31: Tag support for tasks
-    var status: TaskStatus = .pending
+    var status: TaskStatus = TaskStatus.pending
     var priority: Int?
     var blockedReason: String?
     var sortOrder: Int = 0
@@ -37,7 +37,7 @@ final class QueueTask {
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState = .pending
+    var syncState: SyncState = SyncState.pending
     var lastSyncedAt: Date?
     var serverId: String?
     var revision: Int = 1

--- a/Dequeue/Dequeue/Models/Reminder.swift
+++ b/Dequeue/Dequeue/Models/Reminder.swift
@@ -13,7 +13,7 @@ final class Reminder {
     @Attribute(.unique) var id: String
     var parentId: String
     var parentType: ParentType
-    var status: ReminderStatus = .active
+    var status: ReminderStatus = ReminderStatus.active
     var snoozedFrom: Date?
     var remindAt: Date = Date()
     var createdAt: Date = Date()
@@ -23,7 +23,7 @@ final class Reminder {
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState = .pending
+    var syncState: SyncState = SyncState.pending
     var lastSyncedAt: Date?
     var serverId: String?
     var revision: Int = 1

--- a/Dequeue/Dequeue/Models/Stack.swift
+++ b/Dequeue/Dequeue/Models/Stack.swift
@@ -40,7 +40,7 @@ final class Stack {
     // Sync fields
     var userId: String?
     var deviceId: String?
-    var syncState: SyncState = .pending
+    var syncState: SyncState = SyncState.pending
     var lastSyncedAt: Date?
     var serverId: String?
     var revision: Int = 1

--- a/Dequeue/Dequeue/Models/Tag.swift
+++ b/Dequeue/Dequeue/Models/Tag.swift
@@ -46,7 +46,7 @@ final class Tag {
     var deviceId: String?
 
     /// Current sync state with backend
-    var syncState: SyncState = .pending
+    var syncState: SyncState = SyncState.pending
 
     /// Timestamp of last successful sync with backend
     var lastSyncedAt: Date?


### PR DESCRIPTION
Follow-up to PR #335. The `@Model` macro loses type context when generating backing storage code, causing `type 'Any?' has no member 'pending'` build errors. Using fully qualified names (`SyncState.pending` instead of `.pending`) fixes this.

Changes: QueueTask, Attachment, Device, Reminder, Stack, Tag — all enum-typed stored property defaults now use fully qualified type names.