### PR TITLE
fix: add Appfile for TestFlight build number lookup

### DIFF
--- a/Dequeue/fastlane/Appfile
+++ b/Dequeue/fastlane/Appfile
@@ -1,0 +1,4 @@
+app_identifier("com.ardonos.Dequeue")
+apple_id("mail@victorquinn.com")
+team_id("9HE7YP99YB")
+itc_team_id("9HE7YP99YB")


### PR DESCRIPTION
Adds fastlane Appfile with app_identifier so `latest_testflight_build_number` can query TestFlight. Without this, the beta lane fails with 'No value found for app_identifier'.