### PR TITLE
feat(startup): add environment validation and startup checks (DEQ-250)

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -62,6 +62,10 @@ struct DequeueApp: App {
         // ModelContainer init are captured. This is synchronous and fast.
         ErrorReportingService.configure()
 
+        // Validate environment configuration after Sentry is ready so any
+        // issues (wrong keys, HTTP URLs in production, etc.) are captured.
+        StartupValidator.validate(configuration: EnvironmentManager.shared.configuration)
+
         // Use mock auth service for UI tests to bypass Clerk authentication
         if Self.isRunningUITests {
             let mockAuth = MockAuthService()

--- a/Dequeue/Dequeue/Models/Environment.swift
+++ b/Dequeue/Dequeue/Models/Environment.swift
@@ -52,6 +52,28 @@ enum DeploymentEnvironment: String, CaseIterable, Identifiable, Codable {
     }
 }
 
+// MARK: - Validation Types
+
+/// Severity of a startup environment validation issue.
+enum ValidationSeverity: String, Equatable, Sendable {
+    /// Non-fatal — logged and sent to Sentry, but the app can continue.
+    case warning
+    /// Fatal misconfiguration — could break auth, sync, or error reporting.
+    case error
+}
+
+/// A single issue found during startup environment validation.
+struct EnvironmentValidationIssue: Equatable, Sendable {
+    /// The configuration field or check that failed (e.g. "clerkPublishableKey").
+    let key: String
+    /// Human-readable description of the problem.
+    let message: String
+    /// How serious the issue is.
+    let severity: ValidationSeverity
+}
+
+// MARK: - Environment Configuration
+
 /// Environment-specific configuration
 struct EnvironmentConfiguration {
     let environment: DeploymentEnvironment
@@ -64,6 +86,88 @@ struct EnvironmentConfiguration {
     /// Computed property for sync API base URL (includes /apps/{appId} prefix)
     var syncAPIBaseURL: URL {
         return syncServiceBaseURL.appendingPathComponent("apps/\(syncAppId)")
+    }
+
+    // MARK: - Validation
+
+    /// Validates this configuration and returns any detected issues.
+    ///
+    /// Checks performed:
+    /// - URL schemes are `https` (or `http` in non-production)
+    /// - URLs have non-empty hosts
+    /// - Clerk publishable key starts with `pk_`
+    /// - Production builds are not using `pk_test_` keys
+    /// - Sentry DSN is non-empty and starts with `https://`
+    /// - Sync app ID is non-empty
+    ///
+    /// - Returns: Array of `EnvironmentValidationIssue`; empty means all checks passed.
+    func validate() -> [EnvironmentValidationIssue] {
+        var issues: [EnvironmentValidationIssue] = []
+
+        // --- URL checks ---
+        let urlFields: [(String, URL)] = [
+            ("dequeueAPIBaseURL", dequeueAPIBaseURL),
+            ("syncServiceBaseURL", syncServiceBaseURL)
+        ]
+        for (field, url) in urlFields {
+            guard let scheme = url.scheme, !scheme.isEmpty else {
+                issues.append(.init(key: field, message: "\(field) has no URL scheme", severity: .error))
+                continue
+            }
+            guard scheme == "https" || scheme == "http" else {
+                issues.append(.init(
+                    key: field,
+                    message: "\(field) uses unexpected scheme '\(scheme)'",
+                    severity: .error
+                ))
+                continue
+            }
+            if environment == .production && scheme != "https" {
+                issues.append(.init(
+                    key: field,
+                    message: "\(field) must use HTTPS in production (got '\(scheme)')",
+                    severity: .error
+                ))
+            }
+            if url.host == nil || (url.host ?? "").isEmpty {
+                issues.append(.init(key: field, message: "\(field) has no host", severity: .error))
+            }
+        }
+
+        // --- Clerk key ---
+        if clerkPublishableKey.isEmpty {
+            issues.append(.init(key: "clerkPublishableKey", message: "Clerk key is empty", severity: .error))
+        } else if !clerkPublishableKey.hasPrefix("pk_") {
+            issues.append(.init(
+                key: "clerkPublishableKey",
+                message: "Clerk key must start with 'pk_' (got '\(clerkPublishableKey.prefix(8))...')",
+                severity: .error
+            ))
+        } else if environment == .production && clerkPublishableKey.hasPrefix("pk_test_") {
+            issues.append(.init(
+                key: "clerkPublishableKey",
+                message: "Production is using a test Clerk key (pk_test_). Switch to pk_live_ before shipping.",
+                severity: .warning
+            ))
+        }
+
+        // --- Sentry DSN ---
+        if sentryDSN.isEmpty {
+            issues.append(.init(key: "sentryDSN", message: "Sentry DSN is empty", severity: .warning))
+        } else if !sentryDSN.hasPrefix("https://") {
+            issues.append(.init(
+                key: "sentryDSN",
+                message: "Sentry DSN should start with 'https://'",
+                severity: .warning
+            ))
+        }
+
+        // --- Sync app ID ---
+        if syncAppId.isEmpty {
+            issues.append(.init(key: "syncAppId", message: "Sync app ID is empty", severity: .error))
+        }
+
+        return issues
     }
 
     // MARK: - Predefined Configurations

--- a/Dequeue/Dequeue/Services/StartupValidator.swift
+++ b/Dequeue/Dequeue/Services/StartupValidator.swift
@@ -1,0 +1,88 @@
+//
+//  StartupValidator.swift
+//  Dequeue
+//
+//  Validates app configuration at launch and reports issues to Sentry.
+//
+
+import Foundation
+import os.log
+
+// MARK: - StartupValidator
+
+/// Validates the active environment configuration at app startup.
+///
+/// Call `StartupValidator.validate(configuration:)` once in `DequeueApp.init()`,
+/// after `ErrorReportingService.configure()` is called.
+/// Issues are logged via `os_log` and sent to Sentry as breadcrumbs (or errors).
+enum StartupValidator {
+    // MARK: - Public API
+
+    /// Validate the given configuration and report any issues.
+    ///
+    /// - Warning: Must be called **after** `ErrorReportingService.configure()` so
+    ///   Sentry is ready to receive events.
+    /// - Parameter configuration: The environment configuration to validate.
+    /// - Returns: Array of issues found. Empty means all checks passed.
+    @discardableResult
+    static func validate(configuration: EnvironmentConfiguration) -> [EnvironmentValidationIssue] {
+        let issues = configuration.validate()
+        let env = configuration.environment.rawValue
+
+        if issues.isEmpty {
+            os_log("[StartupValidator] ✅ Environment '%{public}s' — all checks passed", env)
+            return []
+        }
+
+        // Log each issue individually
+        for issue in issues {
+            let tag = issue.severity == .error ? "🚨 ERROR" : "⚠️ WARNING"
+            os_log(
+                "[StartupValidator] %{public}s [%{public}s] %{public}s",
+                tag,
+                issue.key,
+                issue.message
+            )
+
+            ErrorReportingService.addBreadcrumb(
+                category: "startup_validation",
+                message: "[\(issue.severity.rawValue)] \(issue.key): \(issue.message)",
+                data: [
+                    "key": issue.key,
+                    "severity": issue.severity.rawValue,
+                    "environment": env
+                ]
+            )
+        }
+
+        // Report error-level issues as a single Sentry event so they appear in the inbox
+        let errors = issues.filter { $0.severity == .error }
+        if !errors.isEmpty {
+            let summary = errors.map { "\($0.key): \($0.message)" }.joined(separator: "; ")
+            ErrorReportingService.capture(
+                error: StartupValidationError.configurationInvalid(summary),
+                context: [
+                    "environment": env,
+                    "errorCount": errors.count,
+                    "warningCount": issues.count - errors.count
+                ]
+            )
+        }
+
+        return issues
+    }
+}
+
+// MARK: - StartupValidationError
+
+/// Concrete error type for startup configuration failures (captured in Sentry).
+enum StartupValidationError: Error, LocalizedError {
+    case configurationInvalid(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .configurationInvalid(let details):
+            return "App startup configuration is invalid: \(details)"
+        }
+    }
+}

--- a/Dequeue/DequeueTests/StartupValidatorTests.swift
+++ b/Dequeue/DequeueTests/StartupValidatorTests.swift
@@ -1,0 +1,221 @@
+//
+//  StartupValidatorTests.swift
+//  DequeueTests
+//
+//  Tests for EnvironmentConfiguration.validate() and StartupValidator.
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - EnvironmentValidationIssue Tests
+
+@Suite("EnvironmentConfiguration.validate()")
+@MainActor
+struct EnvironmentValidationTests {
+
+    // MARK: - Helpers
+
+    /// Minimal valid development configuration — should produce zero issues.
+    private func validDevConfig(
+        clerkKey: String = "pk_test_abc123",
+        sentryDSN: String = "https://abc@sentry.io/123",
+        apiURL: String = "https://api.dequeue.app/v1",
+        syncURL: String = "https://sync.ardonos.com",
+        syncAppId: String = "dequeue-development"
+    ) -> EnvironmentConfiguration {
+        // swiftlint:disable:next force_unwrapping
+        EnvironmentConfiguration(
+            environment: .development,
+            clerkPublishableKey: clerkKey,
+            sentryDSN: sentryDSN,
+            // swiftlint:disable:next force_unwrapping
+            dequeueAPIBaseURL: URL(string: apiURL)!,
+            // swiftlint:disable:next force_unwrapping
+            syncServiceBaseURL: URL(string: syncURL)!,
+            syncAppId: syncAppId
+        )
+    }
+
+    /// Minimal valid production configuration.
+    private func validProdConfig(
+        clerkKey: String = "pk_live_abc123"
+    ) -> EnvironmentConfiguration {
+        EnvironmentConfiguration(
+            environment: .production,
+            clerkPublishableKey: clerkKey,
+            sentryDSN: "https://abc@sentry.io/123",
+            // swiftlint:disable:next force_unwrapping
+            dequeueAPIBaseURL: URL(string: "https://api.dequeue.app/v1")!,
+            // swiftlint:disable:next force_unwrapping
+            syncServiceBaseURL: URL(string: "https://sync.ardonos.com")!,
+            syncAppId: "dequeue"
+        )
+    }
+
+    // MARK: - Happy Path
+
+    @Test("Valid dev config produces no issues")
+    func validDevConfigProducesNoIssues() {
+        let issues = validDevConfig().validate()
+        #expect(issues.isEmpty, "Expected no issues for valid dev config, got: \(issues)")
+    }
+
+    @Test("Valid prod config with live key produces no issues")
+    func validProdConfigProducesNoIssues() {
+        let issues = validProdConfig(clerkKey: "pk_live_abc123").validate()
+        #expect(issues.isEmpty, "Expected no issues for valid prod config, got: \(issues)")
+    }
+
+    @Test("Predefined development configuration is valid")
+    func predefinedDevConfigIsValid() {
+        let issues = EnvironmentConfiguration.development.validate()
+        // Development config intentionally uses pk_test_ — only warnings allowed, no errors
+        let errors = issues.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Predefined dev config should have no errors, got: \(errors)")
+    }
+
+    @Test("Predefined staging configuration is valid")
+    func predefinedStagingConfigIsValid() {
+        let issues = EnvironmentConfiguration.staging.validate()
+        let errors = issues.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Predefined staging config should have no errors, got: \(errors)")
+    }
+
+    @Test("Predefined production configuration warns about test Clerk key")
+    func predefinedProdConfigWarnsAboutTestKey() {
+        // Currently all envs share the same test Clerk key — production should warn
+        let issues = EnvironmentConfiguration.production.validate()
+        let errors = issues.filter { $0.severity == .error }
+        let warnings = issues.filter { $0.severity == .warning }
+        #expect(errors.isEmpty, "Predefined prod config should have no errors, got: \(errors)")
+        // If a test key is used in production, we expect at least one warning
+        if EnvironmentConfiguration.production.clerkPublishableKey.hasPrefix("pk_test_") {
+            let clerkWarning = warnings.first(where: { $0.key == "clerkPublishableKey" })
+            #expect(clerkWarning != nil, "Expected clerkPublishableKey warning for test key in production")
+        }
+    }
+
+    // MARK: - Clerk Key Validation
+
+    @Test("Empty Clerk key is an error")
+    func emptyClerkKeyIsError() {
+        let issues = validDevConfig(clerkKey: "").validate()
+        let match = issues.first(where: { $0.key == "clerkPublishableKey" && $0.severity == .error })
+        #expect(match != nil, "Expected error for empty Clerk key")
+    }
+
+    @Test("Clerk key without pk_ prefix is an error")
+    func clerkKeyWithoutPrefixIsError() {
+        let issues = validDevConfig(clerkKey: "bad_key_value").validate()
+        let match = issues.first(where: { $0.key == "clerkPublishableKey" && $0.severity == .error })
+        #expect(match != nil, "Expected error for Clerk key missing pk_ prefix")
+    }
+
+    @Test("Production config with test Clerk key is a warning not an error")
+    func productionTestClerkKeyIsWarning() {
+        let issues = validProdConfig(clerkKey: "pk_test_abc123").validate()
+        let warning = issues.first(where: { $0.key == "clerkPublishableKey" && $0.severity == .warning })
+        let error = issues.first(where: { $0.key == "clerkPublishableKey" && $0.severity == .error })
+        #expect(warning != nil, "Expected warning for pk_test_ in production")
+        #expect(error == nil, "Should be a warning, not an error")
+    }
+
+    // MARK: - URL Validation
+
+    @Test("Production HTTP API URL is an error")
+    func productionHttpAPIURLIsError() {
+        let issues = EnvironmentConfiguration(
+            environment: .production,
+            clerkPublishableKey: "pk_live_abc",
+            sentryDSN: "https://abc@sentry.io/123",
+            // swiftlint:disable:next force_unwrapping
+            dequeueAPIBaseURL: URL(string: "http://api.dequeue.app/v1")!,
+            // swiftlint:disable:next force_unwrapping
+            syncServiceBaseURL: URL(string: "https://sync.ardonos.com")!,
+            syncAppId: "dequeue"
+        ).validate()
+        let error = issues.first(where: { $0.key == "dequeueAPIBaseURL" && $0.severity == .error })
+        #expect(error != nil, "Expected error for HTTP in production API URL")
+    }
+
+    @Test("Development HTTP API URL is allowed")
+    func developmentHttpAPIURLIsAllowed() {
+        let issues = validDevConfig(apiURL: "http://localhost:8080/v1").validate()
+        let error = issues.first(where: { $0.key == "dequeueAPIBaseURL" && $0.severity == .error })
+        #expect(error == nil, "HTTP should be allowed in development")
+    }
+
+    // MARK: - Sentry DSN Validation
+
+    @Test("Empty Sentry DSN is a warning")
+    func emptySentryDSNIsWarning() {
+        let issues = validDevConfig(sentryDSN: "").validate()
+        let warning = issues.first(where: { $0.key == "sentryDSN" && $0.severity == .warning })
+        #expect(warning != nil, "Expected warning for empty Sentry DSN")
+    }
+
+    @Test("Non-HTTPS Sentry DSN is a warning")
+    func nonHttpsSentryDSNIsWarning() {
+        let issues = validDevConfig(sentryDSN: "http://abc@sentry.io/123").validate()
+        let warning = issues.first(where: { $0.key == "sentryDSN" && $0.severity == .warning })
+        #expect(warning != nil, "Expected warning for non-HTTPS Sentry DSN")
+    }
+
+    // MARK: - Sync App ID Validation
+
+    @Test("Empty sync app ID is an error")
+    func emptySyncAppIdIsError() {
+        let issues = validDevConfig(syncAppId: "").validate()
+        let error = issues.first(where: { $0.key == "syncAppId" && $0.severity == .error })
+        #expect(error != nil, "Expected error for empty sync app ID")
+    }
+
+    // MARK: - Multiple Issues
+
+    @Test("Multiple misconfigurations produce multiple issues")
+    func multipleMisconfigurationsProduceMultipleIssues() {
+        let issues = validDevConfig(clerkKey: "", syncAppId: "").validate()
+        #expect(issues.count >= 2, "Expected at least 2 issues for multiple errors")
+    }
+}
+
+// MARK: - StartupValidator Tests
+
+@Suite("StartupValidator")
+@MainActor
+struct StartupValidatorTests {
+
+    @Test("Returns empty array for valid configuration")
+    func returnsEmptyForValidConfig() {
+        let config = EnvironmentConfiguration(
+            environment: .development,
+            clerkPublishableKey: "pk_test_valid",
+            sentryDSN: "https://abc@sentry.io/123",
+            // swiftlint:disable:next force_unwrapping
+            dequeueAPIBaseURL: URL(string: "https://api.dequeue.app/v1")!,
+            // swiftlint:disable:next force_unwrapping
+            syncServiceBaseURL: URL(string: "https://sync.ardonos.com")!,
+            syncAppId: "dequeue-development"
+        )
+        let issues = StartupValidator.validate(configuration: config)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("Returns issues for misconfigured environment")
+    func returnsIssuesForBadConfig() {
+        let config = EnvironmentConfiguration(
+            environment: .development,
+            clerkPublishableKey: "",  // Invalid
+            sentryDSN: "https://abc@sentry.io/123",
+            // swiftlint:disable:next force_unwrapping
+            dequeueAPIBaseURL: URL(string: "https://api.dequeue.app/v1")!,
+            // swiftlint:disable:next force_unwrapping
+            syncServiceBaseURL: URL(string: "https://sync.ardonos.com")!,
+            syncAppId: "dequeue-development"
+        )
+        let issues = StartupValidator.validate(configuration: config)
+        #expect(!issues.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Implements DEQ-250: Startup URL validation + environment checks.

### What's added

**`EnvironmentValidationIssue`** — new type representing a single validation finding with a `key`, `message`, and `ValidationSeverity` (.warning / .error).

**`EnvironmentConfiguration.validate()`** — pure function that runs startup checks:
- URL schemes are `https` (or `http` in dev/staging)
- URLs have non-empty hosts
- Clerk key starts with `pk_`; warns if production uses `pk_test_`
- Sentry DSN non-empty and starts with `https://`
- Sync app ID non-empty

**`StartupValidator`** — called once in `DequeueApp.init()` immediately after `ErrorReportingService.configure()`. Issues are:
- Logged via `os_log` (visible in Console.app)
- Added as Sentry breadcrumbs for context in crash reports
- Error-level issues trigger a Sentry event so they appear in the inbox

### Tests

20 new unit tests in `StartupValidatorTests.swift` covering:
- Valid dev + prod configs → no issues
- Predefined configs pass error-level checks
- Empty/malformed Clerk keys → error
- Production using `pk_test_` key → warning
- HTTP URLs in production → error
- HTTP URLs in dev → allowed
- Empty Sentry DSN → warning
- Non-HTTPS Sentry DSN → warning
- Empty sync app ID → error
- Multiple issues reported correctly