### PR TITLE
fix: remove full-screen sync overlay that blocks app usage

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -189,41 +189,15 @@ struct RootView: View {
         NotificationService(modelContext: modelContext)
     }
 
-    /// Show loading on fresh devices until initial sync completes.
-    /// Uses view model as primary source of truth with synchronous UserDefaults fallback
-    /// when view model hasn't initialized yet (first render).
-    private var shouldShowInitialSyncLoading: Bool {
-        guard authService.isAuthenticated else { return false }
-        // Use view model if available; fall back to checking checkpoint directly
-        if let viewModel = syncStatusViewModel {
-            return viewModel.isInitialSyncInProgress
-        }
-        // Fallback for first render before view model initializes
-        return UserDefaults.standard.string(forKey: "com.dequeue.lastSyncCheckpoint") == nil
-    }
-
-    private var initialSyncEventsProcessed: Int {
-        syncStatusViewModel?.initialSyncEventsProcessed ?? 0
-    }
-
-    private var initialSyncTotalEvents: Int? {
-        guard let total = syncStatusViewModel?.initialSyncTotalEvents, total > 0 else { return nil }
-        return total
-    }
+    // Initial sync loading removed — sync happens in the background.
+    // Users should never be blocked from using the app while syncing.
 
     var body: some View {
         Group {
             if authService.isLoading {
                 SplashView()
             } else if authService.isAuthenticated {
-                if shouldShowInitialSyncLoading {
-                    InitialSyncLoadingView(
-                        eventsProcessed: initialSyncEventsProcessed,
-                        totalEvents: initialSyncTotalEvents
-                    )
-                } else {
-                    MainTabView()
-                }
+                MainTabView()
             } else {
                 AuthView()
             }
@@ -239,7 +213,6 @@ struct RootView: View {
         }
         .animation(.easeInOut, value: authService.isLoading)
         .animation(.easeInOut, value: authService.isAuthenticated)
-        .animation(.easeInOut, value: shouldShowInitialSyncLoading)
         .alert("Sync Connection Issue", isPresented: $showSyncError) {
             Button("OK") {
                 showSyncError = false

--- a/Dequeue/Dequeue/Views/Stacks/StacksView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/StacksView.swift
@@ -40,17 +40,21 @@ struct StacksView: View {
 
     var body: some View {
         NavigationStack {
-            Group {
+            VStack(spacing: 0) {
                 if let syncStatus = syncStatusViewModel, syncStatus.isInitialSyncInProgress {
-                    // Show loading view during initial sync to prevent flickering (DEQ-240)
-                    InitialSyncLoadingView(
-                        eventsProcessed: syncStatus.initialSyncEventsProcessed,
-                        totalEvents: syncStatus.initialSyncTotalEvents > 0 ? syncStatus.initialSyncTotalEvents : nil
-                    )
-                } else {
-                    // Show normal stacks content after initial sync completes
-                    stacksContent
+                    // Show a subtle banner during initial sync instead of blocking the UI
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Syncing your data...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
                 }
+                stacksContent
             }
             .navigationTitle("Stacks")
             .toolbar {


### PR DESCRIPTION
The `InitialSyncLoadingView` was hijacking the entire screen during initial sync, making the app completely unresponsive. This is terrible UX — users should never be blocked from using the app while data syncs in the background.

**Changes:**
- **DequeueApp.swift**: Remove the sync loading gate — authenticated users go straight to `MainTabView()`
- **StacksView.swift**: Replace full-screen blocker with a subtle inline banner (small spinner + 'Syncing your data...' text)
- Sync continues in the background; users can interact with the app immediately

**Before:** Full-screen 'Syncing your tasks / Connecting to server...' blocks all interaction
**After:** App loads immediately with a small non-intrusive banner during sync