### PR TITLE
fix(sync): add 401-retry to fetchProjectionPage

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -164,6 +164,7 @@ extension SyncManager {
     ) async throws -> [T] {
         var allResults: [T] = []
         var currentURL: String? = url
+        var currentToken = token  // Mutable so 401-retry can update for subsequent pages
 
         while let urlString = currentURL {
             guard let url = URL(string: urlString) else {
@@ -172,7 +173,7 @@ extension SyncManager {
             }
             var request = URLRequest(url: url)
             request.httpMethod = "GET"
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("Bearer \(currentToken)", forHTTPHeaderField: "Authorization")
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
             let fetchStart = Date()
@@ -196,16 +197,39 @@ extension SyncManager {
                 )
             }
 
-            guard httpResponse.statusCode == 200 else {
-                if let responseBody = String(data: data, encoding: .utf8) {
-                    os_log(
-                        "[Sync] Projection fetch failed (\(httpResponse.statusCode)): \(responseBody)"
-                    )
+            // If token was rejected, refresh once and retry — mirrors syncPull 401 handling.
+            // This resolves DEQUEUE-APP-1/DEQUEUE-APP-6 where stale tokens cause pullFailed
+            // on projection sync endpoints (/v1/tags, /v1/stacks, etc.).
+            let decodeData: Data
+            if httpResponse.statusCode == 401 {
+                os_log("[Sync] Token rejected during projection fetch, refreshing...")
+                guard let newToken = try await refreshToken() else {
+                    os_log("[Sync] Token refresh failed during projection fetch")
+                    throw SyncError.notAuthenticated
                 }
-                throw SyncError.pullFailed
+                currentToken = newToken
+                request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
+                let (retryData, retryResponse) = try await syncSession.data(for: request)
+                guard let retryHTTP = retryResponse as? HTTPURLResponse,
+                      retryHTTP.statusCode == 200 else {
+                    let retryStatus = (retryResponse as? HTTPURLResponse)?.statusCode ?? -1
+                    os_log("[Sync] Projection fetch retry failed with status: \(retryStatus)")
+                    throw SyncError.pullFailed
+                }
+                decodeData = retryData
+            } else {
+                guard httpResponse.statusCode == 200 else {
+                    if let responseBody = String(data: data, encoding: .utf8) {
+                        os_log(
+                            "[Sync] Projection fetch failed (\(httpResponse.statusCode)): \(responseBody)"
+                        )
+                    }
+                    throw SyncError.pullFailed
+                }
+                decodeData = data
             }
 
-            let decoded = try JSONDecoder().decode(ProjectionResponse<T>.self, from: data)
+            let decoded = try JSONDecoder().decode(ProjectionResponse<T>.self, from: decodeData)
             allResults.append(contentsOf: decoded.data)
 
             // Handle pagination — use URLComponents to properly manage query parameters


### PR DESCRIPTION
## Problem

Sentry issues **DEQUEUE-APP-1** and **DEQUEUE-APP-6** have been firing since December 2025. Both occur together — same timestamp, same user (Victor's account).

**Root cause:** `fetchProjectionPage` fetches a token once before kicking off 5 parallel GET requests (`/v1/stacks`, `/v1/tasks`, `/v1/arcs`, `/v1/tags`, `/v1/reminders`). If the cached token is stale, the server returns 401. The function had **no retry logic** for 401 — it just threw `SyncError.pullFailed` (Code 3), surfacing as a visible sync failure.

`syncPull` already handles 401 correctly with a token-refresh retry. Projection sync was missing the same pattern.

## Fix

Mirror the `syncPull` retry pattern inside `fetchProjectionPage`:
- Detect 401 response
- Call `refreshToken()` once
- Retry the request with the new token
- Update `currentToken` so subsequent paginated requests also use the fresh token
- If retry fails, throw `pullFailed` as before

## Testing

- ✅ Build passes (macOS)
- ✅ SwiftLint clean (0 errors, 4 pre-existing warnings on line 149)

## Sentry

After this lands, DEQUEUE-APP-1 and DEQUEUE-APP-6 should stop firing. Will resolve in Sentry once the fix is in production.