### PR TITLE
fix: move widget update to .inactive to prevent snapshot crash

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -344,21 +344,24 @@ struct RootView: View {
                     }
                 }
             case .background:
-                // Update widget data before going to background (DEQ-120)
-                // This ensures widgets show the latest state when the user leaves the app
-                WidgetDataService.updateAllWidgets(context: modelContext)
-
-                // Suspend sync, then flush Sentry — all off the main thread.
-                // Order matters: suspend first so any teardown errors get captured
-                // by the subsequent Sentry flush. Using a single Task ensures
-                // sequential execution without blocking the main thread.
+                // ⚠️ DO NOT perform synchronous SwiftData queries here.
+                // iOS takes a snapshot for the app switcher during the .background
+                // transition. Any synchronous SwiftData access via performAndWait
+                // causes a reentrancy assertion failure in NSManagedObjectContext
+                // when the snapshot triggers SwiftUI layout (which also accesses
+                // SwiftData through @Query views).
+                //
+                // Widget update moved to .inactive (fires before .background).
                 Task {
                     await syncManager.suspendForBackground()
                     ErrorReportingService.prepareForBackground()
                 }
             case .inactive:
-                // No logging needed for inactive state
-                break
+                // Update widget data when going inactive (before .background).
+                // This runs before iOS takes the app switcher snapshot, avoiding
+                // the NSManagedObjectContext reentrancy crash that occurs when
+                // synchronous SwiftData queries run during snapshot rendering.
+                WidgetDataService.updateAllWidgets(context: modelContext)
             @unknown default:
                 break
             }


### PR DESCRIPTION
## The Crash

**Every single time** Victor backgrounds the app, it crashes with:
```
EXC_BREAKPOINT (SIGTRAP) - _assertionFailure in libswiftCore
Thread 0 (main), Queue: NSManagedObjectContext
```

## Root Cause

When iOS backgrounds the app, it takes a **snapshot** for the app switcher (`_performSnapshotsWithAction:forScene:completion:`). This snapshot triggers SwiftUI layout (`_UIHostingView.layoutSubviews`), which evaluates `@Query` views through SwiftData's `NSManagedObjectContext.performAndWait`.

Meanwhile, `WidgetDataService.updateAllWidgets()` was running **synchronously** in the `.background` scene phase handler, also doing SwiftData queries via `performAndWait`. This created a **reentrancy** in `NSManagedObjectContext`, triggering a Swift assertion failure.

## The Fix

Move `WidgetDataService.updateAllWidgets()` from `.background` to `.inactive`.

The `.inactive` phase fires **before** `.background` and **before** iOS takes the snapshot. This eliminates the reentrancy — widget data is updated first, then iOS can safely snapshot without conflicting SwiftData access.

## Crash Stack Trace (abbreviated)

```
Thread 0 (triggered):
  _assertionFailure(_:_:file:line:flags:)     ← Swift assertion
  [SwiftData framework - 30+ frames]          ← SwiftData internal
  NSManagedObjectContext.performAndWait        ← Reentrancy!
  [SwiftData framework]
  _ValueActionModifier2.sendAction(old:)       ← SwiftUI value change
  ViewGraphRootValueUpdater.render()           ← SwiftUI render
  _UIHostingView.layoutSubviews()              ← View layout
  _performSnapshotsWithAction:forScene:        ← iOS snapshot trigger
```

## Device Info
- iPhone 16 Pro Max (iPhone17,2)
- iOS 26.3 (23D127)
- Build 198

## This Also Explains Why Sentry Wasn't Capturing

The Sentry crash handler threads were visible in the crash log (`SentryCrash Exception Handler Primary/Secondary`), but the Primary handler was in `_pthread_exit` — dying before it could process the crash. This is likely because the crash occurs during UIKit's snapshot phase, which has restricted execution context.