### PR TITLE
feat: add AI badge to arc history and event log views (DEQ-55)

### DIFF
--- a/Dequeue/Dequeue/Views/Arc/ArcHistoryView.swift
+++ b/Dequeue/Dequeue/Views/Arc/ArcHistoryView.swift
@@ -310,6 +310,15 @@ struct ArcHistoryRow: View {
                 HStack {
                     Text(actionLabel)
                         .font(.headline)
+                    // DEQ-55: Show AI badge for agent-created events
+                    if event.isFromAI {
+                        Text("AI")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(.purple))
+                    }
                     Spacer()
                     Text(event.timestamp, style: .relative)
                         .font(.caption)

--- a/Dequeue/Dequeue/Views/Settings/EventLogView.swift
+++ b/Dequeue/Dequeue/Views/Settings/EventLogView.swift
@@ -128,9 +128,20 @@ struct EventRow: View {
                 .frame(width: 24)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(event.type)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                HStack(spacing: 4) {
+                    Text(event.type)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    // DEQ-55: Show AI badge for agent-created events
+                    if event.isFromAI {
+                        Text("AI")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(.purple))
+                    }
+                }
 
                 Text(timestampText)
                     .font(.caption)


### PR DESCRIPTION
## Summary

Extend the AI event badge from stack history (PR #344) to all event history views.

**Linear:** DEQ-55

## Changes
- **ArcHistoryView**: Shows purple AI badge on agent-created arc events  
- **EventLogView** (Settings > Event Log): Shows AI badge next to event type

Consistent visual indicator across all event history views for events created by AI agents.

## Verification
- ✅ Build passes (macOS)
- ✅ 0 SwiftLint violations