### PR TITLE
feat: wire StreakDashboardView into Settings navigation

### DIFF
--- a/Dequeue/Dequeue/Views/Settings/SettingsView.swift
+++ b/Dequeue/Dequeue/Views/Settings/SettingsView.swift
@@ -125,6 +125,11 @@ struct SettingsView: View {
                 Label("Statistics", systemImage: "chart.bar")
             }
             NavigationLink {
+                StreakDashboardView()
+            } label: {
+                Label("Streaks", systemImage: "flame")
+            }
+            NavigationLink {
                 ExportView()
             } label: {
                 Label("Export Data", systemImage: "square.and.arrow.up")


### PR DESCRIPTION
## Summary

Add a 'Streaks' navigation link in the Settings > Data section, making the existing `StreakDashboardView` accessible to users.

## What This Does

The `StreakDashboardView` was already fully implemented but never linked into the app's navigation. This single-line change adds it to Settings between Statistics and Export Data.

## What Users See

A new 'Streaks' item in Settings that opens a rich dashboard:
- 🔥 Current and best streak counts with gradient card
- 📊 Weekly activity bar chart (tasks per day)
- 🗓️ Monthly heatmap (last 30 days, GitHub-style)
- 📈 Stats grid (total tasks, active days, today, best streak)
- 🏆 Milestone achievements tracker

## Files Changed

| File | Change |
|------|--------|
| `SettingsView.swift` | +5 lines: NavigationLink to StreakDashboardView |

## Testing

- Build succeeds ✅
- SwiftLint: 0 violations ✅
- The StreakTrackerService uses UserDefaults (self-contained, no new dependencies)