### PR TITLE
fix: handle missing isDeleted in projection sync responses

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncTypes.swift
+++ b/Dequeue/Dequeue/Sync/SyncTypes.swift
@@ -72,6 +72,24 @@ struct StackProjection: @preconcurrency Decodable, Sendable {
         case dueTime = "dueAt"
         case createdAt, updatedAt
     }
+
+    // Custom init: isDeleted defaults to false when API omits it
+    // (API list endpoints filter WHERE is_deleted = false and don't include the field)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        status = try container.decode(String.self, forKey: .status)
+        isActive = try container.decode(Bool.self, forKey: .isActive)
+        isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted) ?? false
+        arcId = try container.decodeIfPresent(String.self, forKey: .arcId)
+        tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        startTime = try container.decodeIfPresent(Int64.self, forKey: .startTime)
+        dueTime = try container.decodeIfPresent(Int64.self, forKey: .dueTime)
+        createdAt = try container.decode(Int64.self, forKey: .createdAt)
+        updatedAt = try container.decode(Int64.self, forKey: .updatedAt)
+    }
 }
 
 struct TaskProjection: @preconcurrency Decodable, Sendable {
@@ -114,6 +132,21 @@ struct ArcProjection: @preconcurrency Decodable, Sendable {
         case startTime = "startAt"
         case dueTime = "dueAt"
         case createdAt, updatedAt
+    }
+
+    // Custom init: isDeleted defaults to false when API omits it
+    // (API list endpoints filter WHERE is_deleted = false and don't include the field)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        color = try container.decodeIfPresent(String.self, forKey: .color)
+        isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted) ?? false
+        startTime = try container.decodeIfPresent(Int64.self, forKey: .startTime)
+        dueTime = try container.decodeIfPresent(Int64.self, forKey: .dueTime)
+        createdAt = try container.decode(Int64.self, forKey: .createdAt)
+        updatedAt = try container.decode(Int64.self, forKey: .updatedAt)
     }
 }
 

--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -180,7 +180,7 @@ struct ProjectionResponseTests {
 @Suite("StackProjection Tests")
 @MainActor
 struct StackProjectionTests {
-    @Test("StackProjection decodes with all fields")
+    @Test("StackProjection decodes with all fields using API field names")
     func decodesWithAllFields() throws {
         let json = """
         {
@@ -192,8 +192,8 @@ struct StackProjectionTests {
             "isDeleted": false,
             "arcId": "arc-123",
             "tags": ["errands", "weekly"],
-            "startTime": 1708000000,
-            "dueTime": 1708086400,
+            "startAt": 1708000000,
+            "dueAt": 1708086400,
             "createdAt": 1707900000,
             "updatedAt": 1708000000
         }
@@ -217,6 +217,33 @@ struct StackProjectionTests {
         #expect(stack.updatedAt == 1_708_000_000)
     }
 
+    @Test("StackProjection decodes without isDeleted (API omits it)")
+    func decodesWithoutIsDeleted() throws {
+        // API list endpoints filter WHERE is_deleted = false and don't include the field
+        let json = """
+        {
+            "id": "stack-api",
+            "title": "From API",
+            "status": "active",
+            "isActive": true,
+            "tags": [],
+            "startAt": null,
+            "dueAt": null,
+            "createdAt": 1707900000,
+            "updatedAt": 1707900000
+        }
+        """.data(using: .utf8)!
+
+        let stack = try JSONDecoder().decode(
+            StackProjection.self, from: json
+        )
+
+        #expect(stack.id == "stack-api")
+        #expect(stack.isDeleted == false)
+        #expect(stack.arcId == nil)
+        #expect(stack.description == nil)
+    }
+
     @Test("StackProjection decodes with minimal fields")
     func decodesWithMinimalFields() throws {
         let json = """
@@ -225,7 +252,6 @@ struct StackProjectionTests {
             "title": "Minimal",
             "status": "active",
             "isActive": true,
-            "isDeleted": false,
             "createdAt": 1707900000,
             "updatedAt": 1707900000
         }
@@ -236,6 +262,7 @@ struct StackProjectionTests {
         )
 
         #expect(stack.id == "stack-min")
+        #expect(stack.isDeleted == false)
         #expect(stack.description == nil)
         #expect(stack.arcId == nil)
         #expect(stack.tags == nil)
@@ -312,15 +339,17 @@ struct TaskProjectionTests {
 @Suite("ArcProjection Tests")
 @MainActor
 struct ArcProjectionTests {
-    @Test("ArcProjection decodes correctly")
+    @Test("ArcProjection decodes correctly with API field names")
     func decodesCorrectly() throws {
         let json = """
         {
             "id": "arc-100",
             "title": "Q1 Sprint",
             "description": "First quarter deliverables",
-            "color": "#3498DB",
+            "colorHex": "#3498DB",
             "isDeleted": false,
+            "startAt": 1707500000,
+            "dueAt": 1708500000,
             "createdAt": 1707000000,
             "updatedAt": 1708000000
         }
@@ -335,8 +364,35 @@ struct ArcProjectionTests {
         #expect(arc.description == "First quarter deliverables")
         #expect(arc.color == "#3498DB")
         #expect(arc.isDeleted == false)
+        #expect(arc.startTime == 1_707_500_000)
+        #expect(arc.dueTime == 1_708_500_000)
         #expect(arc.createdAt == 1_707_000_000)
         #expect(arc.updatedAt == 1_708_000_000)
+    }
+
+    @Test("ArcProjection decodes without isDeleted (API omits it)")
+    func decodesWithoutIsDeleted() throws {
+        // API list endpoints filter WHERE is_deleted = false and don't include the field
+        let json = """
+        {
+            "id": "arc-api",
+            "title": "From API",
+            "colorHex": "#FF0000",
+            "startAt": null,
+            "dueAt": null,
+            "createdAt": 1707000000,
+            "updatedAt": 1707000000
+        }
+        """.data(using: .utf8)!
+
+        let arc = try JSONDecoder().decode(
+            ArcProjection.self, from: json
+        )
+
+        #expect(arc.id == "arc-api")
+        #expect(arc.isDeleted == false)
+        #expect(arc.color == "#FF0000")
+        #expect(arc.description == nil)
     }
 
     @Test("ArcProjection decodes with nil optionals")
@@ -345,7 +401,6 @@ struct ArcProjectionTests {
         {
             "id": "arc-101",
             "title": "No extras",
-            "isDeleted": false,
             "createdAt": 1707000000,
             "updatedAt": 1707000000
         }
@@ -357,6 +412,9 @@ struct ArcProjectionTests {
 
         #expect(arc.description == nil)
         #expect(arc.color == nil)
+        #expect(arc.isDeleted == false)
+        #expect(arc.startTime == nil)
+        #expect(arc.dueTime == nil)
     }
 }
 


### PR DESCRIPTION
## Summary

**Critical bug: Projection sync (DEQ-230) has NEVER worked in production.**

`StackProjection` and `ArcProjection` declared `isDeleted` as non-optional `Bool`, but the API list endpoints filter `WHERE is_deleted = false` and **never include `isDeleted` in the JSON response**. This caused `JSONDecoder` to throw `keyNotFound` on every decode attempt.

## Impact

- New devices performing initial sync always silently fall back to slower event replay
- The entire projection sync code path (DEQ-230) has been dead code in production
- No user-visible bugs (fallback works), but significantly slower first-time sync

## Root Cause

API's `StackResponse` and `ArcResponse` Go structs don't include `IsDeleted` field. The DB query already filters `WHERE is_deleted = false`, so returned items are always non-deleted. But the iOS model expected the field in JSON.

## Changes

- Add custom `init(from:)` to `StackProjection` — uses `decodeIfPresent` for `isDeleted`, defaults to `false`
- Add custom `init(from:)` to `ArcProjection` — same fix
- Update tests to use correct API field names (`startAt`/`dueAt`, `colorHex`)
- Add test cases verifying decode works **without** `isDeleted` (real API response format)
- Add `startTime`/`dueTime` test coverage for `ArcProjection`

## Testing

- All `StackProjectionTests` pass (3 tests including new `decodesWithoutIsDeleted`)
- All `ArcProjectionTests` pass (3 tests including new `decodesWithoutIsDeleted`)
- Full build succeeds locally