### PR TITLE
feat(observability): Sentry performance transactions for sync ops (DEQ-248)

### DIFF
--- a/Dequeue/Dequeue/Services/ErrorReportingService+SyncObservability.swift
+++ b/Dequeue/Dequeue/Services/ErrorReportingService+SyncObservability.swift
@@ -2,11 +2,13 @@
 //  ErrorReportingService+SyncObservability.swift
 //  Dequeue
 //
-//  Remote observability for sync operations. Provides structured Sentry breadcrumbs
-//  and error events so sync failures can be diagnosed without Xcode console logs.
+//  Remote observability for sync operations. Provides structured Sentry breadcrumbs,
+//  error events, and performance transactions so sync behaviour can be diagnosed
+//  and profiled without Xcode console logs.
 //
 //  DEQ-246: Structured Sentry breadcrumbs for all sync & network operations
 //  DEQ-247: Fire Sentry error events on critical API failures (4xx/5xx)
+//  DEQ-248: Sentry performance transactions for sync health metrics
 //
 
 import Foundation
@@ -275,6 +277,80 @@ extension ErrorReportingService {
                 }
             }
         }
+    }
+
+    // MARK: - Performance Transactions (DEQ-248)
+    //
+    // Design note: The Sentry `Span` protocol is @MainActor-isolated in strict Swift 6
+    // concurrency mode, so all Sentry performance API calls must happen on MainActor.
+    // SyncManager (a custom actor) therefore records plain `Date` values for timing,
+    // then calls these @MainActor methods at operation completion to create and
+    // immediately finish a transaction with a retroactive startTimestamp.
+    //
+    // This gives accurate total-duration traces in Sentry Performance without
+    // any Span objects ever crossing actor boundaries.
+
+    /// Timing and entity-count metrics captured by `SyncManager` during a projection sync.
+    struct ProjectionSyncMetrics {
+        let syncId: String
+        let syncStart: Date
+        let fetchDurationMs: Int
+        let populateDurationMs: Int
+        let stacks: Int
+        let tasks: Int
+        let arcs: Int
+        let tags: Int
+        let reminders: Int
+        let success: Bool
+    }
+
+    /// Records a completed projection sync as a Sentry performance transaction.
+    ///
+    /// The transaction's start timestamp is set retroactively to `metrics.syncStart`,
+    /// so the duration visible in Sentry Performance matches the actual wall-clock time.
+    @MainActor
+    static func recordProjectionSyncTransaction(_ metrics: ProjectionSyncMetrics) {
+        let tx = SentrySDK.startTransaction(name: "Projection Sync", operation: "sync.projection")
+        tx.startTimestamp = metrics.syncStart
+        tx.setData(value: metrics.syncId, key: "sync_id")
+
+        let totalEntities = metrics.stacks + metrics.tasks + metrics.arcs + metrics.tags + metrics.reminders
+        tx.setData(value: totalEntities, key: "entity_count")
+        tx.setData(value: metrics.stacks, key: "stacks")
+        tx.setData(value: metrics.tasks, key: "tasks")
+        tx.setData(value: metrics.arcs, key: "arcs")
+        tx.setData(value: metrics.tags, key: "tags")
+        tx.setData(value: metrics.reminders, key: "reminders")
+
+        // Sub-operation durations as Sentry measurements (visible alongside the transaction)
+        tx.setMeasurement(name: "fetch_duration_ms", value: NSNumber(value: metrics.fetchDurationMs))
+        tx.setMeasurement(name: "populate_duration_ms", value: NSNumber(value: metrics.populateDurationMs))
+
+        tx.finish(status: metrics.success ? .ok : .internalError)
+    }
+
+    /// Timing metrics captured by `SyncManager` during an event push cycle.
+    struct EventPushMetrics {
+        let syncId: String
+        let pushStart: Date
+        let httpDurationMs: Int
+        let eventCount: Int
+        let httpStatusCode: Int
+        let success: Bool
+    }
+
+    /// Records a completed event push cycle as a Sentry performance transaction.
+    ///
+    /// The transaction's start timestamp is set retroactively to `metrics.pushStart`.
+    @MainActor
+    static func recordEventPushTransaction(_ metrics: EventPushMetrics) {
+        let tx = SentrySDK.startTransaction(name: "Event Push", operation: "sync.push")
+        tx.startTimestamp = metrics.pushStart
+        tx.setData(value: metrics.syncId, key: "sync_id")
+        tx.setData(value: metrics.eventCount, key: "event_count")
+        tx.setData(value: metrics.httpStatusCode, key: "http.status_code")
+        tx.setMeasurement(name: "http_duration_ms", value: NSNumber(value: metrics.httpDurationMs))
+        tx.finish(status: metrics.success ? .ok : .internalError)
     }
 
     // MARK: - Private Helpers

--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -24,7 +24,7 @@ extension SyncManager {
     ///
     /// Falls back to event replay if projection fetch fails.
     func syncViaProjections() async throws {
-        let startTime = Date()
+        let syncStart = Date()
         let syncId = Self.generateSyncId()
         os_log("[Sync] Projection sync started: syncId=\(syncId)")
 
@@ -41,6 +41,10 @@ extension SyncManager {
         }
 
         let baseURL = await MainActor.run { Configuration.dequeueAPIBaseURL }
+
+        // ── Fetch phase ──────────────────────────────────────────────────────────────
+        // DEQ-248: Record fetch-phase wall-clock timing for Sentry performance transaction.
+        let fetchStart = Date()
 
         // Fetch all resource types in parallel
         // Note: dequeueAPIBaseURL already includes /v1 prefix, so paths are relative
@@ -68,24 +72,29 @@ extension SyncManager {
             let tags = try await tagsTask
             let reminders = try await remindersTask
 
+            let fetchDurationMs = Int(Date().timeIntervalSince(fetchStart) * 1_000)
+
             let sc = stacks.count, tc = tasks.count, ac = arcs.count
             let tgc = tags.count, rc = reminders.count
             os_log("[Sync] Fetched projections: \(sc) stacks, \(tc) tasks, \(ac) arcs, \(tgc) tags, \(rc) reminders")
 
-            // Populate local models
+            // ── Populate phase ────────────────────────────────────────────────────────
+            let populateStart = Date()
             try await populateFromProjections(
                 stacks: stacks, tasks: tasks, arcs: arcs, tags: tags, reminders: reminders
             )
+            let populateDurationMs = Int(Date().timeIntervalSince(populateStart) * 1_000)
 
             // Set checkpoint to now (all future events will be synced incrementally)
             let checkpoint = Self.iso8601Standard.string(from: Date())
             saveLastSyncCheckpoint(checkpoint)
 
-            let duration = Date().timeIntervalSince(startTime)
+            let duration = Date().timeIntervalSince(syncStart)
             let durationFormatted = String(format: "%.2f", duration)
             os_log("[Sync] Projection sync complete: syncId=\(syncId), duration=\(durationFormatted)s")
 
             await MainActor.run {
+                // Existing breadcrumb + log
                 ErrorReportingService.logProjectionSyncComplete(
                     stacks: stacks.count,
                     tasks: tasks.count,
@@ -93,6 +102,23 @@ extension SyncManager {
                     tags: tags.count,
                     reminders: reminders.count,
                     duration: duration
+                )
+
+                // DEQ-248: Record Sentry performance transaction with retroactive start time.
+                // All Sentry Span API calls must happen on MainActor (strict concurrency).
+                ErrorReportingService.recordProjectionSyncTransaction(
+                    .init(
+                        syncId: syncId,
+                        syncStart: syncStart,
+                        fetchDurationMs: fetchDurationMs,
+                        populateDurationMs: populateDurationMs,
+                        stacks: stacks.count,
+                        tasks: tasks.count,
+                        arcs: arcs.count,
+                        tags: tags.count,
+                        reminders: reminders.count,
+                        success: true
+                    )
                 )
             }
 
@@ -103,10 +129,21 @@ extension SyncManager {
                 itemsDownloaded: stacks.count + tasks.count + arcs.count + tags.count + reminders.count
             )
         } catch {
-            let duration = Date().timeIntervalSince(startTime)
+            let duration = Date().timeIntervalSince(syncStart)
             os_log("[Sync] Projection sync failed: \(error.localizedDescription)")
             await MainActor.run {
                 ErrorReportingService.logProjectionSyncFailed(error: error, duration: duration)
+                // DEQ-248: Still record a failed transaction so we can see failure rates.
+                ErrorReportingService.recordProjectionSyncTransaction(
+                    .init(
+                        syncId: syncId,
+                        syncStart: syncStart,
+                        fetchDurationMs: Int(duration * 1_000),
+                        populateDurationMs: 0,
+                        stacks: 0, tasks: 0, arcs: 0, tags: 0, reminders: 0,
+                        success: false
+                    )
+                )
             }
             throw error
         }

--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -535,9 +535,9 @@ actor SyncManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: ["events": syncEvents])
 
-        let pushStartTime = Date()
+        let httpStart = Date()
         let (data, response) = try await syncSession.data(for: request)
-        let pushDuration = Date().timeIntervalSince(pushStartTime)
+        let pushDuration = Date().timeIntervalSince(httpStart)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw SyncError.pushFailed
@@ -601,6 +601,19 @@ actor SyncManager {
             os_log("[Sync] Push completed: syncId=\(syncId), duration=\(String(format: "%.2f", duration))s")
             await MainActor.run {
                 ErrorReportingService.logSyncPush(eventCount: pendingEventData.count, duration: duration, success: true)
+
+                // DEQ-248: Record Sentry performance transaction with retroactive start time.
+                // All Sentry Span API calls must happen on MainActor (strict concurrency).
+                ErrorReportingService.recordEventPushTransaction(
+                    .init(
+                        syncId: syncId,
+                        pushStart: startTime,
+                        httpDurationMs: Int(pushDuration * 1_000),
+                        eventCount: pendingEventData.count,
+                        httpStatusCode: httpResponse.statusCode,
+                        success: true
+                    )
+                )
             }
             await ErrorReportingService.logSyncComplete(
                 syncId: syncId,
@@ -613,6 +626,8 @@ actor SyncManager {
             // The reachability check can take 2+ seconds, which would delay sync retry unnecessarily
             let duration = Date().timeIntervalSince(startTime)
             let capturedError = error
+            let capturedHttpStatus = httpResponse.statusCode
+            let capturedEventCount = pendingEventData.count
             Task.detached(priority: .utility) {
                 let failureReason = await NetworkReachability.classifyFailure(error: capturedError)
                 await ErrorReportingService.logSyncFailure(
@@ -622,6 +637,19 @@ actor SyncManager {
                     failureReason: failureReason.description,
                     internetReachable: failureReason.isServerProblem
                 )
+                // DEQ-248: Record failed push transaction.
+                await MainActor.run {
+                    ErrorReportingService.recordEventPushTransaction(
+                        .init(
+                            syncId: syncId,
+                            pushStart: startTime,
+                            httpDurationMs: Int(pushDuration * 1_000),
+                            eventCount: capturedEventCount,
+                            httpStatusCode: capturedHttpStatus,
+                            success: false
+                        )
+                    )
+                }
             }
             throw error
         }


### PR DESCRIPTION
## Summary

Adds Sentry Performance transaction recording for projection sync and event push operations, implementing DEQ-248.

## What changed

### `ErrorReportingService+SyncObservability.swift`
- Adds `ProjectionSyncMetrics` and `EventPushMetrics` structs to keep API ergonomic and stay within SwiftLint's parameter-count limit
- Adds `@MainActor recordProjectionSyncTransaction(_:)` — sets the transaction's `startTimestamp` **retroactively** so Sentry Performance shows real wall-clock duration
- Adds `@MainActor recordEventPushTransaction(_:)` — same retroactive-timing pattern for push cycles

### `SyncManager+ProjectionSync.swift`
- Records `syncStart`, `fetchStart`, `populateStart` timestamps (plain `Date` — Sendable, no actor friction)
- Calls `recordProjectionSyncTransaction` via `await MainActor.run {}` in both success and failure paths
- Tags: sync_id, per-type entity counts, fetch_duration_ms, populate_duration_ms

### `SyncManager.swift`
- Records `httpStart` timestamp around the push HTTP request
- Calls `recordEventPushTransaction` via `await MainActor.run {}` on success and failure
- Tags: sync_id, event_count, http.status_code, http_duration_ms

## Design decision: retroactive timestamps

Sentry's `Span` protocol is **@MainActor-isolated** under Swift 6 strict concurrency. Rather than fighting actor boundaries with `@unchecked Sendable` wrappers, all Sentry API calls stay on MainActor. `SyncManager` records timing as plain `Date` values, then fires one `@MainActor` call at completion. Setting `tx.startTimestamp` before `tx.finish()` gives accurate duration in Sentry Performance with no `Span` ever crossing an actor boundary.

## Sentry visibility

- **Sentry > Performance > "Projection Sync"** (operation: `sync.projection`)
- **Sentry > Performance > "Event Push"** (operation: `sync.push`)
- Both transactions carry `sync_id` for cross-correlation with existing breadcrumbs (DEQ-246)

## Checklist
- [x] SwiftLint clean
- [x] macOS build passes