### PR TITLE
test(observability): smoke-cover ErrorReportingService+SyncObservability

### DIFF
--- a/Dequeue/DequeueTests/ErrorReportingServiceSyncObservabilityTests.swift
+++ b/Dequeue/DequeueTests/ErrorReportingServiceSyncObservabilityTests.swift
@@ -254,24 +254,22 @@ struct ErrorReportingServiceSyncObservabilityTests {
 
     // MARK: - logProjectionSyncFailed
 
-    @Test("logProjectionSyncFailed unsuppressed fires Sentry event and does not crash")
-    func testLogProjectionSyncFailedUnsuppressed() {
+    @Test("logProjectionSyncFailed fires Sentry event and does not crash")
+    func testLogProjectionSyncFailedServerError() {
         let error = NSError(domain: "SyncError", code: 500, userInfo: [
             NSLocalizedDescriptionKey: "Projection sync failed: server returned 500"
         ])
         ErrorReportingService.logProjectionSyncFailed(error: error, duration: 2.5)
     }
 
-    @Test("logProjectionSyncFailed suppressed skips Sentry event and does not crash")
-    func testLogProjectionSyncFailedSuppressed() {
-        // isSuppressed=true → guard !isSuppressed else { return } fires.
-        // Breadcrumb still written; Sentry capture skipped.
+    @Test("logProjectionSyncFailed with URL error does not crash")
+    func testLogProjectionSyncFailedURLError() {
         let error = NSError(
             domain: NSURLErrorDomain,
-            code: -1,
-            userInfo: [NSLocalizedDescriptionKey: "Request failed with status code: 429"]
+            code: NSURLErrorNetworkConnectionLost,
+            userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."]
         )
-        ErrorReportingService.logProjectionSyncFailed(error: error, duration: 0.3, isSuppressed: true)
+        ErrorReportingService.logProjectionSyncFailed(error: error, duration: 0.3)
     }
 
     @Test("logProjectionSyncFailed with long error message does not crash")


### PR DESCRIPTION
## Summary

Add 54 smoke tests for all methods in `ErrorReportingService+SyncObservability.swift` — a 440-line file that previously had **zero direct test coverage**.

## What's covered

| Method | Tests |
|---|---|
| `logSyncStateTransition` | with/without trigger |
| `logWebSocketConnecting` | plain URL, token URL (redaction path), token-only URL |
| `logWebSocketConnected/Disconnected` | with/without close code |
| `logWebSocketError` | attempts 1, 2, 3 (Sentry event threshold), 20 |
| `logSyncNetworkRequest` | 200, 401 excluded, 403, 500, token URL, nil optionals |
| `logSyncPull` | with/without checkpoint, zero events |
| `logSyncPush` | success, failure, zero events |
| `logProjectionSyncStart/Complete` | normal counts + all-zero |
| `logProjectionSyncFailed` | server error, URL error, long message |
| `logAuthTokenRefresh` | success, failure unsuppressed, failure suppressed, no error string |
| `logCertPinningResult` | matched, mismatch, empty hashes |
| `recordProjectionSyncTransaction` | success, failure, zero durations |
| `recordEventPushTransaction` | success, failure, zero events |

## Why smoke tests

Sentry is not configured in the test environment, so Sentry side-effects are no-ops. The tests verify crash-free behaviour across all code paths — including the conditional branches that fire Sentry error events (`logWebSocketError` attempt ≥ 3, `logProjectionSyncFailed`, `logAuthTokenRefresh` failure, cert-pinning mismatch).

## Local verification

- Build: ✅ `xcodebuild build-for-testing`
- Tests: ✅ 54/54 passed
- SwiftLint: ✅ 0 new violations