### PR TITLE
test(ui): resolve TODO — verify active stack star indicator

### DIFF
--- a/Dequeue/DequeueUITests/StackCreationUITests.swift
+++ b/Dequeue/DequeueUITests/StackCreationUITests.swift
@@ -96,7 +96,14 @@ final class StackCreationUITests: XCTestCase {
         // Verify stack created
         XCTAssertTrue(app.staticTexts["Active Stack Test"].waitForExistence(timeout: 3))
 
-        // TODO: Verify stack is actually active (check banner or indicator)
+        // Verify stack is actually active — star indicator should appear in the list row
+        // StackRowView renders Image(systemName: "star.fill").accessibilityLabel("Active stack")
+        // when stack.isActive == true
+        let activeIndicator = app.images["Active stack"]
+        XCTAssertTrue(
+            activeIndicator.waitForExistence(timeout: 2),
+            "Active stack should display star indicator in the list row"
+        )
     }
 
     // MARK: - Stack Creation with Dates


### PR DESCRIPTION
## Summary

Resolves the `// TODO: Verify stack is actually active` in `testCreateStackAsActive()`.

## What changed

After creating a stack with "Set as Active Stack" enabled, the test now asserts that the star indicator is visible in the list row — verifying the active flag actually propagated to the UI.

## How it works

`StackRowView` renders `Image(systemName: "star.fill").accessibilityLabel("Active stack")` when `stack.isActive == true`. The new assertion queries `app.images["Active stack"]` via XCTest accessibility APIs.

```swift
let activeIndicator = app.images["Active stack"]
XCTAssertTrue(
    activeIndicator.waitForExistence(timeout: 2),
    "Active stack should display star indicator in the list row"
)
```

## Checks

- SwiftLint: 0 new violations (2 pre-existing warnings unchanged)
- Build (macOS): ✅ BUILD SUCCEEDED