### PR TITLE
feat(ios): wire StreakDashboardView into Settings navigation

### DIFF
--- a/Dequeue/Dequeue/Views/Settings/SettingsView.swift
+++ b/Dequeue/Dequeue/Views/Settings/SettingsView.swift
@@ -125,6 +125,11 @@ struct SettingsView: View {
                 Label("Statistics", systemImage: "chart.bar")
             }
             NavigationLink {
+                StreakDashboardView()
+            } label: {
+                Label("Streaks", systemImage: "flame")
+            }
+            NavigationLink {
                 ExportView()
             } label: {
                 Label("Export Data", systemImage: "square.and.arrow.up")


### PR DESCRIPTION
## Summary

Adds a 'Streaks' navigation link in the Settings Data section, making the existing `StreakDashboardView` accessible to users.

The `StreakDashboardView` was fully implemented but never linked into the navigation flow. This is a 5-line addition to surface it.

### What users see
A new **Streaks** row (🔥 flame icon) in Settings → Data, linking to:
- Current and best streak counts
- Weekly activity bar chart
- Monthly heatmap (last 30 days)
- Task completion stats
- Milestone achievements

## Changes
- `SettingsView.swift`: Add `NavigationLink` to `StreakDashboardView` in Data section

## Testing
- Build: ✅ iOS Simulator
- SwiftLint: ✅ No errors in changed file
- No new warnings introduced