### PR TITLE
fix: add snoozedFrom and status to ReminderProjection sync

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -338,8 +338,11 @@ extension SyncManager {
                 id: reminderData.id,
                 parentId: parentId,
                 parentType: parentType,
+                status: parseReminderStatus(reminderData.status),
+                snoozedFrom: dateFromUnixMs(reminderData.snoozedFrom),
                 remindAt: dateFromUnixMs(reminderData.triggerTime),
                 createdAt: dateFromUnixMs(reminderData.createdAt),
+                updatedAt: dateFromUnixMs(reminderData.updatedAt),
                 isDeleted: reminderData.isDeleted
             )
 
@@ -419,6 +422,16 @@ extension SyncManager {
         case "closed": return .closed
         case "in_progress": return .pending
         default: return .pending
+        }
+    }
+
+    /// Parses reminder status string to enum.
+    nonisolated func parseReminderStatus(_ status: String) -> ReminderStatus {
+        switch status.lowercased() {
+        case "active": return .active
+        case "snoozed": return .snoozed
+        case "fired": return .fired
+        default: return .active
         }
     }
 }

--- a/Dequeue/Dequeue/Sync/SyncTypes.swift
+++ b/Dequeue/Dequeue/Sync/SyncTypes.swift
@@ -169,6 +169,7 @@ struct ReminderProjection: @preconcurrency Decodable, Sendable {
     let parentType: String
     let parentId: String
     let remindAt: Int64
+    let snoozedFrom: Int64?
     let status: String
     let createdAt: Int64
     let updatedAt: Int64

--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -495,6 +495,7 @@ struct ReminderProjectionTests {
         #expect(reminder.taskId == nil)
         #expect(reminder.triggerTime == 1_708_100_000)
         #expect(reminder.isDeleted == false)
+        #expect(reminder.snoozedFrom == nil)
     }
 
     @Test("ReminderProjection decodes with task parent")
@@ -519,6 +520,7 @@ struct ReminderProjectionTests {
         #expect(reminder.stackId == nil)
         #expect(reminder.arcId == nil)
         #expect(reminder.isDeleted == false)
+        #expect(reminder.snoozedFrom == nil)
     }
 
     @Test("ReminderProjection decodes with arc parent")
@@ -543,6 +545,33 @@ struct ReminderProjectionTests {
         #expect(reminder.stackId == nil)
         #expect(reminder.taskId == nil)
         #expect(reminder.isDeleted == true)
+        #expect(reminder.snoozedFrom == nil)
+    }
+
+    @Test("ReminderProjection decodes snoozed reminder with snoozedFrom")
+    func decodesSnoozedReminder() throws {
+        let json = """
+        {
+            "id": "rem-13",
+            "parentType": "stack",
+            "parentId": "stack-xyz",
+            "remindAt": 1708400000,
+            "snoozedFrom": 1708100000,
+            "status": "snoozed",
+            "createdAt": 1708000000,
+            "updatedAt": 1708300000
+        }
+        """.data(using: .utf8)!
+
+        let reminder = try JSONDecoder().decode(
+            ReminderProjection.self, from: json
+        )
+
+        #expect(reminder.id == "rem-13")
+        #expect(reminder.stackId == "stack-xyz")
+        #expect(reminder.snoozedFrom == 1_708_100_000)
+        #expect(reminder.triggerTime == 1_708_400_000)
+        #expect(reminder.isDeleted == false)
     }
 }
 


### PR DESCRIPTION
## Problem

ReminderProjection was missing the `snoozedFrom` field that the API returns. During projection sync (new device setup), snoozed reminders would lose their original trigger time. Additionally:
- Reminder `status` was not mapped from the API response (defaulted to `.active`, losing `snoozed`/`fired` states)
- `updatedAt` was not passed through (used `Date()` default instead of the API value)

This is the same class of bug as PRs #351, #352, #353 — projection sync field mismatches.

## Changes

- Add `snoozedFrom: Int64?` to `ReminderProjection` struct
- Add `parseReminderStatus()` helper to map API status strings to `ReminderStatus` enum
- Pass `status`, `snoozedFrom`, and `updatedAt` through in `populateReminders()`
- Add test for snoozed reminder decoding with `snoozedFrom` field

## Testing

- All existing tests pass
- New test: `decodesSnoozedReminder` verifies snoozedFrom is properly decoded
- SwiftLint: 0 violations