### PR TITLE
fix(lint): fix 5 SwiftLint violations in SyncManager files

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager+ProjectionSync.swift
@@ -146,7 +146,11 @@ extension SyncManager {
                         syncStart: syncStart,
                         fetchDurationMs: Int(duration * 1_000),
                         populateDurationMs: 0,
-                        stacks: 0, tasks: 0, arcs: 0, tags: 0, reminders: 0,
+                        stacks: 0,
+                        tasks: 0,
+                        arcs: 0,
+                        tags: 0,
+                        reminders: 0,
                         success: false
                     )
                 )

--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -376,7 +376,11 @@ actor SyncManager {
 
     private func connectWebSocket() async throws {
         await MainActor.run {
-            ErrorReportingService.logSyncStateTransition(from: "disconnected", to: "connecting", trigger: "connectWebSocket")
+            ErrorReportingService.logSyncStateTransition(
+                from: "disconnected",
+                to: "connecting",
+                trigger: "connectWebSocket"
+            )
         }
 
         guard let token = try await refreshToken() else {


### PR DESCRIPTION
## Summary

Fixes 5 of 7 SwiftLint violations:

### SyncManager+ProjectionSync.swift (line 149)
- **4× multiline_arguments** — put each `.init()` argument on its own line

### SyncManager.swift (line 379)
- **1× line_length** — break 125-char `logSyncStateTransition` call into multi-line form (≤120 chars)

Violations reduced from **7 → 2**. The remaining 2 (`file_length` and `function_body_length` in SyncManager.swift) require larger refactoring and are left for a future PR.

## Tests
- Build passes: `xcodebuild build ... CODE_SIGNING_REQUIRED=NO` ✅
- No logic changes — formatting only