### PR TITLE
fix: use TaskService for task completion in TodayView (sync bug)

### DIFF
--- a/Dequeue/Dequeue/Views/Today/TodayView.swift
+++ b/Dequeue/Dequeue/Views/Today/TodayView.swift
@@ -328,6 +328,11 @@ private struct TodayTaskRow: View {
     let onComplete: () -> Void
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.syncManager) private var syncManager
+    @Environment(\.authService) private var authService
+
+    @State private var taskService: TaskService?
+    @State private var isCompleting = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -365,11 +370,12 @@ private struct TodayTaskRow: View {
             Button {
                 completeTask()
             } label: {
-                Image(systemName: "checkmark.circle")
+                Image(systemName: isCompleting ? "checkmark.circle.fill" : "checkmark.circle")
                     .font(.title3)
                     .foregroundStyle(.green)
             }
             .buttonStyle(.plain)
+            .disabled(isCompleting)
         }
         .padding(12)
         .background(
@@ -377,6 +383,17 @@ private struct TodayTaskRow: View {
                 .fill(.background)
                 .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
         )
+        .task {
+            guard taskService == nil else { return }
+            let deviceId = await DeviceService.shared.getDeviceId()
+            let userId = authService.currentUserId ?? ""
+            taskService = TaskService(
+                modelContext: modelContext,
+                userId: userId,
+                deviceId: deviceId,
+                syncManager: syncManager
+            )
+        }
     }
 
     private var priorityColor: Color {
@@ -389,10 +406,18 @@ private struct TodayTaskRow: View {
     }
 
     private func completeTask() {
-        task.status = .completed
-        task.updatedAt = Date()
-        try? modelContext.save()
-        onComplete()
+        guard let service = taskService else { return }
+        isCompleting = true
+        Task {
+            do {
+                try await service.markAsCompleted(task)
+                HapticManager.shared.success()
+                onComplete()
+            } catch {
+                isCompleting = false
+                logger.error("Failed to complete task from Today view: \(error)")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Bug

TodayTaskRow was completing tasks by directly mutating the model:

```swift
// ❌ Before: bypasses EventService + sync
task.status = .completed
task.updatedAt = Date()
try? modelContext.save()
```

This skipped the entire sync pipeline:
- **No sync event recorded** — completions from Today view wouldn't sync to other devices
- **syncState not set** — SyncManager wouldn't know to push the change
- **Reminders not dismissed** — Active/snoozed reminders for the completed task would persist (DEQ-212 regression)
- **No recurring task handling** — Recurring tasks wouldn't create their next occurrence
- **No haptic feedback**

## Fix

Now uses `TaskService.markAsCompleted()` which properly handles the full completion flow:

```swift
// ✅ After: proper completion through TaskService
try await service.markAsCompleted(task)
HapticManager.shared.success()
```

This is the same path used by `TaskDetailView` and other completion flows.

### Additional improvements:
- **Visual feedback**: Checkmark fills (`checkmark.circle.fill`) while completing
- **Double-tap prevention**: Button disabled during async completion
- **Proper service initialization**: Uses `authService` for userId (matching pattern from TaskDetailView)

## Testing

- SwiftLint: 0 violations
- Build verified locally (macOS)
- Pattern matches TaskDetailView's proven completion flow