### PR TITLE
fix: target iOS for TestFlight build, guard Sentry profiling

### DIFF
--- a/Dequeue/Dequeue/Services/ErrorReportingService.swift
+++ b/Dequeue/Dequeue/Services/ErrorReportingService.swift
@@ -156,12 +156,14 @@ enum ErrorReportingService {
                     ]
 
                     // ============================================
-                    // PROFILING (CPU profiling for performance issues)
+                    // PROFILING (CPU profiling for performance issues, iOS only)
                     // ============================================
+                    #if os(iOS)
                     options.configureProfiling = { profiling in
                         profiling.lifecycle = .trace            // Profile during traces
                         profiling.sessionSampleRate = 1.0       // 100% of sessions
                     }
+                    #endif
 
                     // ============================================
                     // SESSION REPLAY (video-like playback of sessions, iOS only)

--- a/Dequeue/fastlane/Fastfile
+++ b/Dequeue/fastlane/Fastfile
@@ -44,6 +44,7 @@ platform :ios do
       project: "Dequeue.xcodeproj",
       scheme: "Dequeue",
       configuration: "Release",
+      destination: "generic/platform=iOS",
       export_method: "app-store",
       output_directory: "./build",
       output_name: "Dequeue.ipa"


### PR DESCRIPTION
Two fixes for TestFlight CI:

1. **Fastfile**: Add `destination: 'generic/platform=iOS'` to `build_app` — fastlane was auto-selecting visionOS, causing build failures since Sentry profiling API isn't available there
2. **ErrorReportingService**: Wrap `configureProfiling` in `#if os(iOS)` platform guard

This unblocks the TestFlight pipeline for iOS builds. macOS and visionOS support will come later.