### PR TITLE
feat: sync actor metadata and show AI badge in history (DEQ-55)

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -123,6 +123,18 @@ actor SyncManager {
     }()
     // swiftlint:enable force_try
 
+    /// Adds actor metadata fields (actor_type, actor_id) to an event dictionary (DEQ-55).
+    /// Extracts from the encoded EventMetadata Data, mapping camelCase to snake_case for the server.
+    static func addActorMetadata(from metadata: Data?, to eventDict: inout [String: Any]) {
+        guard let metadata,
+              let metadataDict = try? JSONSerialization.jsonObject(with: metadata) as? [String: Any],
+              let actorType = metadataDict["actorType"] as? String else { return }
+        eventDict["actor_type"] = actorType
+        if let actorId = metadataDict["actorId"] as? String {
+            eventDict["actor_id"] = actorId
+        }
+    }
+
     /// Generates a short sync ID for tracking sync operations in logs.
     /// Uses first 8 characters of a UUID for brevity while maintaining uniqueness.
     static func generateSyncId() -> String {
@@ -410,6 +422,7 @@ actor SyncManager {
                     timestamp: event.timestamp,
                     type: event.type,
                     payload: event.payload,
+                    metadata: event.metadata,
                     userId: event.userId,
                     deviceId: event.deviceId,
                     appId: event.appId,
@@ -443,7 +456,8 @@ actor SyncManager {
             let eventUserId = !eventData.userId.isEmpty ? eventData.userId : (self.userId ?? "")
             let eventDeviceIdToUse = !eventData.deviceId.isEmpty ? eventData.deviceId : eventDeviceId
 
-            return [
+            // Build event dict with required fields
+            var eventDict: [String: Any] = [
                 "id": eventData.id,
                 "user_id": eventUserId,
                 "device_id": eventDeviceIdToUse,
@@ -453,6 +467,11 @@ actor SyncManager {
                 "payload": payload,
                 "payload_version": eventData.payloadVersion
             ]
+
+            // DEQ-55: Include actor metadata if present
+            Self.addActorMetadata(from: eventData.metadata, to: &eventDict)
+
+            return eventDict
         }
 
         // Send via WebSocket for immediate delivery to other devices (fire-and-forget optimization).
@@ -1260,11 +1279,22 @@ actor SyncManager {
         let eventAppId = eventData["app_id"] as? String ?? ""
         let payloadVersion = eventData["payload_version"] as? Int ?? Event.currentPayloadVersion
 
+        // DEQ-55: Parse actor metadata from server event
+        var metadataData: Data?
+        if let actorTypeString = eventData["actor_type"] as? String {
+            var metadataDict: [String: Any] = ["actorType": actorTypeString]
+            if let actorId = eventData["actor_id"] as? String {
+                metadataDict["actorId"] = actorId
+            }
+            metadataData = try? JSONSerialization.data(withJSONObject: metadataDict)
+        }
+
         return Event(
             id: id,
             type: type,
             payload: payloadData,
             timestamp: eventTimestamp,
+            metadata: metadataData,
             entityId: entityId,
             userId: eventUserId,
             deviceId: eventDeviceId,

--- a/Dequeue/Dequeue/Sync/SyncTypes.swift
+++ b/Dequeue/Dequeue/Sync/SyncTypes.swift
@@ -16,6 +16,7 @@ struct EventData: Sendable {
     let timestamp: Date
     let type: String
     let payload: Data
+    let metadata: Data?  // DEQ-55: Actor metadata (actorType, actorId)
     let userId: String
     let deviceId: String
     let appId: String

--- a/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackHistoryView.swift
@@ -279,6 +279,15 @@ struct StackHistoryRow: View {
                 HStack {
                     Text(displayConfig.label)
                         .font(.headline)
+                    // DEQ-55: Show AI badge for agent-created events
+                    if event.isFromAI {
+                        Text("AI")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(.purple))
+                    }
                     Spacer()
                     Text(event.timestamp, style: .relative)
                         .font(.caption)

--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -24,6 +24,7 @@ struct EventDataTests {
             timestamp: now,
             type: "stack.created",
             payload: payload,
+            metadata: nil,
             userId: "user-456",
             deviceId: "device-789",
             appId: "app-001",
@@ -34,6 +35,7 @@ struct EventDataTests {
         #expect(event.timestamp == now)
         #expect(event.type == "stack.created")
         #expect(event.payload == payload)
+        #expect(event.metadata == nil)
         #expect(event.userId == "user-456")
         #expect(event.deviceId == "device-789")
         #expect(event.appId == "app-001")
@@ -47,6 +49,7 @@ struct EventDataTests {
             timestamp: Date(),
             type: "task.created",
             payload: Data(),
+            metadata: nil,
             userId: "u",
             deviceId: "d",
             appId: "a",
@@ -55,6 +58,28 @@ struct EventDataTests {
 
         #expect(event.payload.isEmpty)
         #expect(event.id == "evt-empty")
+    }
+
+    @Test("EventData stores actor metadata (DEQ-55)")
+    func eventDataWithActorMetadata() throws {
+        let metadata = try JSONEncoder().encode(EventMetadata.ai(agentId: "ada"))
+
+        let event = EventData(
+            id: "evt-ai",
+            timestamp: Date(),
+            type: "task.completed",
+            payload: Data("{\"taskId\":\"t1\"}".utf8),
+            metadata: metadata,
+            userId: "user-1",
+            deviceId: "api-dequeue",
+            appId: "app-1",
+            payloadVersion: 2
+        )
+
+        #expect(event.metadata != nil)
+        let decoded = try JSONDecoder().decode(EventMetadata.self, from: event.metadata!)
+        #expect(decoded.actorType == .ai)
+        #expect(decoded.actorId == "ada")
     }
 }
 


### PR DESCRIPTION
## Summary

Complete the iOS side of DEQ-55: transmit actor metadata through the sync pipeline and display AI badges in event history.

**Linear:** DEQ-55
**Depends on:** stacks-sync PR #45, dequeue-api PR #116

## Changes

### Sync Pipeline
- `EventData` now includes `metadata` field for actor info
- Push events include `actor_type`/`actor_id` from local `EventMetadata`
- Incoming events parse `actor_type`/`actor_id` into `EventMetadata`
- Extracted `addActorMetadata()` static helper to keep `pushEvents()` complexity in check

### UI
- Stack history view shows purple **AI** badge on agent-created events
- Uses existing `Event.isFromAI` computed property (already implemented)

### Tests
- New test: `EventData` with AI actor metadata round-trip

## Verification
- ✅ Build passes (macOS)
- ✅ 0 SwiftLint violations
- ✅ iOS models (ActorType, EventMetadata) already existed - this PR wires them through sync