### PR TITLE
fix(sync): disconnect on auth errors in periodic push/pull loops

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -1654,6 +1654,13 @@ actor SyncManager {
                 do {
                     try await self.pushEvents()
                 } catch {
+                    // Auth errors are permanent — stop the loop to avoid spamming Sentry
+                    // (e.g. Clerk session revoked: repeating every 5s generates thousands of events)
+                    if await self.isAuthenticationError(error) {
+                        os_log("[Sync] Periodic push: auth failure, disconnecting to stop retry loop")
+                        await self.disconnect()
+                        break
+                    }
                     await MainActor.run {
                         ErrorReportingService.capture(error: error, context: ["source": "periodic_push"])
                     }
@@ -1675,12 +1682,33 @@ actor SyncManager {
                     os_log("[Sync] Fallback pull (safety net, every \(self.fallbackPullIntervalMinutes) minutes)")
                     try await self.pullEvents()
                 } catch {
+                    // Auth errors are permanent — stop the loop to avoid spamming Sentry
+                    if await self.isAuthenticationError(error) {
+                        os_log("[Sync] Fallback pull: auth failure, disconnecting to stop retry loop")
+                        await self.disconnect()
+                        break
+                    }
                     await MainActor.run {
                         ErrorReportingService.capture(error: error, context: ["source": "fallback_pull"])
                     }
                 }
             }
         }
+    }
+
+    /// Returns true if the error indicates a permanent authentication failure.
+    ///
+    /// When auth is permanently broken (e.g. Clerk session revoked/expired), periodic sync
+    /// loops should stop rather than retrying — each retry produces a Sentry event.
+    private func isAuthenticationError(_ error: Error) -> Bool {
+        if case SyncError.notAuthenticated = error { return true }
+        if case AuthError.notAuthenticated = error { return true }
+        // Clerk errors with authentication_invalid code are permanent (session revoked)
+        let description = error.localizedDescription
+        if description.contains("authentication_invalid") || description.contains("Unable to authenticate") {
+            return true
+        }
+        return false
     }
 
     // MARK: - Network Monitoring


### PR DESCRIPTION
## Problem

When a Clerk session is revoked or expires, the periodic push and fallback pull loops in `SyncManager` keep retrying every few seconds. Each retry fails with an auth error and reports to Sentry — generating thousands of identical events before the user re-authenticates.

## Solution

Add `isAuthenticationError()` helper to detect permanent auth failures:
- `SyncError.notAuthenticated`
- `AuthError.notAuthenticated`  
- Clerk-specific: `authentication_invalid` / `Unable to authenticate` strings

When a permanent auth error is detected in either loop, disconnect cleanly and `break` instead of reporting to Sentry.

## Changes

- `isAuthenticationError(_ error: Error) -> Bool` — new private helper
- Periodic push loop: checks auth error → `await disconnect()` + break
- Fallback pull loop: same treatment
- Fixed Swift actor isolation: added `await` to actor-isolated calls (`isAuthenticationError`, `disconnect`) from within `Task { [weak self] in }` closures

## Testing

Build passes locally (macOS). CI will verify iOS + macOS build + SwiftLint.