### PR TITLE
test(filters): add extended coverage for TaskFilterService

### DIFF
--- a/Dequeue/DequeueTests/TaskFilterTests.swift
+++ b/Dequeue/DequeueTests/TaskFilterTests.swift
@@ -523,6 +523,7 @@ struct TaskFilterServiceExtendedTests {
         let context = try makeFilterTestContext()
         let task = try makeFilterTask(title: "Task A", in: context)
         task.taskDescription = "This needs backend work"
+        try context.save()
         let taskB = try makeFilterTask(title: "Task B", in: context)
 
         let service = TaskFilterService(modelContext: context)
@@ -686,7 +687,7 @@ struct TaskFilterServiceExtendedTests {
         let service = TaskFilterService(modelContext: context)
         var filter = TaskFilter()
         filter.dateRangeFilter = .custom
-        filter.customStartDate = cal.date(byAdding: .day, value: -1, to: now)
+        filter.customStartDate = try #require(cal.date(byAdding: .day, value: -1, to: now))
         filter.customEndDate = twoDaysFromNow
         let results = service.apply(filter: filter, to: [t1, t2, t3])
 
@@ -776,8 +777,9 @@ struct TaskFilterServiceExtendedTests {
 struct DateRangeFilterExtendedTests {
     @Test("Tomorrow returns correct bounds")
     func tomorrowRange() {
-        let range = DateRangeFilter.tomorrow.dateRange()
-        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let now = Date()
+        let range = DateRangeFilter.tomorrow.dateRange(from: now)
+        let startOfToday = Calendar.current.startOfDay(for: now)
         let expectedStart = Calendar.current.date(byAdding: .day, value: 1, to: startOfToday)
         let expectedEnd = Calendar.current.date(byAdding: .day, value: 2, to: startOfToday)
         #expect(range.start == expectedStart)
@@ -786,8 +788,9 @@ struct DateRangeFilterExtendedTests {
 
     @Test("Next week spans days 7 through 14")
     func nextWeekRange() {
-        let range = DateRangeFilter.nextWeek.dateRange()
-        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let now = Date()
+        let range = DateRangeFilter.nextWeek.dateRange(from: now)
+        let startOfToday = Calendar.current.startOfDay(for: now)
         let expectedStart = Calendar.current.date(byAdding: .day, value: 7, to: startOfToday)
         let expectedEnd = Calendar.current.date(byAdding: .day, value: 14, to: startOfToday)
         #expect(range.start == expectedStart)
@@ -796,8 +799,9 @@ struct DateRangeFilterExtendedTests {
 
     @Test("This month spans 1 month from today")
     func thisMonthRange() {
-        let range = DateRangeFilter.thisMonth.dateRange()
-        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let now = Date()
+        let range = DateRangeFilter.thisMonth.dateRange(from: now)
+        let startOfToday = Calendar.current.startOfDay(for: now)
         let expectedEnd = Calendar.current.date(byAdding: .month, value: 1, to: startOfToday)
         #expect(range.start == startOfToday)
         #expect(range.end == expectedEnd)


### PR DESCRIPTION
## Summary

Adds 15 new test cases to `TaskFilterTests.swift` covering previously untested filter scenarios in `TaskFilterService`.

## New Test Coverage

### Search (`TaskFilterServiceExtendedTests`)
- Search by task **description** (not just title)
- Search by **tag content**
- Search with **no matches** returns empty

### Stack Filters
- Single stack selection filters correctly
- Multiple stack selection uses **OR logic**

### Sorting
- Sort by **sortOrder** ascending
- Sort by **dueDate** places nil due dates **last** (ascending)

### Date Range Filters
- **Overdue** filter returns only tasks before today
- **Custom date range** with start and end bounds
- **Custom date range** with only start date (open-ended)

### Combined Filters
- **Status + tags + search** combined correctly (all filters AND'd together)
- **Empty input** returns empty results
- **Blocked** status filter

### DateRangeFilter Extended
- Tomorrow, nextWeek, thisMonth bound calculations
- Custom returns nil bounds (handled separately)
- `dateRange(from:)` uses reference date correctly

### Property Validation
- PriorityFilter display names and colors
- StatusFilter display names

## Test Pattern

All tests follow the existing codebase pattern:
- `makeFilterTestContext()` for in-memory ModelContainer
- `makeFilterTask()` helper for QueueTask creation
- `@MainActor` annotation for Swift 6 concurrency compliance
- `.serialized` trait on extended suite to avoid runtime deallocation crashes

No production code changes.