### PR TITLE
fix: add CancellationError handling to WebhookDetailView

### DIFF
--- a/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
+++ b/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
@@ -301,6 +301,10 @@ struct WebhookDetailView: View {
             deliveries = response.data
             nextCursor = response.pagination.nextCursor
             hasMore = response.pagination.hasMore
+        } catch is CancellationError {
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return
         } catch {
             logger.error("Failed to load deliveries: \(error)")
             errorMessage = error.localizedDescription
@@ -315,6 +319,10 @@ struct WebhookDetailView: View {
             deliveries.append(contentsOf: response.data)
             nextCursor = response.pagination.nextCursor
             hasMore = response.pagination.hasMore
+        } catch is CancellationError {
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return
         } catch {
             logger.error("Failed to load more deliveries: \(error)")
             errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary

Add missing `CancellationError` and `URLError(.cancelled)` handling to `WebhookDetailView`'s network functions.

## Problem

`loadDeliveries()` and `loadMoreDeliveries()` are called from `.task` blocks but didn't handle task cancellation. When navigating away from the view while a request was in-flight, the catch block would set the error message to `"cancelled"` and show it to the user.

This is the same bug pattern fixed in PR #356 for the main WebhooksView list, APIKeysSettingsView, and StatsView — this instance in `WebhookDetailView` was missed.

## Fix

Add `catch is CancellationError` and `catch let urlError as URLError where urlError.code == .cancelled` handlers before the generic catch in both functions, matching the established pattern.

## Files Changed

| File | Change |
|------|--------|
| `WebhooksView.swift` | +8 lines: CancellationError handling in loadDeliveries/loadMore |