### PR TITLE
fix: prevent SwiftData crash during iOS snapshot with overlay

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -328,14 +328,25 @@ struct RootView: View {
             }
         }
         #if os(iOS)
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
-            // Show overlay BEFORE iOS takes the snapshot.
-            // willResignActive fires before the snapshot render pass.
-            showSnapshotOverlay = true
+        .task {
+            // UIApplication notifications only work in the actual app, not in test runners
+            guard !ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath") else {
+                return
+            }
+
+            // Listen for UIKit-level notifications (fire before scenePhase changes)
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.willResignActiveNotification) {
+                showSnapshotOverlay = true
+            }
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-            // Remove overlay when app returns to foreground
-            showSnapshotOverlay = false
+        .task {
+            guard !ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath") else {
+                return
+            }
+
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.didBecomeActiveNotification) {
+                showSnapshotOverlay = false
+            }
         }
         #endif
         .task {


### PR DESCRIPTION
## P0 — App crashes every time it's backgrounded

Build 203 (with PR #362's .inactive fix) still crashes. The previous fix was wrong — the crash is NOT from our `onChange` handler. It's from SwiftUI's own rendering of `@Query` views during the iOS app-switcher snapshot.

## Root Cause

When iOS backgrounds the app, it takes a snapshot for the app switcher via `_performSnapshotsWithAction:forScene:completion:`. During this snapshot:

1. SwiftUI renders the current view hierarchy (`_UIHostingView.layoutSubviews`)
2. `@Query` views trigger SwiftData's `NSManagedObjectContext.performAndWait`
3. SwiftData hits an internal assertion failure (`_assertionFailure` in libswiftCore, 30+ frames deep in SwiftData framework)
4. App crashes with EXC_BREAKPOINT/SIGTRAP

This happens on **every** background transition, including taking screenshots.

## The Fix

**Snapshot privacy overlay**: Before iOS takes the snapshot, cover the entire view hierarchy with an opaque overlay. This prevents `@Query` views from being rendered during the snapshot.

- Uses `willResignActiveNotification` (UIKit level) which fires **before** the snapshot
- Shows a simple solid background + icon overlay  
- Removes overlay on `didBecomeActiveNotification`
- No animation (`.transition(.identity)`) — must be instant

Also moved `WidgetDataService.updateAllWidgets()` from `.inactive` to the `.active` handler to eliminate all SwiftData queries during the background transition.

## Testing

1. Open app, navigate to any tab
2. Background the app (swipe up / press home)  
3. **Should NOT crash**
4. Return to app — overlay should disappear instantly
5. Repeat from different tabs (Stacks, Activity, Settings)