### PR TITLE
fix: Replace fatalError crashes with graceful recovery, init Sentry earlier

### DIFF
--- a/Dequeue/Dequeue.xcodeproj/project.pbxproj
+++ b/Dequeue/Dequeue.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -474,6 +475,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/Dequeue/Dequeue/Views/Settings/SettingsView.swift
+++ b/Dequeue/Dequeue/Views/Settings/SettingsView.swift
@@ -250,32 +250,10 @@ struct SettingsView: View {
     }
 
     private func deleteAllDataAndRestart() {
-        let fileManager = FileManager.default
-        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            fatalError("Could not find Application Support directory")
-        }
-
-        let storeURL = appSupport.appendingPathComponent("default.store")
-        let storeShmURL = appSupport.appendingPathComponent("default.store-shm")
-        let storeWalURL = appSupport.appendingPathComponent("default.store-wal")
-
-        do {
-            if fileManager.fileExists(atPath: storeURL.path) {
-                try fileManager.removeItem(at: storeURL)
-            }
-            if fileManager.fileExists(atPath: storeShmURL.path) {
-                try fileManager.removeItem(at: storeShmURL)
-            }
-            if fileManager.fileExists(atPath: storeWalURL.path) {
-                try fileManager.removeItem(at: storeWalURL)
-            }
-
-            UserDefaults.standard.removeObject(forKey: "com.dequeue.lastSyncCheckpoint")
-            fatalError("Data deleted - restart app to resync")
-        } catch {
-            ErrorReportingService.capture(error: error, context: ["action": "delete_all_data"])
-            fatalError("Failed to delete data: \(error.localizedDescription)")
-        }
+        // Use the shared store deletion logic and exit cleanly instead of crashing.
+        // A clean exit(0) avoids polluting crash analytics unlike fatalError.
+        DequeueApp.deleteSwiftDataStore()
+        exit(0)
     }
 
     private func signOut() async {


### PR DESCRIPTION
## Problem

The app is crashing on TestFlight before Sentry can even initialize, making debugging impossible. The root cause is schema changes across 10+ model files (PRs #335-#336) causing `ModelContainer` init to fail on existing installs, which hits a `fatalError()` in `DequeueApp.init()`.

## Changes

### 1. DequeueApp.swift — Graceful ModelContainer failure recovery
- **Replace `fatalError()`** when ModelContainer fails after store deletion with an in-memory fallback container and a user-facing `DatabaseErrorView` that explains the issue and offers a "Delete Local Data & Relaunch" button
- **Move `ErrorReportingService.configure()`** to the very top of `init()`, before ModelContainer creation, so Sentry captures any init crashes
- Make `deleteSwiftDataStore()` non-private so it can be reused

### 2. ErrorReportingService.swift — Synchronous Sentry init
- Remove `async` from `configure()` — call `SentrySDK.start` directly instead of wrapping in `withCheckedContinuation + DispatchQueue.global.async`
- Eliminates the `SWIFT TASK CONTINUATION MISUSE` risk from the old pattern
- Ensures crash reporting is active before any other initialization code

### 3. SettingsView.swift — Remove production fatalError calls
- Replace `fatalError()` in `deleteAllDataAndRestart()` with `exit(0)` via the shared `DequeueApp.deleteSwiftDataStore()` helper — clean exit instead of crash analytics pollution
- Keep the intentional `#if DEBUG` test crash button

### 4. Info.plist — Auto-clear encryption compliance
- Add `ITSAppUsesNonExemptEncryption = NO` to build settings to skip the manual compliance prompt for future TestFlight builds

## Testing
- `xcodebuild build` ✅ (macOS, `CODE_SIGNING_ALLOWED=NO`)
- SwiftLint: 0 new warnings, 0 errors