### PR TITLE
fix(ios): prevent SwiftData crash during app-switcher snapshot

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -398,14 +398,25 @@ struct RootView: View {
             }
         }
         #if os(iOS)
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
-            // Show overlay BEFORE iOS takes the snapshot.
-            // willResignActive fires before the snapshot render pass.
-            showSnapshotOverlay = true
+        .task {
+            // UIApplication notifications only work in the actual app, not in test runners
+            guard !ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath") else {
+                return
+            }
+
+            // Listen for UIKit-level notifications (fire before scenePhase changes)
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.willResignActiveNotification) {
+                showSnapshotOverlay = true
+            }
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-            // Remove overlay when app returns to foreground
-            showSnapshotOverlay = false
+        .task {
+            guard !ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath") else {
+                return
+            }
+
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.didBecomeActiveNotification) {
+                showSnapshotOverlay = false
+            }
         }
         #endif
         .task {


### PR DESCRIPTION
## Problem

When iOS takes an app-switcher snapshot (on backgrounding), it renders the current view hierarchy. SwiftUI's `@Query` views call SwiftData's `performAndWait` during this render. If another `performAndWait` is already in flight (e.g. a sync operation), this causes a reentrancy assertion failure deep in SwiftData/CoreData (30+ frame crash).

## Fix

Three commits:

1. **Core fix** (`10c1614`): Add a `showSnapshotOverlay` state variable to `RootView`. When the app is about to resign active, an opaque full-screen overlay instantly covers the view hierarchy — hiding all `@Query`-backed views before iOS renders the snapshot. The overlay is removed when the app becomes active again.

   - Listens to `UIApplication.willResignActiveNotification` (UIKit-level, fires *before* `scenePhase` changes) to guarantee the overlay is in the view tree when iOS takes the snapshot.
   - Uses `.transition(.identity)` — no animation, must be instant.

2. **macOS compatibility** (`5a1b853`): Use `Color(.systemBackground)` (iOS) vs `Color(nsColor: .windowBackgroundColor)` (macOS) to avoid `UIColor` reference on macOS.

3. **Test guard** (`0222b27`): Skip `UIApplication.willResignActiveNotification` listeners in test environments (where `UIApplication` isn't available) to prevent test crashes.

Also moves `WidgetDataService.updateAllWidgets` from `.inactive` → `.active` phase, so widget refreshes never happen during the risky background transition window.

## Testing

- Build succeeded on iOS Simulator (iPhone 17, iOS 26.3.1)
- SwiftLint: 0 violations
- The overlay approach is the standard workaround for this class of SwiftData snapshot crashes