### PR TITLE
fix: align TagProjection with API response format (colorHex, updatedAt)

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -216,7 +216,8 @@ extension SyncManager {
                 id: tagData.id,
                 name: tagData.name,
                 colorHex: tagData.color,
-                createdAt: dateFromUnixMs(tagData.createdAt)
+                createdAt: dateFromUnixMs(tagData.createdAt),
+                updatedAt: dateFromUnixMs(tagData.updatedAt)
             )
             context.insert(tag)
             tagMap[tag.id] = tag

--- a/Dequeue/Dequeue/Sync/SyncTypes.swift
+++ b/Dequeue/Dequeue/Sync/SyncTypes.swift
@@ -122,6 +122,13 @@ struct TagProjection: @preconcurrency Decodable, Sendable {
     let name: String
     let color: String?
     let createdAt: Int64
+    let updatedAt: Int64
+
+    // API returns colorHex but we use color internally
+    private enum CodingKeys: String, CodingKey {
+        case id, name, createdAt, updatedAt
+        case color = "colorHex"
+    }
 }
 
 struct ReminderProjection: @preconcurrency Decodable, Sendable {

--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -365,14 +365,15 @@ struct ArcProjectionTests {
 @Suite("TagProjection Tests")
 @MainActor
 struct TagProjectionTests {
-    @Test("TagProjection decodes correctly")
+    @Test("TagProjection decodes correctly with colorHex mapping")
     func decodesCorrectly() throws {
         let json = """
         {
             "id": "tag-50",
             "name": "urgent",
-            "color": "#E74C3C",
-            "createdAt": 1707500000
+            "colorHex": "#E74C3C",
+            "createdAt": 1707500000,
+            "updatedAt": 1707600000
         }
         """.data(using: .utf8)!
 
@@ -384,6 +385,7 @@ struct TagProjectionTests {
         #expect(tag.name == "urgent")
         #expect(tag.color == "#E74C3C")
         #expect(tag.createdAt == 1_707_500_000)
+        #expect(tag.updatedAt == 1_707_600_000)
     }
 
     @Test("TagProjection decodes with nil color")
@@ -392,7 +394,8 @@ struct TagProjectionTests {
         {
             "id": "tag-51",
             "name": "misc",
-            "createdAt": 1707500000
+            "createdAt": 1707500000,
+            "updatedAt": 1707500000
         }
         """.data(using: .utf8)!
 
@@ -401,6 +404,7 @@ struct TagProjectionTests {
         )
 
         #expect(tag.color == nil)
+        #expect(tag.updatedAt == 1_707_500_000)
     }
 }
 


### PR DESCRIPTION
## Summary

Same class of bug as PR #351 (task notes mapping): **TagProjection** used a `color` property but the API returns `colorHex`. Without a `CodingKey` mapping, tag colors were silently set to `nil` during projection sync (new device setup).

## Bug

When a new device performs initial projection sync:
1. API returns `{"colorHex": "#E74C3C", ...}` for tags
2. `TagProjection.color` has no CodingKey → JSON decoder can't match the field
3. `color` defaults to `nil`
4. Tag is created locally without any color → **data loss**

## Changes

- Add `CodingKeys` to `TagProjection` mapping `color` → `colorHex`
- Add missing `updatedAt` field to `TagProjection` (API returns it, was being dropped)
- Pass `updatedAt` to `Tag` model in `populateTags()`
- Update tests to use correct API field name `colorHex`

## Testing

- All `TagProjectionTests` pass locally
- Full build succeeds
- Zero SwiftLint violations on changed files