### PR TITLE
fix: resolve Swift 6 strict concurrency errors in test target

### DIFF
--- a/Dequeue/Dequeue/Configuration.swift
+++ b/Dequeue/Dequeue/Configuration.swift
@@ -39,7 +39,8 @@ enum Configuration {
 
     /// Distributed tracing targets - only send trace headers to our own backend
     /// This enables connecting mobile traces to backend traces in Sentry
-    static let tracePropagationTargets: [String] = [
+    /// Explicitly nonisolated: accessed from background threads during Sentry configuration
+    nonisolated static let tracePropagationTargets: [String] = [
         "api.dequeue.app",
         "sync.ardonos.com",
         "localhost",
@@ -77,15 +78,18 @@ enum Configuration {
 
     // MARK: - App Info
 
-    static let appVersion: String = {
+    /// Explicitly nonisolated: accessed from background threads during Sentry configuration
+    nonisolated static let appVersion: String = {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
     }()
 
-    static let buildNumber: String = {
+    /// Explicitly nonisolated: accessed from background threads during Sentry configuration
+    nonisolated static let buildNumber: String = {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
     }()
 
-    static let bundleIdentifier: String = {
+    /// Explicitly nonisolated: accessed from background threads during Sentry configuration
+    nonisolated static let bundleIdentifier: String = {
         Bundle.main.bundleIdentifier ?? "com.ardonos.Dequeue"
     }()
 }

--- a/Dequeue/Dequeue/Intents/DequeueAppIntents.swift
+++ b/Dequeue/Dequeue/Intents/DequeueAppIntents.swift
@@ -25,7 +25,6 @@ struct StackEntity: AppEntity {
     var status: String
 
     var displayRepresentation: DisplayRepresentation {
-        let subtitle: String
         if isActive {
             return DisplayRepresentation(
                 title: "⚡ \(title)",

--- a/Dequeue/Dequeue/Services/CertificatePinningDelegate.swift
+++ b/Dequeue/Dequeue/Services/CertificatePinningDelegate.swift
@@ -108,7 +108,7 @@ nonisolated enum CertificatePinningError: LocalizedError, Sendable {
 /// than leaf certificates, because Let's Encrypt leaf certificates rotate every 90 days.
 final class CertificatePinningDelegate: NSObject, URLSessionDelegate, Sendable {
     // nonisolated(unsafe) because Logger is thread-safe but not marked Sendable in current SDK
-    nonisolated(unsafe) private static let pinLogger = Logger(
+    nonisolated private static let pinLogger = Logger(
         subsystem: "com.dequeue", category: "CertificatePinning"
     )
 
@@ -227,7 +227,7 @@ final class CertificatePinningDelegate: NSObject, URLSessionDelegate, Sendable {
 /// for any connections to Dequeue API servers.
 nonisolated enum PinnedURLSession {
     // nonisolated(unsafe) to allow lazy init from any context
-    nonisolated(unsafe) private static let _shared: URLSession = makeSession()
+    nonisolated private static let _shared: URLSession = makeSession()
 
     /// Shared URLSession with certificate pinning enabled for production domains.
     nonisolated static var shared: URLSession { _shared }
@@ -289,7 +289,7 @@ nonisolated enum PinnedURLSession {
 /// All methods are nonisolated and safe to call from any URLSession delegate callback thread.
 nonisolated enum CertificatePinningValidator {
     // nonisolated(unsafe) to avoid MainActor inference on static stored property
-    nonisolated(unsafe) private static let config: CertificatePinningConfiguration = {
+    nonisolated private static let config: CertificatePinningConfiguration = {
         #if DEBUG
         return .debug
         #else
@@ -297,7 +297,7 @@ nonisolated enum CertificatePinningValidator {
         #endif
     }()
 
-    nonisolated(unsafe) private static let validatorLogger = Logger(
+    nonisolated private static let validatorLogger = Logger(
         subsystem: "com.dequeue", category: "CertificatePinning"
     )
 

--- a/Dequeue/Dequeue/Services/FocusTimerService.swift
+++ b/Dequeue/Dequeue/Services/FocusTimerService.swift
@@ -12,7 +12,7 @@ import Combine
 import UserNotifications
 import os.log
 
-private let logger = Logger(subsystem: "com.dequeue", category: "FocusTimer")
+private nonisolated let logger = Logger(subsystem: "com.dequeue", category: "FocusTimer")
 
 // MARK: - Timer Phase
 

--- a/Dequeue/Dequeue/Services/SpotlightIndexer.swift
+++ b/Dequeue/Dequeue/Services/SpotlightIndexer.swift
@@ -5,7 +5,7 @@
 //  CoreSpotlight indexing for system-wide search of stacks and tasks
 //
 
-import CoreSpotlight
+@preconcurrency import CoreSpotlight
 import SwiftData
 import os.log
 
@@ -209,7 +209,6 @@ final class SpotlightIndexer {
         var parts: [String] = []
 
         let allTasks = stack.tasks.filter { !$0.isDeleted }
-        let pending = allTasks.filter { $0.status == .pending }
         let completed = allTasks.filter { $0.status == .completed }
 
         if allTasks.isEmpty {

--- a/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
+++ b/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
@@ -50,7 +50,7 @@ internal final class SyncStatusViewModel {
     private let eventService: EventService
     private var syncManager: SyncManager?
     // nonisolated(unsafe) allows access from deinit for cleanup with @Observable.
-    // nonisolated(unsafe) needed for mutable property accessed in deinit
+    // Must use unsafe variant because this is a mutable stored property.
     nonisolated(unsafe) private var updateTask: Task<Void, Never>?
     private var previousPendingCount: Int = 0
 

--- a/Dequeue/Dequeue/Views/Components/AccessibilityModifiers.swift
+++ b/Dequeue/Dequeue/Views/Components/AccessibilityModifiers.swift
@@ -82,9 +82,10 @@ struct TaskAccessibilityModifier: ViewModifier {
     }
 
     private var accessibilityTraits: AccessibilityTraits {
-        var traits: AccessibilityTraits = .isButton
-        if isActive { traits.insert(.isSelected) }
-        return traits
+        if isActive {
+            return [.isButton, .isSelected]
+        }
+        return .isButton
     }
 }
 

--- a/Dequeue/Dequeue/Views/Components/DragDropModifiers.swift
+++ b/Dequeue/Dequeue/Views/Components/DragDropModifiers.swift
@@ -14,9 +14,9 @@ import UniformTypeIdentifiers
 
 extension UTType {
     /// Custom UTType for Dequeue task references (task ID)
-    nonisolated(unsafe) static let dequeueTask = UTType(exportedAs: "app.dequeue.task")
+    nonisolated static let dequeueTask = UTType(exportedAs: "app.dequeue.task")
     /// Custom UTType for Dequeue stack references (stack ID)
-    nonisolated(unsafe) static let dequeueStack = UTType(exportedAs: "app.dequeue.stack")
+    nonisolated static let dequeueStack = UTType(exportedAs: "app.dequeue.stack")
 }
 
 // MARK: - Task Transferable

--- a/Dequeue/Dequeue/Views/Components/MarkdownRenderer.swift
+++ b/Dequeue/Dequeue/Views/Components/MarkdownRenderer.swift
@@ -45,7 +45,7 @@ struct MarkdownRenderer {
     /// Renders full markdown including block elements (headers, lists, etc.)
     static func renderFull(_ markdown: String) -> AttributedString {
         do {
-            var result = try AttributedString(markdown: markdown, options: .init(
+            let result = try AttributedString(markdown: markdown, options: .init(
                 allowsExtendedAttributes: true,
                 interpretedSyntax: .full,
                 failurePolicy: .returnPartiallyParsedIfPossible

--- a/Dequeue/DequeueTests/AccessibilityTests.swift
+++ b/Dequeue/DequeueTests/AccessibilityTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import SwiftUI
 import SwiftData
 @testable import Dequeue
 

--- a/Dequeue/DequeueTests/ActivityFeedTests.swift
+++ b/Dequeue/DequeueTests/ActivityFeedTests.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Activity Feed Tests", .serialized)
+@MainActor
 struct ActivityFeedTests {
     // MARK: - Event Type Filtering
 

--- a/Dequeue/DequeueTests/AnalyticsServiceTests.swift
+++ b/Dequeue/DequeueTests/AnalyticsServiceTests.swift
@@ -54,6 +54,7 @@ private func makeAnalyticsTask(
 // MARK: - Summary Tests
 
 @Suite("ProductivitySummary")
+@MainActor
 struct ProductivitySummaryTests {
     @Test("Completion rate calculation")
     func completionRate() {
@@ -98,6 +99,7 @@ struct ProductivitySummaryTests {
 // MARK: - Analytics Service Tests
 
 @Suite("AnalyticsService")
+@MainActor
 struct AnalyticsServiceTests {
     @Test("Summary counts tasks correctly")
     @MainActor func summaryCountsCorrectly() throws {
@@ -304,6 +306,7 @@ struct AnalyticsServiceTests {
 // MARK: - Model Tests
 
 @Suite("Analytics Models")
+@MainActor
 struct AnalyticsModelTests {
     @Test("DailyCompletionData has correct dayLabel")
     func dailyDataLabel() {

--- a/Dequeue/DequeueTests/AppIntentsTests.swift
+++ b/Dequeue/DequeueTests/AppIntentsTests.swift
@@ -126,6 +126,7 @@ struct TaskEntityTests {
 // MARK: - Intent Priority Tests
 
 @Suite("IntentPriority")
+@MainActor
 struct IntentPriorityTests {
     @Test("Priority raw values match expected integers")
     func priorityRawValues() {
@@ -147,6 +148,7 @@ struct IntentPriorityTests {
 // MARK: - Intent Error Tests
 
 @Suite("IntentError")
+@MainActor
 struct IntentErrorTests {
     @Test("All error cases have localized descriptions")
     func errorDescriptions() {

--- a/Dequeue/DequeueTests/AppThemeTests.swift
+++ b/Dequeue/DequeueTests/AppThemeTests.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @testable import Dequeue
 
 @Suite("AppTheme Tests")
+@MainActor
 struct AppThemeTests {
     // MARK: - Raw Value Tests
 

--- a/Dequeue/DequeueTests/AttachmentFileCacheTests.swift
+++ b/Dequeue/DequeueTests/AttachmentFileCacheTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("AttachmentFileCache Tests")
+@MainActor
 struct AttachmentFileCacheTests {
     // MARK: - FileCacheError Tests
 

--- a/Dequeue/DequeueTests/BatchOperationTests.swift
+++ b/Dequeue/DequeueTests/BatchOperationTests.swift
@@ -12,6 +12,7 @@ import Foundation
 // MARK: - BatchOperation Tests
 
 @Suite("BatchOperation Model")
+@MainActor
 struct BatchOperationModelTests {
 
     @Test("All operations have system images")
@@ -57,6 +58,7 @@ struct BatchOperationModelTests {
 // MARK: - BatchOperationResult Tests
 
 @Suite("BatchOperationResult")
+@MainActor
 struct BatchOperationResultTests {
 
     @Test("Full success result")
@@ -256,6 +258,7 @@ struct BatchSelectionManagerTests {
 // MARK: - Available Operations Tests
 
 @Suite("Available Operations Logic")
+@MainActor
 struct AvailableOperationsTests {
 
     @Test("Pending tasks have complete option")

--- a/Dequeue/DequeueTests/BatchServiceTests.swift
+++ b/Dequeue/DequeueTests/BatchServiceTests.swift
@@ -96,6 +96,7 @@ private func makeHTTPResponse(statusCode: Int = 200) -> HTTPURLResponse {
 // MARK: - Batch Complete Tests
 
 @Suite("BatchService - Batch Complete")
+@MainActor
 struct BatchCompleteTests {
     @Test("Successfully completes multiple tasks")
     @MainActor
@@ -198,6 +199,7 @@ struct BatchCompleteTests {
 // MARK: - Batch Move Tests
 
 @Suite("BatchService - Batch Move")
+@MainActor
 struct BatchMoveTests {
     @Test("Successfully moves tasks to target stack")
     @MainActor
@@ -253,6 +255,7 @@ struct BatchMoveTests {
 // MARK: - Batch Delete Tests
 
 @Suite("BatchService - Batch Delete")
+@MainActor
 struct BatchDeleteTests {
     @Test("Successfully deletes multiple tasks")
     @MainActor
@@ -286,6 +289,7 @@ struct BatchDeleteTests {
 // MARK: - Validation Tests
 
 @Suite("BatchService - Validation")
+@MainActor
 struct BatchValidationTests {
     @Test("Rejects empty task IDs")
     @MainActor
@@ -363,6 +367,7 @@ struct BatchValidationTests {
 // MARK: - Error Handling Tests
 
 @Suite("BatchService - Error Handling")
+@MainActor
 struct BatchErrorHandlingTests {
     @Test("Handles server error responses")
     @MainActor
@@ -443,6 +448,7 @@ struct BatchErrorHandlingTests {
 // MARK: - Model Tests
 
 @Suite("BatchService - Models")
+@MainActor
 struct BatchModelTests {
     @Test("BatchResponse correctly identifies full success")
     func testFullSuccess() {

--- a/Dequeue/DequeueTests/CUIDTests.swift
+++ b/Dequeue/DequeueTests/CUIDTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("CUID Tests")
+@MainActor
 struct CUIDTests {
     // MARK: - Generation Tests
 

--- a/Dequeue/DequeueTests/CalendarServiceTests.swift
+++ b/Dequeue/DequeueTests/CalendarServiceTests.swift
@@ -6,8 +6,10 @@
 //
 
 import XCTest
+import EventKit
 @testable import Dequeue
 
+@MainActor
 final class CalendarServiceTests: XCTestCase {
 
     // MARK: - CalendarEvent Model Tests

--- a/Dequeue/DequeueTests/ColorHexTests.swift
+++ b/Dequeue/DequeueTests/ColorHexTests.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @testable import Dequeue
 
 @Suite("Color+Hex Tests")
+@MainActor
 struct ColorHexTests {
     // MARK: - Successful Parsing
 

--- a/Dequeue/DequeueTests/DataImportTests.swift
+++ b/Dequeue/DequeueTests/DataImportTests.swift
@@ -12,6 +12,7 @@ import Foundation
 // MARK: - ImportFormat Tests
 
 @Suite("ImportFormat")
+@MainActor
 struct ImportFormatTests {
 
     @Test("All formats have extensions")
@@ -37,6 +38,7 @@ struct ImportFormatTests {
 // MARK: - CSV Parser Tests
 
 @Suite("CSV Parser")
+@MainActor
 struct CSVParserTests {
 
     @Test("Basic CSV with title column")
@@ -166,6 +168,7 @@ struct CSVParserTests {
 // MARK: - JSON Parser Tests
 
 @Suite("JSON Parser")
+@MainActor
 struct JSONParserTests {
 
     @Test("Parse JSON array of tasks")
@@ -252,6 +255,7 @@ struct JSONParserTests {
 // MARK: - Plain Text Parser Tests
 
 @Suite("Plain Text Parser")
+@MainActor
 struct PlainTextParserTests {
 
     @Test("Parse simple lines")
@@ -342,6 +346,7 @@ struct PlainTextParserTests {
 // MARK: - Helper Function Tests
 
 @Suite("Import Helpers")
+@MainActor
 struct ImportHelperTests {
 
     @Test("Parse priority strings")
@@ -377,6 +382,7 @@ struct ImportHelperTests {
 // MARK: - ImportResult Tests
 
 @Suite("ImportResult")
+@MainActor
 struct ImportResultTests {
 
     @Test("Success result")
@@ -434,6 +440,7 @@ struct ImportResultTests {
 // MARK: - ImportError Tests
 
 @Suite("ImportError")
+@MainActor
 struct ImportErrorTests {
 
     @Test("All errors have descriptions")

--- a/Dequeue/DequeueTests/DateMorningReminderTests.swift
+++ b/Dequeue/DequeueTests/DateMorningReminderTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Date+MorningReminder Tests")
+@MainActor
 struct DateMorningReminderTests {
     // MARK: - Basic Functionality
 

--- a/Dequeue/DequeueTests/DateSmartFormatTests.swift
+++ b/Dequeue/DequeueTests/DateSmartFormatTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Date+SmartFormat Tests")
+@MainActor
 struct DateSmartFormatTests {
     // MARK: - Today Formatting (relative)
 

--- a/Dequeue/DequeueTests/DragDropTests.swift
+++ b/Dequeue/DequeueTests/DragDropTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import UniformTypeIdentifiers
 @testable import Dequeue
 
+@MainActor
 final class DragDropTests: XCTestCase {
 
     // MARK: - TaskTransferItem Tests

--- a/Dequeue/DequeueTests/EnumsTests.swift
+++ b/Dequeue/DequeueTests/EnumsTests.swift
@@ -12,6 +12,7 @@ import Foundation
 // MARK: - StackStatus Tests
 
 @Suite("StackStatus Tests")
+@MainActor
 struct StackStatusTests {
     @Test("StackStatus has correct raw values")
     func stackStatusRawValues() {
@@ -60,6 +61,7 @@ struct StackStatusTests {
 // MARK: - TaskStatus Tests
 
 @Suite("TaskStatus Tests")
+@MainActor
 struct TaskStatusTests {
     @Test("TaskStatus has correct raw values")
     func taskStatusRawValues() {
@@ -93,6 +95,7 @@ struct TaskStatusTests {
 // MARK: - ReminderStatus Tests
 
 @Suite("ReminderStatus Tests")
+@MainActor
 struct ReminderStatusTests {
     @Test("ReminderStatus has correct raw values")
     func reminderStatusRawValues() {
@@ -119,6 +122,7 @@ struct ReminderStatusTests {
 // MARK: - ArcStatus Tests
 
 @Suite("ArcStatus Tests")
+@MainActor
 struct ArcStatusTests {
     @Test("ArcStatus has correct raw values")
     func arcStatusRawValues() {
@@ -146,6 +150,7 @@ struct ArcStatusTests {
 // MARK: - ParentType Tests
 
 @Suite("ParentType Tests")
+@MainActor
 struct ParentTypeTests {
     @Test("ParentType has correct raw values")
     func parentTypeRawValues() {
@@ -172,6 +177,7 @@ struct ParentTypeTests {
 // MARK: - ActorType Tests
 
 @Suite("ActorType Tests")
+@MainActor
 struct ActorTypeTests {
     @Test("ActorType has correct raw values")
     func actorTypeRawValues() {
@@ -261,6 +267,7 @@ struct EventMetadataTests {
 // MARK: - SyncState Tests
 
 @Suite("SyncState Tests")
+@MainActor
 struct SyncStateTests {
     @Test("SyncState has correct raw values")
     func syncStateRawValues() {
@@ -287,6 +294,7 @@ struct SyncStateTests {
 // MARK: - UploadState Tests
 
 @Suite("UploadState Tests")
+@MainActor
 struct UploadStateTests {
     @Test("UploadState has correct raw values")
     func uploadStateRawValues() {
@@ -314,6 +322,7 @@ struct UploadStateTests {
 // MARK: - EventType Tests
 
 @Suite("EventType Tests")
+@MainActor
 struct EventTypeTests {
     @Test("EventType stack events have correct raw values")
     func eventTypeStackRawValues() {

--- a/Dequeue/DequeueTests/MarkdownRendererTests.swift
+++ b/Dequeue/DequeueTests/MarkdownRendererTests.swift
@@ -14,6 +14,7 @@ import SwiftUI
 // MARK: - MarkdownRenderer Tests
 
 @Suite("MarkdownRenderer")
+@MainActor
 struct MarkdownRendererTests {
     @Test("Renders plain text without crash")
     @MainActor func plainText() {
@@ -95,6 +96,7 @@ struct MarkdownRendererTests {
 // MARK: - Markdown Cheat Sheet Tests
 
 @Suite("MarkdownCheatSheet")
+@MainActor
 struct MarkdownCheatSheetTests {
     @Test("Has all expected examples")
     func hasExamples() {

--- a/Dequeue/DequeueTests/OnboardingTests.swift
+++ b/Dequeue/DequeueTests/OnboardingTests.swift
@@ -12,6 +12,7 @@ import Foundation
 // MARK: - OnboardingPage Tests
 
 @Suite("OnboardingPage Model")
+@MainActor
 struct OnboardingPageTests {
 
     @Test("Pages are defined")

--- a/Dequeue/DequeueTests/PDFThumbnailGeneratorTests.swift
+++ b/Dequeue/DequeueTests/PDFThumbnailGeneratorTests.swift
@@ -16,6 +16,7 @@ import AppKit
 @testable import Dequeue
 
 @Suite("PDFThumbnailGenerator Tests")
+@MainActor
 struct PDFThumbnailGeneratorTests {
     // MARK: - Attachment Extension Tests
 

--- a/Dequeue/DequeueTests/RecurrenceRuleTests.swift
+++ b/Dequeue/DequeueTests/RecurrenceRuleTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Dequeue
 
+@MainActor
 final class RecurrenceRuleTests: XCTestCase {
 
     // MARK: - RecurrenceRule Model Tests

--- a/Dequeue/DequeueTests/Services/CertificatePinningDelegateTests.swift
+++ b/Dequeue/DequeueTests/Services/CertificatePinningDelegateTests.swift
@@ -14,6 +14,7 @@ import Security
 // MARK: - CertificatePinningConfiguration Tests
 
 @Suite("CertificatePinningConfiguration")
+@MainActor
 struct CertificatePinningConfigurationTests {
 
     @Test("Production configuration has expected domains")
@@ -91,6 +92,7 @@ struct CertificatePinningConfigurationTests {
 // MARK: - PinningFailureInfo Tests
 
 @Suite("PinningFailureInfo")
+@MainActor
 struct PinningFailureInfoTests {
 
     @Test("Failure info stores all properties")
@@ -128,6 +130,7 @@ struct PinningFailureInfoTests {
 // MARK: - CertificatePinningError Tests
 
 @Suite("CertificatePinningError")
+@MainActor
 struct CertificatePinningErrorTests {
 
     @Test("Pin validation failed error description includes domain")
@@ -156,6 +159,7 @@ struct CertificatePinningErrorTests {
 // MARK: - CertificatePinningDelegate Tests
 
 @Suite("CertificatePinningDelegate")
+@MainActor
 struct CertificatePinningDelegateTests {
 
     @Test("Delegate initializes with configuration")
@@ -260,6 +264,7 @@ struct CertificatePinningDelegateTests {
 // MARK: - CertificatePinningValidator Tests
 
 @Suite("CertificatePinningValidator")
+@MainActor
 struct CertificatePinningValidatorTests {
 
     @Test("Non-server-trust challenges return false")
@@ -318,6 +323,7 @@ struct CertificatePinningValidatorTests {
 // MARK: - PinnedURLSession Tests
 
 @Suite("PinnedURLSession")
+@MainActor
 struct PinnedURLSessionTests {
 
     @Test("Shared session is not nil")
@@ -362,6 +368,7 @@ struct PinnedURLSessionTests {
 // MARK: - Integration Tests
 
 @Suite("Certificate Pinning Integration")
+@MainActor
 struct CertificatePinningIntegrationTests {
 
     @Test("Real connection to api.dequeue.app succeeds with pinning")

--- a/Dequeue/DequeueTests/SmartNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/SmartNotificationServiceTests.swift
@@ -101,6 +101,7 @@ private func makeTask(
 // MARK: - Settings Tests
 
 @Suite("SmartNotificationSettings")
+@MainActor
 struct SmartNotificationSettingsTests {
     @Test("Default settings are sensible")
     func defaultSettings() {
@@ -136,6 +137,7 @@ struct SmartNotificationSettingsTests {
 // MARK: - Service Initialization Tests
 
 @Suite("SmartNotificationService Initialization")
+@MainActor
 struct ServiceInitTests {
     @Test("Loads default settings when none saved")
     @MainActor func defaultInit() throws {
@@ -195,6 +197,7 @@ struct ServiceInitTests {
 // MARK: - Due Date Notification Tests
 
 @Suite("Due Date Notifications")
+@MainActor
 struct DueDateTests {
     @Test("Schedules notification for task with future due date")
     @MainActor func schedulesForFutureDue() async throws {
@@ -357,6 +360,7 @@ struct DueDateTests {
 // MARK: - Morning Digest Tests
 
 @Suite("Morning Digest")
+@MainActor
 struct MorningDigestTests {
     @Test("Schedules morning digest when tasks exist")
     @MainActor func schedulesWithTasks() async throws {
@@ -429,6 +433,7 @@ struct MorningDigestTests {
 // MARK: - Overdue Alert Tests
 
 @Suite("Overdue Alerts")
+@MainActor
 struct OverdueAlertTests {
     @Test("Schedules alerts for overdue tasks")
     @MainActor func schedulesForOverdue() async throws {
@@ -522,6 +527,7 @@ struct OverdueAlertTests {
 // MARK: - Query Helper Tests
 
 @Suite("Query Helpers")
+@MainActor
 struct QueryHelperTests {
     @Test("Fetches tasks due on a specific date")
     @MainActor func fetchTasksDueOn() throws {
@@ -592,6 +598,7 @@ struct QueryHelperTests {
 // MARK: - Full Refresh Tests
 
 @Suite("Full Notification Refresh")
+@MainActor
 struct FullRefreshTests {
     @Test("Refresh cleans and re-schedules all")
     @MainActor func refreshAll() async throws {
@@ -631,6 +638,7 @@ struct FullRefreshTests {
 // MARK: - Category Configuration Tests
 
 @Suite("Notification Categories")
+@MainActor
 struct CategoryTests {
     @Test("Configures all expected categories")
     @MainActor func configuresCategories() throws {

--- a/Dequeue/DequeueTests/SpotlightIndexerTests.swift
+++ b/Dequeue/DequeueTests/SpotlightIndexerTests.swift
@@ -11,6 +11,7 @@ import CoreSpotlight
 @testable import Dequeue
 
 @Suite("SpotlightIndexer")
+@MainActor
 struct SpotlightIndexerTests {
 
     // MARK: - Spotlight Activity Handling

--- a/Dequeue/DequeueTests/StackFilteringTests.swift
+++ b/Dequeue/DequeueTests/StackFilteringTests.swift
@@ -12,6 +12,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("Stack Filtering Tests", .serialized)
+@MainActor
 struct StackFilteringTests {
     // MARK: - HomeView Filter Logic Tests
     // These tests verify the filtering logic that HomeView uses

--- a/Dequeue/DequeueTests/StorageQuotaHandlerTests.swift
+++ b/Dequeue/DequeueTests/StorageQuotaHandlerTests.swift
@@ -12,6 +12,7 @@ import Foundation
 // MARK: - QuotaCheckResult Tests
 
 @Suite("QuotaCheckResult Tests")
+@MainActor
 struct QuotaCheckResultTests {
     @Test("allowed case")
     func allowedCase() {
@@ -60,6 +61,7 @@ struct QuotaCheckResultTests {
 // MARK: - QuotaExceededError Tests
 
 @Suite("QuotaExceededError Tests")
+@MainActor
 struct QuotaExceededErrorTests {
     @Test("errorDescription is correct")
     func errorDescription() {
@@ -287,6 +289,7 @@ struct StorageQuotaHandlerTests {
 // MARK: - QuotaExceededDecision Tests
 
 @Suite("QuotaExceededDecision Tests")
+@MainActor
 struct QuotaExceededDecisionTests {
     @Test("All decision cases exist")
     func allCases() {

--- a/Dequeue/DequeueTests/SyncManagerPerformanceTests.swift
+++ b/Dequeue/DequeueTests/SyncManagerPerformanceTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("SyncManager Performance Tests")
+@MainActor
 struct SyncManagerPerformanceTests {
     // MARK: - ISO8601 Timestamp Parsing Tests
 

--- a/Dequeue/DequeueTests/SyncManagerReconnectTests.swift
+++ b/Dequeue/DequeueTests/SyncManagerReconnectTests.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Dequeue
 
 @Suite("SyncManager Reconnection Tests")
+@MainActor
 struct SyncManagerReconnectTests {
     @Test("Exponential backoff with jitter stays within expected range")
     func testBackoffJitter() async {

--- a/Dequeue/DequeueTests/TagTests.swift
+++ b/Dequeue/DequeueTests/TagTests.swift
@@ -13,6 +13,7 @@ import Foundation
 // MARK: - Tag Model Tests
 
 @Suite("Tag Model Tests")
+@MainActor
 struct TagModelTests {
     @Test("Tag initializes with default values")
     func tagInitializesWithDefaults() {

--- a/Dequeue/DequeueTests/TaskActivityTests.swift
+++ b/Dequeue/DequeueTests/TaskActivityTests.swift
@@ -13,6 +13,7 @@ import Foundation
 // MARK: - TaskActivityType Tests
 
 @Suite("TaskActivityType")
+@MainActor
 struct TaskActivityTypeTests {
     @Test("All types have icons")
     func allHaveIcons() {
@@ -64,6 +65,7 @@ struct TaskActivityTypeTests {
 // MARK: - TaskActivity Model Tests
 
 @Suite("TaskActivity Model")
+@MainActor
 struct TaskActivityModelTests {
     @Test("Creates with default values")
     func defaultInit() {
@@ -152,6 +154,7 @@ struct TaskActivityModelTests {
 // MARK: - TaskActivityService Tests
 
 @Suite("TaskActivityService")
+@MainActor
 struct TaskActivityServiceTests {
     @Test("Records and retrieves activities")
     @MainActor func recordAndRetrieve() {

--- a/Dequeue/DequeueTests/TaskFilterTests.swift
+++ b/Dequeue/DequeueTests/TaskFilterTests.swift
@@ -37,9 +37,9 @@ private func makeFilterTask(
     let task = QueueTask(
         title: title,
         dueTime: dueTime,
+        tags: tags,
         status: status,
         priority: priority,
-        tags: tags,
         isDeleted: isDeleted,
         stack: stack
     )
@@ -51,6 +51,7 @@ private func makeFilterTask(
 // MARK: - TaskFilter Model Tests
 
 @Suite("TaskFilter Model")
+@MainActor
 struct TaskFilterModelTests {
     @Test("Default filter has no active filters")
     func defaultFilter() {
@@ -147,6 +148,7 @@ struct TaskFilterModelTests {
 // MARK: - DateRangeFilter Tests
 
 @Suite("DateRangeFilter")
+@MainActor
 struct DateRangeFilterTests {
     @Test("Any returns no bounds")
     func anyRange() {
@@ -211,6 +213,7 @@ struct DateRangeFilterTests {
 // MARK: - TaskSortOption Tests
 
 @Suite("TaskSortOption")
+@MainActor
 struct TaskSortOptionTests {
     @Test("All options have display names")
     func displayNames() {
@@ -230,6 +233,7 @@ struct TaskSortOptionTests {
 // MARK: - TaskFilterService Tests
 
 @Suite("TaskFilterService")
+@MainActor
 struct TaskFilterServiceTests {
     @Test("Apply with default filter returns all non-deleted tasks")
     @MainActor func defaultFilterReturnsAll() throws {
@@ -439,6 +443,7 @@ struct TaskFilterServiceTests {
 // MARK: - FilterPreset Tests
 
 @Suite("FilterPreset")
+@MainActor
 struct FilterPresetTests {
     @Test("Built-in presets have names and icons")
     func builtInsValid() {

--- a/Dequeue/DequeueTests/TodayViewModelTests.swift
+++ b/Dequeue/DequeueTests/TodayViewModelTests.swift
@@ -47,6 +47,7 @@ private func insertTask(
 // MARK: - Today Section Tests
 
 @Suite("TodaySection")
+@MainActor
 struct TodaySectionTests {
     @Test("All sections have unique ids")
     func uniqueIds() {
@@ -81,6 +82,7 @@ struct TodaySectionTests {
 // MARK: - ViewModel Grouping Tests
 
 @Suite("TodayViewModel Task Grouping")
+@MainActor
 struct ViewModelGroupingTests {
     @Test("Empty state shows no tasks")
     @MainActor func emptyState() throws {


### PR DESCRIPTION
## Summary

Fixes Swift 6 strict concurrency errors that prevent the test target from building.

### Problem

With `SWIFT_STRICT_CONCURRENCY = complete` and Swift 6.0, all test suites that access `@MainActor`-isolated types (SwiftData models, services, singletons) must be explicitly annotated with `@MainActor`. Without this, the compiler emits errors like:

- `main actor-isolated property 'X' can not be referenced from a nonisolated context`
- `Call to main actor-isolated initializer in a synchronous nonisolated context`
- `main actor-isolated conformance of 'X' to 'Y' cannot be used in nonisolated context`

### Changes

**Test files (31 files):**
- Add `@MainActor` to all Swift Testing `@Suite` structs
- Add `@MainActor` to all `XCTestCase` subclasses
- Add `import EventKit` to CalendarServiceTests (for `EKAuthorizationStatus.rawValue`)
- Add `import SwiftUI` to AccessibilityTests (for `Color` type)
- Fix argument order in TaskFilterTests helper

**Source files (10 files):**
- Add `nonisolated` annotations where properties/methods are accessed from background threads (Configuration, ErrorReportingService, CertificatePinningDelegate, etc.)
- These were pre-existing uncommitted changes needed for proper concurrency compliance

### Verification

- `xcodebuild build` ✅ (main target builds)
- `xcodebuild build-for-testing` ✅ (test target builds — was failing before)
- SwiftLint: 0 serious violations
- `SWIFT_STRICT_CONCURRENCY = complete` preserved (no downgrade)