### PR TITLE
fix: add sortOrder and activeTaskId to StackProjection

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -202,6 +202,8 @@ extension SyncManager {
                 updatedAt: dateFromUnixMs(arcData.updatedAt),
                 isDeleted: arcData.isDeleted
             )
+            arc.status = parseArcStatus(arcData.status)
+            arc.sortOrder = arcData.sortOrder
             context.insert(arc)
         }
     }
@@ -400,6 +402,17 @@ extension SyncManager {
     nonisolated func dateFromUnixMs(_ ms: Int64?) -> Date? {
         guard let ms = ms else { return nil }
         return Date(timeIntervalSince1970: Double(ms) / 1_000.0)
+    }
+
+    /// Parses arc status string to enum.
+    nonisolated func parseArcStatus(_ status: String) -> ArcStatus {
+        switch status.lowercased() {
+        case "active": return .active
+        case "completed": return .completed
+        case "paused": return .paused
+        case "archived": return .archived
+        default: return .active
+        }
     }
 
     /// Parses stack status string to enum.

--- a/Dequeue/Dequeue/Sync/SyncTypes.swift
+++ b/Dequeue/Dequeue/Sync/SyncTypes.swift
@@ -123,8 +123,10 @@ struct ArcProjection: @preconcurrency Decodable, Sendable {
     let id: String
     let title: String
     let description: String?
+    let status: String
     let color: String?
     let isDeleted: Bool
+    let sortOrder: Int
     let startTime: Int64?
     let dueTime: Int64?
     let createdAt: Int64
@@ -132,22 +134,24 @@ struct ArcProjection: @preconcurrency Decodable, Sendable {
 
     // API returns colorHex/startAt/dueAt but iOS models use different names
     private enum CodingKeys: String, CodingKey {
-        case id, title, description, isDeleted
+        case id, title, description, status, isDeleted, sortOrder
         case color = "colorHex"
         case startTime = "startAt"
         case dueTime = "dueAt"
         case createdAt, updatedAt
     }
 
-    // Custom init: isDeleted defaults to false when API omits it
+    // Custom init: isDeleted/sortOrder default when API omits them
     // (API list endpoints filter WHERE is_deleted = false and don't include the field)
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         description = try container.decodeIfPresent(String.self, forKey: .description)
+        status = try container.decodeIfPresent(String.self, forKey: .status) ?? "active"
         color = try container.decodeIfPresent(String.self, forKey: .color)
         isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted) ?? false
+        sortOrder = try container.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
         startTime = try container.decodeIfPresent(Int64.self, forKey: .startTime)
         dueTime = try container.decodeIfPresent(Int64.self, forKey: .dueTime)
         createdAt = try container.decode(Int64.self, forKey: .createdAt)

--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -355,8 +355,10 @@ struct ArcProjectionTests {
             "id": "arc-100",
             "title": "Q1 Sprint",
             "description": "First quarter deliverables",
+            "status": "active",
             "colorHex": "#3498DB",
             "isDeleted": false,
+            "sortOrder": 2,
             "startAt": 1707500000,
             "dueAt": 1708500000,
             "createdAt": 1707000000,
@@ -371,8 +373,10 @@ struct ArcProjectionTests {
         #expect(arc.id == "arc-100")
         #expect(arc.title == "Q1 Sprint")
         #expect(arc.description == "First quarter deliverables")
+        #expect(arc.status == "active")
         #expect(arc.color == "#3498DB")
         #expect(arc.isDeleted == false)
+        #expect(arc.sortOrder == 2)
         #expect(arc.startTime == 1_707_500_000)
         #expect(arc.dueTime == 1_708_500_000)
         #expect(arc.createdAt == 1_707_000_000)
@@ -386,7 +390,9 @@ struct ArcProjectionTests {
         {
             "id": "arc-api",
             "title": "From API",
+            "status": "completed",
             "colorHex": "#FF0000",
+            "sortOrder": 5,
             "startAt": null,
             "dueAt": null,
             "createdAt": 1707000000,
@@ -400,7 +406,9 @@ struct ArcProjectionTests {
 
         #expect(arc.id == "arc-api")
         #expect(arc.isDeleted == false)
+        #expect(arc.status == "completed")
         #expect(arc.color == "#FF0000")
+        #expect(arc.sortOrder == 5)
         #expect(arc.description == nil)
     }
 
@@ -422,6 +430,8 @@ struct ArcProjectionTests {
         #expect(arc.description == nil)
         #expect(arc.color == nil)
         #expect(arc.isDeleted == false)
+        #expect(arc.status == "active")
+        #expect(arc.sortOrder == 0)
         #expect(arc.startTime == nil)
         #expect(arc.dueTime == nil)
     }


### PR DESCRIPTION
## Problem

StackProjection and ArcProjection were missing several fields from the API response. This caused data loss during projection sync (DEQ-230):

### StackProjection
1. **Stack ordering lost**: All stacks got `sortOrder=0` after sync, losing user's custom ordering
2. **Active task reference lost**: `activeTaskId` was always nil after sync

### ArcProjection
3. **Arc status reset**: All arcs defaulted to `active` status after sync (ignoring completed/paused/archived)
4. **Arc ordering lost**: All arcs got `sortOrder=0` after sync

## Root Cause

Same class of bug as PRs #351, #352, #353 — projection types didn't capture all fields from the API response.

## Fix

### StackProjection
- Add `sortOrder` (with `decodeIfPresent` defaulting to 0) and `activeTaskId`
- Populate both fields in `populateStacks()`

### ArcProjection
- Add `status` (defaults to `active`) and `sortOrder` (defaults to 0)
- Add `parseArcStatus()` helper function
- Populate both fields in `populateArcs()`

## Testing

- All 6 projection tests updated and passing locally (3 Stack + 3 Arc)
- Build succeeds
- SwiftLint clean