### PR TITLE
fix: resolve sync "Connecting..." stuck state after max reconnect attempts

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -1394,9 +1394,16 @@ actor SyncManager {
         let currentAttempts = reconnectAttempts
         guard currentAttempts < maxReconnectAttempts,
               token != nil else {
+            // Clean up the stale WebSocket task so connectionStatus correctly
+            // reports .disconnected ("Offline") instead of .connecting ("Connecting...").
+            // Without this, webSocketTask remains non-nil after exhausting retries,
+            // causing the UI to show "Connecting..." indefinitely.
+            webSocketTask?.cancel(with: .goingAway, reason: nil)
+            webSocketTask = nil
+            os_log("[Sync] Giving up reconnection after \(currentAttempts) attempts")
             await ErrorReportingService.addBreadcrumb(
                 category: "sync",
-                message: "Max reconnect attempts reached",
+                message: "Max reconnect attempts reached, transitioning to disconnected",
                 data: ["attempts": currentAttempts]
             )
             return


### PR DESCRIPTION
## Problem

Victor's devices showed sync permanently stuck in "Connecting..." state. The UI never transitioned to "Offline" even when the WebSocket was truly disconnected.

## Root Cause

In `SyncManager.handleDisconnect()`, when all 10 reconnect attempts are exhausted, the method returned without cleaning up `webSocketTask`. This left:

- `webSocketTask != nil` (stale reference to a failed WebSocket)
- `isConnected == false`

The `connectionStatus` computed property:
```swift
var connectionStatus: ConnectionStatus {
    guard webSocketTask != nil else { return .disconnected }
    return isConnected ? .connected : .connecting
}
```

...returns `.connecting` when `webSocketTask` exists but `isConnected` is false, causing the UI to permanently display "Connecting..." instead of "Offline".

## Fix

Cancel and nil the `webSocketTask` when giving up on reconnection, so `connectionStatus` correctly reports `.disconnected` and the UI shows "Offline".

This is a 3-line fix (plus logging) with no behavior change to the reconnection logic itself — it only affects the terminal state when reconnection has been abandoned.

## Testing

- SwiftLint: ✅ 0 violations
- Build/CI: Relies on GitHub Actions (local Xcode has IDESimulatorFoundation plugin issue)