### PR TITLE
fix(ci): detect build failures that silently passed as success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,11 @@ jobs:
 
           # Parse results
           RESULTS_JSON=$(xcrun xcresulttool get --format json --path UnitTestResults.xcresult 2>/dev/null || echo "{}")
-          FAILED_COUNT=$(echo "$RESULTS_JSON" | grep -o '"testsFailedCount"[[:space:]]*:[[:space:]]*{"_value"[[:space:]]*:[[:space:]]*"[0-9]*"' | grep -o '[0-9]*$' | head -1 || echo "0")
-          PASSED_COUNT=$(echo "$RESULTS_JSON" | grep -o '"testsPassedCount"[[:space:]]*:[[:space:]]*{"_value"[[:space:]]*:[[:space:]]*"[0-9]*"' | grep -o '[0-9]*$' | head -1 || echo "0")
+          FAILED_COUNT=$(echo "$RESULTS_JSON" | grep -o '"testsFailedCount"[[:space:]]*:[[:space:]]*{"_value"[[:space:]]*:[[:space:]]*"[0-9]*"' | grep -o '[0-9]*$' | head -1 || true)
+          PASSED_COUNT=$(echo "$RESULTS_JSON" | grep -o '"testsPassedCount"[[:space:]]*:[[:space:]]*{"_value"[[:space:]]*:[[:space:]]*"[0-9]*"' | grep -o '[0-9]*$' | head -1 || true)
+          # Default to empty if grep found nothing (pipeline exit code from head masks grep failure)
+          FAILED_COUNT="${FAILED_COUNT:-}"
+          PASSED_COUNT="${PASSED_COUNT:-}"
 
           echo "Tests passed: $PASSED_COUNT"
           echo "Tests failed: $FAILED_COUNT"
@@ -217,10 +220,15 @@ jobs:
             exit 0
           fi
 
-          # Exit code 65 with no failures = test runner crash, not test failure
+          # Exit code 65 with no failures but SOME tests passed = test runner crash, not test failure
+          # If no tests passed either, this is likely a build failure — don't silently pass
           if [ "$XCODEBUILD_EXIT" = "65" ]; then
-            echo "::warning::xcodebuild returned exit code 65 but no test failures detected"
-            exit 0
+            if [ -n "$PASSED_COUNT" ] && [ "$PASSED_COUNT" != "0" ]; then
+              echo "::warning::xcodebuild returned exit code 65 but $PASSED_COUNT tests passed with no failures — likely test runner crash"
+              exit 0
+            fi
+            echo "::error::xcodebuild returned exit code 65 with no tests executed — likely a build failure"
+            exit 1
           fi
 
           # No tests ran and xcodebuild failed — don't silently pass


### PR DESCRIPTION
## Summary

Fixes a bug in the Unit Tests CI job where build failures were silently treated as passing.

## Problem

When `xcodebuild test` returns exit code 65 (which covers both **test failures** and **build failures**), the CI script checked if any test failures were detected and, if none, treated it as a success. This silently passed builds that failed to compile — the test result parser found 0 failures (because no tests ran) and the exit code 65 fallback assumed it was a test runner crash.

**Example on main:** `SyncTypesTests.swift` had a compilation error on macOS 15 runners, causing `xcodebuild test` to exit 65 with "Testing cancelled because the build failed." The CI job reported ✅ success.

## Fix

When exit code 65 is detected:
- **Some tests passed** → Treat as warning (test runner crash after partial execution) — existing behavior preserved
- **No tests passed** → Fail the job — likely a build failure

Also improves the grep pipeline fallback comment for clarity.

## Testing

This is a CI-only change. The fix is verified by analyzing the exact flow of the previous false-positive success on main branch.