### PR TITLE
feat(DEQ-202): replace initial sync banner with full-screen overlay

### DIFF
--- a/Dequeue/Dequeue/Views/Stacks/StacksView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/StacksView.swift
@@ -40,69 +40,68 @@ struct StacksView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                if let syncStatus = syncStatusViewModel, syncStatus.isInitialSyncInProgress {
-                    // Show a subtle banner during initial sync instead of blocking the UI
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Syncing your data...")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(.ultraThinMaterial)
-                }
-                stacksContent
-            }
-            .navigationTitle("Stacks")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    HStack(spacing: 16) {
-                        // Calendar button
-                        Button {
-                            showCalendarSheet = true
-                        } label: {
-                            Label("Calendar", systemImage: "calendar")
-                        }
-                        .accessibilityLabel("Calendar")
+            stacksContent
+                .navigationTitle("Stacks")
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        HStack(spacing: 16) {
+                            // Calendar button
+                            Button {
+                                showCalendarSheet = true
+                            } label: {
+                                Label("Calendar", systemImage: "calendar")
+                            }
+                            .accessibilityLabel("Calendar")
 
-                        // Reminders button with badge
-                        Button {
-                            showRemindersSheet = true
-                        } label: {
-                            remindersButtonLabel
-                        }
-                        .accessibilityLabel("Reminders")
-                        .accessibilityHint(urgentReminderCount > 0
-                            ? "\(urgentReminderCount) reminders need attention"
-                            : "View all reminders")
+                            // Reminders button with badge
+                            Button {
+                                showRemindersSheet = true
+                            } label: {
+                                remindersButtonLabel
+                            }
+                            .accessibilityLabel("Reminders")
+                            .accessibilityHint(urgentReminderCount > 0
+                                ? "\(urgentReminderCount) reminders need attention"
+                                : "View all reminders")
 
-                        // Add stack button
-                        Button {
-                            showAddSheet = true
-                        } label: {
-                            Label("Add Stack", systemImage: "plus")
+                            // Add stack button
+                            Button {
+                                showAddSheet = true
+                            } label: {
+                                Label("Add Stack", systemImage: "plus")
+                            }
+                            #if os(macOS)
+                            .keyboardShortcut("n", modifiers: .command)
+                            #endif
+                            .accessibilityIdentifier("addStackButton")
+                            .accessibilityLabel("Add new stack")
+                            .accessibilityHint("Creates a new stack")
                         }
-                        #if os(macOS)
-                        .keyboardShortcut("n", modifiers: .command)
-                        #endif
-                        .accessibilityIdentifier("addStackButton")
-                        .accessibilityLabel("Add new stack")
-                        .accessibilityHint("Creates a new stack")
                     }
                 }
-            }
-            .task {
-                // Initialize sync status view model
-                if syncStatusViewModel == nil {
-                    let viewModel = SyncStatusViewModel(modelContext: modelContext)
-                    if let manager = syncManager {
-                        viewModel.setSyncManager(manager)
+                .task {
+                    // Initialize sync status view model
+                    if syncStatusViewModel == nil {
+                        let viewModel = SyncStatusViewModel(modelContext: modelContext)
+                        if let manager = syncManager {
+                            viewModel.setSyncManager(manager)
+                        }
+                        syncStatusViewModel = viewModel
                     }
-                    syncStatusViewModel = viewModel
                 }
+        }
+        // DEQ-202: Full-screen loading overlay during initial sync (first device load).
+        // Covers the entire NavigationStack to prevent flickering as events are projected
+        // into SwiftData one-by-one. Shows accurate progress when totalEvents is known
+        // via WebSocket sync.stream.start message.
+        .overlay {
+            if let syncStatus = syncStatusViewModel, syncStatus.isInitialSyncInProgress {
+                InitialSyncLoadingView(
+                    eventsProcessed: syncStatus.initialSyncEventsProcessed,
+                    totalEvents: syncStatus.initialSyncTotalEvents > 0
+                        ? syncStatus.initialSyncTotalEvents
+                        : nil
+                )
             }
         }
         .sheet(isPresented: $showAddSheet) {


### PR DESCRIPTION
## Summary

Wires up the existing `InitialSyncLoadingView` (which was built but never used) as a full-screen overlay on `StacksView`, replacing the previous subtle banner.

## Problem

During initial sync on a new device, the app was showing a small "Syncing your data..." banner while stacks flickered in and out as events were projected into SwiftData. The `InitialSyncLoadingView` was already built with proper progress tracking (DEQ-240) but was dead code — never connected to the view.

## Fix

Replace the inline HStack banner with a `.overlay { }` on the NavigationStack that shows `InitialSyncLoadingView` when `isInitialSyncInProgress` is true. This completely hides the flickering content underneath.

- **Determinate progress bar** when `totalEvents` is known (populated from WebSocket `sync.stream.start` message)
- **Indeterminate spinner** when total is unknown (fallback)
- Shows "X of Y events" counter

## Changes

- `StacksView.swift`: Remove banner, add `.overlay { InitialSyncLoadingView(...) }` on NavigationStack

## Testing

- Build: ✅ passes (`xcodebuild build` with `CODE_SIGN_IDENTITY="-"`)
- Lint: ✅ 0 violations (`swiftlint lint`)
- Test failures are all pre-existing (verified against baseline on main)

Partially addresses DEQ-202 (Phase 1: client-side loading state).