### PR TITLE
fix: replace nonisolated(unsafe) with nonisolated per Swift 6 guidance

### DIFF
--- a/Dequeue/Dequeue/Services/AuthService.swift
+++ b/Dequeue/Dequeue/Services/AuthService.swift
@@ -67,9 +67,9 @@ final class ClerkAuthService: AuthServiceProtocol {
     private(set) var currentUserId: String?
 
     // Session state change stream for multi-device session handling
-    // Note: continuation is nonisolated(unsafe) to allow access from deinit
+    // Note: continuation is nonisolated to allow access from deinit
     private let sessionStateChangesStream: AsyncStream<SessionStateChange>
-    nonisolated(unsafe) private var sessionStateChangeContinuation: AsyncStream<SessionStateChange>.Continuation?
+    nonisolated private var sessionStateChangeContinuation: AsyncStream<SessionStateChange>.Continuation?
 
     /// Stream of session state changes for observing unexpected auth events
     /// Use this to react to sessions being invalidated or restored in multi-device scenarios
@@ -358,7 +358,7 @@ final class MockAuthService: AuthServiceProtocol {
     var currentUserId: String?
 
     private let sessionStateChangesStream: AsyncStream<SessionStateChange>
-    nonisolated(unsafe) private var sessionStateChangeContinuation: AsyncStream<SessionStateChange>.Continuation?
+    nonisolated private var sessionStateChangeContinuation: AsyncStream<SessionStateChange>.Continuation?
 
     var sessionStateChanges: AsyncStream<SessionStateChange> {
         sessionStateChangesStream

--- a/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
+++ b/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
@@ -49,9 +49,8 @@ internal final class SyncStatusViewModel {
     private let modelContext: ModelContext
     private let eventService: EventService
     private var syncManager: SyncManager?
-    // nonisolated(unsafe) allows access from deinit for cleanup with @Observable.
-    // Must use unsafe variant for compatibility across Swift 6.x toolchains.
-    nonisolated(unsafe) private var updateTask: Task<Void, Never>?
+    // nonisolated allows access from deinit for cleanup with @Observable.
+    nonisolated private var updateTask: Task<Void, Never>?
     private var previousPendingCount: Int = 0
 
     init(modelContext: ModelContext) {


### PR DESCRIPTION
## Summary

Resolves 3 compiler warnings introduced by recent Swift 6.x toolchain updates.

### Changes

- **AuthService.swift** (2 instances): `nonisolated(unsafe)` → `nonisolated` on `sessionStateChangeContinuation` in both `AuthService` and `MockAuthService`
- **SyncStatusViewModel.swift** (1 instance): `nonisolated(unsafe)` → `nonisolated` on `updateTask`

### Context

The Swift compiler now warns that `nonisolated(unsafe)` has no effect on these properties and suggests using plain `nonisolated` instead. The `(unsafe)` variant was originally needed for deinit access patterns in earlier Swift 6.x betas but is no longer required.

### Verification

- ✅ Zero compiler warnings after change
- ✅ SwiftLint: 0 violations
- ✅ Build succeeds (macOS)