### PR TITLE
fix(search): retry on 401 with force-refresh token, suppress Sentry noise

### DIFF
--- a/Dequeue/Dequeue/Services/AuthService.swift
+++ b/Dequeue/Dequeue/Services/AuthService.swift
@@ -47,6 +47,9 @@ protocol AuthServiceProtocol {
     @MainActor func configure() async
     @MainActor func signOut() async throws
     @MainActor func getAuthToken() async throws -> String
+    /// Force-fetches a fresh token from Clerk, bypassing the local cache.
+    /// Use when a request returns 401 to retry with a guaranteed-fresh token.
+    @MainActor func forceRefreshAuthToken() async throws -> String
     @MainActor func refreshSessionIfNeeded() async
 }
 
@@ -236,7 +239,23 @@ final class ClerkAuthService: AuthServiceProtocol {
         guard let session else {
             throw AuthError.notAuthenticated
         }
-        guard let token = try await session.getToken()?.jwt else {
+        // Use a 30-second expiration buffer (vs the default 10s) to preemptively
+        // refresh tokens before they expire during in-flight requests.
+        guard let token = try await session.getToken(.init(expirationBuffer: 30))?.jwt else {
+            throw AuthError.noToken
+        }
+        return token
+    }
+
+    @MainActor
+    func forceRefreshAuthToken() async throws -> String {
+        let session = await MainActor.run { Clerk.shared.session }
+        guard let session else {
+            throw AuthError.notAuthenticated
+        }
+        // Skip the cache entirely — forces a fresh JWT from Clerk's servers.
+        // Use this after receiving a 401 to recover from revoked/expired sessions.
+        guard let token = try await session.getToken(.init(skipCache: true))?.jwt else {
             throw AuthError.noToken
         }
         return token
@@ -393,6 +412,12 @@ final class MockAuthService: AuthServiceProtocol {
             throw AuthError.notAuthenticated
         }
         return "mock-token-\(UUID().uuidString)"
+    }
+
+    @MainActor
+    func forceRefreshAuthToken() async throws -> String {
+        // Same as getAuthToken for mock — no real cache to bypass
+        return try await getAuthToken()
     }
 
     @MainActor

--- a/Dequeue/Dequeue/Services/ErrorReportingService.swift
+++ b/Dequeue/Dequeue/Services/ErrorReportingService.swift
@@ -144,10 +144,15 @@ enum ErrorReportingService {
             options.enableAppHangTracking = true
             options.appHangTimeoutInterval = 2.0        // Report hangs > 2 seconds
 
-            // Capture HTTP errors
+            // Capture HTTP errors.
+            // Exclude 401 (Unauthorized): the app explicitly handles 401s with a
+            // force-refresh retry (SearchService, SyncManager). A persistent 401 after
+            // retry throws SearchError.notAuthenticated which triggers the re-auth alert.
+            // Auto-capturing 401s only floods Sentry with noise for broken sessions.
             options.enableCaptureFailedRequests = true
             options.failedRequestStatusCodes = [
-                HttpStatusCodeRange(min: 400, max: 599)  // All 4xx and 5xx
+                HttpStatusCodeRange(min: 400, max: 400),  // 400 Bad Request
+                HttpStatusCodeRange(min: 402, max: 599)   // 402–599 (skip 401 Unauthorized)
             ]
 
             // ============================================

--- a/Dequeue/Dequeue/Services/SearchService.swift
+++ b/Dequeue/Dequeue/Services/SearchService.swift
@@ -156,8 +156,6 @@ final class SearchService: @unchecked Sendable {
             throw SearchError.queryTooLong
         }
 
-        let token = try await authService.getAuthToken()
-
         var components = URLComponents(
             url: Configuration.dequeueAPIBaseURL.appendingPathComponent("search"),
             resolvingAgainstBaseURL: true
@@ -171,12 +169,27 @@ final class SearchService: @unchecked Sendable {
             throw SearchError.invalidResponse
         }
 
+        logger.debug("Searching for: \(trimmed)")
+
+        return try await executeSearchRequest(url: url, query: trimmed, retrying: false)
+    }
+
+    /// Executes the actual HTTP search request. On 401, retries once with a force-refreshed token.
+    private func executeSearchRequest(url: URL, query: String, retrying: Bool) async throws -> SearchResponse {
+        let token: String
+        do {
+            // On retry, bypass the Clerk token cache to get a guaranteed-fresh JWT.
+            token = retrying
+                ? try await authService.forceRefreshAuthToken()
+                : try await authService.getAuthToken()
+        } catch {
+            throw SearchError.notAuthenticated
+        }
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-
-        logger.debug("Searching for: \(trimmed)")
 
         do {
             let (data, response) = try await urlSession.data(for: request)
@@ -185,13 +198,28 @@ final class SearchService: @unchecked Sendable {
                 throw SearchError.invalidResponse
             }
 
+            // On 401, attempt a single retry with a force-refreshed token.
+            // This handles expired/revoked Clerk sessions that weren't caught locally.
+            if httpResponse.statusCode == 401 {
+                if !retrying {
+                    logger.warning("Search got 401 — force-refreshing token and retrying")
+                    return try await executeSearchRequest(url: url, query: query, retrying: true)
+                } else {
+                    // Both the initial request and the force-refresh retry returned 401.
+                    // The Clerk session is genuinely broken (expired, revoked, or invalidated).
+                    // Throw notAuthenticated so the caller can prompt re-authentication.
+                    logger.error("Search got 401 after force-refresh — session is invalid, require re-auth")
+                    throw SearchError.notAuthenticated
+                }
+            }
+
             guard (200...299).contains(httpResponse.statusCode) else {
                 let errorMessage = (try? JSONDecoder().decode([String: String].self, from: data))?["error"]
                 throw SearchError.serverError(statusCode: httpResponse.statusCode, message: errorMessage)
             }
 
             let searchResponse = try JSONDecoder().decode(SearchResponse.self, from: data)
-            logger.info("Search returned \(searchResponse.total) results for '\(trimmed)'")
+            logger.info("Search returned \(searchResponse.total) results for '\(query)'")
             return searchResponse
         } catch let error as SearchError {
             throw error

--- a/Dequeue/Dequeue/Views/Auth/AuthView.swift
+++ b/Dequeue/Dequeue/Views/Auth/AuthView.swift
@@ -348,6 +348,7 @@ private final class DefaultAuthService: AuthServiceProtocol, @unchecked Sendable
     func configure() async {}
     func signOut() async throws {}
     func getAuthToken() async throws -> String { throw AuthError.notAuthenticated }
+    func forceRefreshAuthToken() async throws -> String { throw AuthError.notAuthenticated }
     func refreshSessionIfNeeded() async {}
 }
 

--- a/Dequeue/Dequeue/Views/Search/SearchView.swift
+++ b/Dequeue/Dequeue/Views/Search/SearchView.swift
@@ -12,12 +12,14 @@ private let logger = Logger(subsystem: "com.dequeue", category: "SearchView")
 
 struct SearchView: View {
     @Environment(\.searchService) private var searchService
+    @Environment(\.authService) private var authService
     @State private var searchText = ""
     @State private var results: [SearchResultItem] = []
     @State private var isSearching = false
     @State private var errorMessage: String?
     @State private var hasSearched = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var requiresReauth = false
 
     var body: some View {
         NavigationStack {
@@ -39,6 +41,18 @@ struct SearchView: View {
             }
             .onSubmit(of: .search) {
                 performImmediateSearch()
+            }
+            .alert("Session Expired", isPresented: $requiresReauth) {
+                Button("Sign In Again", role: .destructive) {
+                    // Sign-out is handled by the auth state observer in the app root;
+                    // clearing the Clerk session will redirect to the login screen.
+                    Task { await signOut() }
+                }
+                Button("Cancel", role: .cancel) {
+                    requiresReauth = false
+                }
+            } message: {
+                Text("Your session has expired. Please sign in again to use search.")
             }
         }
     }
@@ -150,10 +164,26 @@ struct SearchView: View {
             return
         } catch let urlError as URLError where urlError.code == .cancelled {
             return
+        } catch SearchError.notAuthenticated {
+            // Session is genuinely broken — prompt the user to re-authenticate.
+            // Do not show a generic error; show the re-auth alert instead.
+            logger.warning("Search requires re-authentication — showing re-auth alert")
+            requiresReauth = true
+            hasSearched = false
         } catch {
             logger.error("Search failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
             hasSearched = true
+        }
+    }
+
+    // MARK: - Sign Out
+
+    private func signOut() async {
+        do {
+            try await authService.signOut()
+        } catch {
+            logger.error("Sign-out after search 401 failed: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the search 401 auth loop and reduces Sentry noise from expected authentication failures.

## Problem

When a Clerk session token is near expiry or becomes stale, search requests return 401. The app had no retry logic, so users would see repeated auth errors. Additionally, Sentry was auto-capturing every 401 as an error event, flooding the error dashboard with noise from expected token expiry.

## Changes

### AuthService
- Added `forceRefreshAuthToken()` to `AuthServiceProtocol` and `ClerkAuthService`
  - Uses `skipCache: true` to bypass the Clerk token cache and guarantee a fresh JWT
- Improved `getAuthToken()` expiration buffer from the default 10s to 30s to preemptively refresh tokens before they expire during in-flight requests

### SearchService
- Refactored `performSearch` to extract `executeSearchRequest(url:query:retrying:)`
- On 401: retries once with `forceRefreshAuthToken()`
- If retry also returns 401: throws `SearchError.notAuthenticated` — the Clerk session is genuinely broken (expired/revoked)

### ErrorReportingService
- Excluded HTTP 401 from Sentry auto-capture
- 401s are now handled explicitly; a persistent 401 throws `notAuthenticated` which surfaces a re-auth alert (not a Sentry error event)
- Covers: 400, 402–599 (skips 401)

### SearchView
- Added re-auth alert triggered on `SearchError.notAuthenticated`
- Prompts user to sign in again; calls `authService.signOut()` to clear the Clerk session and redirect to login

## Testing

- Build: ✅ passes on iOS Simulator
- Unit tests (SearchService, AuthService): ✅ pass
- Pre-existing AnalyticsServiceTests/UI test simulator flakiness unrelated to these changes