### PR TITLE
fix(tests): correct TaskProjection test field names to match API schema

### DIFF
--- a/Dequeue/DequeueTests/SyncTypesTests.swift
+++ b/Dequeue/DequeueTests/SyncTypesTests.swift
@@ -292,12 +292,12 @@ struct TaskProjectionTests {
             "id": "task-001",
             "stackId": "stack-abc",
             "title": "Buy milk",
-            "description": "Organic whole milk",
+            "notes": "Organic whole milk",
             "sortOrder": 0,
             "status": "pending",
             "isActive": true,
-            "startTime": 1708000000,
-            "dueTime": 1708086400,
+            "startAt": 1708000000,
+            "dueAt": 1708086400,
             "createdAt": 1707900000,
             "updatedAt": 1708000000
         }
@@ -310,7 +310,7 @@ struct TaskProjectionTests {
         #expect(task.id == "task-001")
         #expect(task.stackId == "stack-abc")
         #expect(task.title == "Buy milk")
-        #expect(task.description == "Organic whole milk")
+        #expect(task.notes == "Organic whole milk")
         #expect(task.sortOrder == 0)
         #expect(task.status == "pending")
         #expect(task.isActive == true)
@@ -337,7 +337,7 @@ struct TaskProjectionTests {
             TaskProjection.self, from: json
         )
 
-        #expect(task.description == nil)
+        #expect(task.notes == nil)
         #expect(task.startTime == nil)
         #expect(task.dueTime == nil)
     }


### PR DESCRIPTION
## Summary

Fixes compilation errors in `SyncTypesTests.swift` on macOS 26 / Xcode 26.3 by correcting field names in `TaskProjectionTests` to match the actual `TaskProjection` struct and API response format.

## Changes

- **JSON test data**: Changed `"description"` → `"notes"` (TaskProjection uses `notes`, not `description`)
- **JSON test data**: Changed `"startTime"`/`"dueTime"` → `"startAt"`/`"dueAt"` (matching CodingKeys which map API field names)
- **Assertions**: Changed `task.description` → `task.notes` to reference the actual property

## Root Cause

`TaskProjection` uses `notes: String?` for task descriptions (matching the API), while `StackProjection` and `ArcProjection` use `description: String?`. The test was incorrectly using `description` for tasks. Similarly, the CodingKeys map `startAt` → `startTime` and `dueAt` → `dueTime`, so JSON test data needs to use the API-side names.

## Testing

- ✅ Build succeeds (`xcodebuild build-for-testing`)
- ✅ TaskProjection tests pass locally
- ✅ SwiftLint clean