### PR TITLE
feat(sync): add phase-aware status messages during projection sync

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -33,7 +33,11 @@ extension SyncManager {
         }
 
         isInitialSyncActive = true
-        defer { isInitialSyncActive = false }
+        syncStatusMessage = "Connecting to server\u{2026}"
+        defer {
+            isInitialSyncActive = false
+            syncStatusMessage = ""
+        }
 
         guard let token = try await refreshToken() else {
             os_log("[Sync] Projection sync failed: Not authenticated")
@@ -44,6 +48,7 @@ extension SyncManager {
 
         // ── Fetch phase ──────────────────────────────────────────────────────────────
         // DEQ-248: Record fetch-phase wall-clock timing for Sentry performance transaction.
+        syncStatusMessage = "Fetching your data\u{2026}"
         let fetchStart = Date()
 
         // Fetch all resource types in parallel
@@ -79,6 +84,7 @@ extension SyncManager {
             os_log("[Sync] Fetched projections: \(sc) stacks, \(tc) tasks, \(ac) arcs, \(tgc) tags, \(rc) reminders")
 
             // ── Populate phase ────────────────────────────────────────────────────────
+            syncStatusMessage = "Saving locally\u{2026}"
             let populateStart = Date()
             try await populateFromProjections(
                 stacks: stacks, tasks: tasks, arcs: arcs, tags: tags, reminders: reminders

--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -65,6 +65,8 @@ actor SyncManager {
     var isInitialSyncActive = false
     var syncEventsProcessed = 0
     var syncTotalEvents = 0
+    /// Human-readable status message shown during initial sync (set by projection/event sync paths)
+    var syncStatusMessage: String = ""
 
     /// Whether an initial sync is currently in progress (fresh device downloading events)
     var isInitialSyncInProgress: Bool {
@@ -85,6 +87,12 @@ actor SyncManager {
     /// Total number of events to sync during initial sync (DEQ-240)
     var initialSyncTotalEvents: Int {
         syncTotalEvents
+    }
+
+    /// Human-readable status message for the current sync phase.
+    /// Set during projection sync to inform users of progress phases.
+    var initialSyncMessage: String {
+        syncStatusMessage
     }
 
     // Key for storing last sync checkpoint in UserDefaults (shared constant from DequeueApp)

--- a/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
+++ b/Dequeue/Dequeue/Sync/SyncStatusViewModel.swift
@@ -46,6 +46,9 @@ internal final class SyncStatusViewModel {
     /// Total number of events during initial sync (DEQ-240)
     private(set) var initialSyncTotalEvents: Int = 0
 
+    /// Human-readable status message for the current sync phase (e.g. "Fetching your data…")
+    private(set) var initialSyncMessage: String = ""
+
     private let modelContext: ModelContext
     private let eventService: EventService
     private var syncManager: SyncManager?
@@ -99,6 +102,7 @@ internal final class SyncStatusViewModel {
             let initialSyncActive = await syncManager.isInitialSyncInProgress
             let eventsProcessed = await syncManager.initialSyncEventsProcessed
             let totalEvents = await syncManager.initialSyncTotalEvents
+            let syncMessage = await syncManager.initialSyncMessage
 
             // Fetch pending event count - do this AFTER connection status to minimize race window.
             // Note: There's an inherent race between status and count fetches, but this is
@@ -127,6 +131,7 @@ internal final class SyncStatusViewModel {
             isInitialSyncInProgress = initialSyncActive
             initialSyncEventsProcessed = eventsProcessed
             initialSyncTotalEvents = totalEvents
+            initialSyncMessage = syncMessage
 
             // Update pending count
             pendingEventCount = currentCount

--- a/Dequeue/Dequeue/Views/Stacks/StacksView.swift
+++ b/Dequeue/Dequeue/Views/Stacks/StacksView.swift
@@ -100,7 +100,8 @@ struct StacksView: View {
                     eventsProcessed: syncStatus.initialSyncEventsProcessed,
                     totalEvents: syncStatus.initialSyncTotalEvents > 0
                         ? syncStatus.initialSyncTotalEvents
-                        : nil
+                        : nil,
+                    statusMessage: syncStatus.initialSyncMessage
                 )
             }
         }

--- a/Dequeue/Dequeue/Views/Sync/InitialSyncLoadingView.swift
+++ b/Dequeue/Dequeue/Views/Sync/InitialSyncLoadingView.swift
@@ -3,7 +3,7 @@
 //  Dequeue
 //
 //  Loading view shown during initial sync to prevent flickering UI
-//  Enhanced with progress tracking (DEQ-240)
+//  Enhanced with progress tracking (DEQ-240) and phase-aware messages
 //
 
 import SwiftUI
@@ -11,6 +11,9 @@ import SwiftUI
 struct InitialSyncLoadingView: View {
     let eventsProcessed: Int
     let totalEvents: Int?  // DEQ-240: Add total count for progress bar
+    /// Phase-aware status message (e.g. "Fetching your data…", "Saving locally…").
+    /// Falls back to computed text when empty.
+    var statusMessage: String = ""
 
     var body: some View {
         VStack(spacing: 20) {
@@ -30,8 +33,14 @@ struct InitialSyncLoadingView: View {
             Text("Syncing your stacks")
                 .font(.headline)
 
-            // DEQ-240: Show "X of Y events" when total is known
-            if let total = totalEvents, total > 0 {
+            // Phase-aware message takes priority; fall back to event count display.
+            if !statusMessage.isEmpty {
+                Text(statusMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .animation(.easeInOut(duration: 0.3), value: statusMessage)
+            } else if let total = totalEvents, total > 0 {
+                // DEQ-240: Show "X of Y events" when total is known
                 Text("\(eventsProcessed) of \(total) events")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -42,7 +51,7 @@ struct InitialSyncLoadingView: View {
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
             } else {
-                Text("Connecting to server...")
+                Text("Connecting to server\u{2026}")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -62,6 +71,14 @@ struct InitialSyncLoadingView: View {
 
 #Preview("Zero Events") {
     InitialSyncLoadingView(eventsProcessed: 0, totalEvents: nil)
+}
+
+#Preview("Fetching Phase") {
+    InitialSyncLoadingView(eventsProcessed: 0, totalEvents: nil, statusMessage: "Fetching your data\u{2026}")
+}
+
+#Preview("Saving Phase") {
+    InitialSyncLoadingView(eventsProcessed: 0, totalEvents: nil, statusMessage: "Saving locally\u{2026}")
 }
 
 #Preview("Unknown Total") {


### PR DESCRIPTION
## What

During initial sync on a new device, the loading overlay previously showed **"Connecting to server..."** for the entire duration — even while the app was actively fetching data from the API and writing it to SwiftData.

This PR adds meaningful phase-aware status messages that update as the sync progresses:

| Phase | Message |
|-------|---------|
| Auth check | `Connecting to server…` |
| Parallel API fetch | `Fetching your data…` |
| SwiftData population | `Saving locally…` |

## Why

The projection sync (default path for new devices) can take several seconds for users with lots of data. "Connecting to server..." was misleading and unhelpful during those seconds. These messages give users a clearer picture of what's happening.

## How

- **SyncManager**: Added `syncStatusMessage: String` var and `initialSyncMessage` accessor
- **SyncManager+ProjectionSync**: Sets phase messages at each stage of `syncViaProjections()`; `defer` block clears message when sync completes
- **SyncStatusViewModel**: Exposes `initialSyncMessage: String` property, fetched alongside other sync state
- **InitialSyncLoadingView**: Added `statusMessage` param; phase message takes priority over event-count display; crossfades with `.animation(.easeInOut)` for smooth transitions
- **StacksView**: Passes `syncStatus.initialSyncMessage` through to the loading view

## Testing

- Build succeeded (iOS Simulator, CODE_SIGNING_ALLOWED=NO)
- SwiftLint: 0 new violations (7 pre-existing warnings unchanged)
- Backward compatible: when `statusMessage` is empty, the view falls back to existing event-count display logic