### PR TITLE
fix: Wait for TestFlight build processing to enable distribution

### DIFF
--- a/Dequeue/fastlane/Fastfile
+++ b/Dequeue/fastlane/Fastfile
@@ -57,7 +57,7 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true
+      changelog: ENV["CHANGELOG"] || "Bug fixes and improvements"
     )
   end
 


### PR DESCRIPTION
## Problem

TestFlight builds were being uploaded successfully but never distributed to testers. Victor could see the build in App Store Connect but it wasn't assigned to any test group.

## Root Cause

`upload_to_testflight` had `skip_waiting_for_build_processing: true`, which causes Fastlane to exit immediately after uploading the IPA. Since Fastlane doesn't wait for Apple to finish processing the build, it never distributes to internal testers.

## Fix

- Remove `skip_waiting_for_build_processing: true` — Fastlane will now wait for Apple to process the build and auto-distribute to internal testers
- Add `changelog` parameter using the `CHANGELOG` env var from the workflow (defaults to "Bug fixes and improvements")

## Impact

- CI job will take ~5-15 minutes longer (waiting for build processing)
- Internal testers will automatically receive new builds
- Workflow timeout is already 60 minutes, more than enough

## Testing

This is a Fastlane config change — verified syntax is correct. Will be tested on next TestFlight deploy.