### PR TITLE
test(models): cover TaskPriorityLevel enum and DeploymentEnvironment computed properties

### DIFF
--- a/Dequeue/DequeueTests/DeploymentEnvironmentTests.swift
+++ b/Dequeue/DequeueTests/DeploymentEnvironmentTests.swift
@@ -1,0 +1,143 @@
+//
+//  DeploymentEnvironmentTests.swift
+//  DequeueTests
+//
+//  Tests for DeploymentEnvironment computed properties (displayName, badge, id),
+//  ValidationSeverity, and EnvironmentValidationIssue.
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - DeploymentEnvironment Tests
+
+@Suite("DeploymentEnvironment Tests")
+@MainActor
+struct DeploymentEnvironmentTests {
+    @Test("DeploymentEnvironment has exactly 3 cases")
+    func caseCount() {
+        #expect(DeploymentEnvironment.allCases.count == 3)
+    }
+
+    @Test("DeploymentEnvironment id equals rawValue (Identifiable)")
+    func idEqualsRawValue() {
+        for env in DeploymentEnvironment.allCases {
+            #expect(env.id == env.rawValue)
+        }
+    }
+
+    @Test("DeploymentEnvironment displayName is correct for each case")
+    func displayNames() {
+        #expect(DeploymentEnvironment.development.displayName == "Development")
+        #expect(DeploymentEnvironment.staging.displayName == "Staging")
+        #expect(DeploymentEnvironment.production.displayName == "Production")
+    }
+
+    @Test("DeploymentEnvironment displayName values are unique")
+    func displayNamesAreUnique() {
+        let names = DeploymentEnvironment.allCases.map { $0.displayName }
+        #expect(Set(names).count == DeploymentEnvironment.allCases.count)
+    }
+
+    @Test("DeploymentEnvironment badge emoji is correct for each case")
+    func badgeEmojis() {
+        #expect(DeploymentEnvironment.development.badge == "🛠️")
+        #expect(DeploymentEnvironment.staging.badge == "🧪")
+        #expect(DeploymentEnvironment.production.badge == "🚀")
+    }
+
+    @Test("DeploymentEnvironment badge values are unique")
+    func badgesAreUnique() {
+        let badges = DeploymentEnvironment.allCases.map { $0.badge }
+        #expect(Set(badges).count == DeploymentEnvironment.allCases.count)
+    }
+
+    @Test("DeploymentEnvironment configuration has matching environment property")
+    func configurationEnvironmentMatches() {
+        for env in DeploymentEnvironment.allCases {
+            #expect(env.configuration.environment == env)
+        }
+    }
+
+    @Test("DeploymentEnvironment is Codable (round-trip for all cases)")
+    func codableRoundTrip() throws {
+        for env in DeploymentEnvironment.allCases {
+            let data = try JSONEncoder().encode(env)
+            let decoded = try JSONDecoder().decode(DeploymentEnvironment.self, from: data)
+            #expect(decoded == env, "Round-trip failed for \(env.rawValue)")
+        }
+    }
+
+    @Test("DeploymentEnvironment returns nil for invalid raw value")
+    func invalidRawValue() {
+        #expect(DeploymentEnvironment(rawValue: "unknown") == nil)
+        #expect(DeploymentEnvironment(rawValue: "") == nil)
+        #expect(DeploymentEnvironment(rawValue: "Production") == nil) // case-sensitive
+    }
+}
+
+// MARK: - ValidationSeverity Tests
+
+@Suite("ValidationSeverity Tests")
+@MainActor
+struct ValidationSeverityTests {
+    @Test("ValidationSeverity has correct raw values")
+    func rawValues() {
+        #expect(ValidationSeverity.warning.rawValue == "warning")
+        #expect(ValidationSeverity.error.rawValue == "error")
+    }
+
+    @Test("ValidationSeverity Equatable works correctly")
+    func equatable() {
+        #expect(ValidationSeverity.warning == .warning)
+        #expect(ValidationSeverity.error == .error)
+        #expect(ValidationSeverity.warning != .error)
+    }
+
+    @Test("ValidationSeverity can be created from raw String")
+    func fromRawValue() {
+        #expect(ValidationSeverity(rawValue: "warning") == .warning)
+        #expect(ValidationSeverity(rawValue: "error") == .error)
+        #expect(ValidationSeverity(rawValue: "critical") == nil)
+    }
+}
+
+// MARK: - EnvironmentValidationIssue Tests
+
+@Suite("EnvironmentValidationIssue Tests")
+@MainActor
+struct EnvironmentValidationIssueTests {
+    @Test("EnvironmentValidationIssue stores all fields correctly")
+    func storesFields() {
+        let issue = EnvironmentValidationIssue(
+            key: "clerkPublishableKey",
+            message: "Clerk key is empty",
+            severity: .error
+        )
+        #expect(issue.key == "clerkPublishableKey")
+        #expect(issue.message == "Clerk key is empty")
+        #expect(issue.severity == .error)
+    }
+
+    @Test("EnvironmentValidationIssue Equatable compares all fields")
+    func equatable() {
+        let issue1 = EnvironmentValidationIssue(key: "key", message: "msg", severity: .warning)
+        let issue2 = EnvironmentValidationIssue(key: "key", message: "msg", severity: .warning)
+        let differentKey = EnvironmentValidationIssue(key: "other", message: "msg", severity: .warning)
+        let differentMessage = EnvironmentValidationIssue(key: "key", message: "different", severity: .warning)
+        let differentSeverity = EnvironmentValidationIssue(key: "key", message: "msg", severity: .error)
+
+        #expect(issue1 == issue2)
+        #expect(issue1 != differentKey)
+        #expect(issue1 != differentMessage)
+        #expect(issue1 != differentSeverity)
+    }
+
+    @Test("EnvironmentValidationIssue warning severity is not error")
+    func warningSeverityIsNotError() {
+        let issue = EnvironmentValidationIssue(key: "sentryDSN", message: "DSN empty", severity: .warning)
+        #expect(issue.severity == .warning)
+        #expect(issue.severity != .error)
+    }
+}

--- a/Dequeue/DequeueTests/EnumsTests.swift
+++ b/Dequeue/DequeueTests/EnumsTests.swift
@@ -419,3 +419,48 @@ struct EventTypeTests {
         #expect(EventType(rawValue: "stack") == nil)
     }
 }
+
+// MARK: - TaskPriorityLevel Tests
+
+@Suite("TaskPriorityLevel Tests")
+@MainActor
+struct TaskPriorityLevelTests {
+    @Test("TaskPriorityLevel has correct Int raw values")
+    func taskPriorityLevelRawValues() {
+        #expect(TaskPriorityLevel.none.rawValue == 0)
+        #expect(TaskPriorityLevel.low.rawValue == 1)
+        #expect(TaskPriorityLevel.medium.rawValue == 2)
+        #expect(TaskPriorityLevel.high.rawValue == 3)
+    }
+
+    @Test("TaskPriorityLevel can be created from valid Int raw values")
+    func taskPriorityLevelFromRawValue() {
+        // Use explicit type to avoid `.none` being interpreted as Optional.none
+        #expect(TaskPriorityLevel(rawValue: 0) == TaskPriorityLevel.none)
+        #expect(TaskPriorityLevel(rawValue: 1) == TaskPriorityLevel.low)
+        #expect(TaskPriorityLevel(rawValue: 2) == TaskPriorityLevel.medium)
+        #expect(TaskPriorityLevel(rawValue: 3) == TaskPriorityLevel.high)
+    }
+
+    @Test("TaskPriorityLevel returns nil for out-of-range raw values")
+    func taskPriorityLevelInvalidRawValue() {
+        #expect(TaskPriorityLevel(rawValue: -1) == nil)
+        #expect(TaskPriorityLevel(rawValue: 4) == nil)
+        #expect(TaskPriorityLevel(rawValue: 99) == nil)
+    }
+
+    @Test("TaskPriorityLevel raw values are strictly ascending")
+    func taskPriorityLevelOrdering() {
+        #expect(TaskPriorityLevel.none.rawValue < TaskPriorityLevel.low.rawValue)
+        #expect(TaskPriorityLevel.low.rawValue < TaskPriorityLevel.medium.rawValue)
+        #expect(TaskPriorityLevel.medium.rawValue < TaskPriorityLevel.high.rawValue)
+    }
+
+    @Test("TaskPriorityLevel none is the default (rawValue 0)")
+    func taskPriorityLevelNoneIsZero() {
+        // Used in LocalStatsService as the fallback when priority is nil
+        // Use explicit type to avoid `.none` being interpreted as Optional.none
+        let fallback = TaskPriorityLevel(rawValue: TaskPriorityLevel.none.rawValue)
+        #expect(fallback == TaskPriorityLevel.none)
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for two previously untested areas:

### 1. `TaskPriorityLevel` (added to `EnumsTests.swift`)
`TaskPriorityLevel` is used in `LocalStatsService` for priority-based task counting but had zero test coverage.

**Tests added:**
- Raw values are 0–3 for `none`/`low`/`medium`/`high`
- Creation from valid Int raw values
- Returns `nil` for out-of-range raw values (-1, 4, 99)
- Raw values are strictly ascending (ordering guarantee)
- `none.rawValue == 0` (default fallback used in `LocalStatsService`)

**Gotcha fixed:** `.none` is ambiguous when the LHS is `TaskPriorityLevel?` (the `init(rawValue:)` return type). Swift interprets `.none` as `Optional.none` (nil) rather than `TaskPriorityLevel.none`. Fixed by using explicit `TaskPriorityLevel.none` qualification.

### 2. `DeploymentEnvironment` + `ValidationSeverity` + `EnvironmentValidationIssue` (new `DeploymentEnvironmentTests.swift`)
`EnvironmentManagerTests.swift` covers the manager behaviour but the model computed properties (`displayName`, `badge`, `id`) and the validation types were not tested.

**Tests added:**
- `DeploymentEnvironment.id` equals `rawValue` (Identifiable)
- `displayName` returns correct human-readable strings
- `badge` returns distinct emoji per environment
- Both are unique across all cases
- Codable round-trip for all 3 cases
- Invalid rawValue → `nil`
- `configuration.environment` matches the enum case
- `ValidationSeverity` raw values and Equatable
- `EnvironmentValidationIssue` field storage and Equatable (all fields matter)

## Testing
All new tests pass locally:
```
TaskPriorityLevelTests (5 tests) — all passed
DeploymentEnvironmentTests (9 tests) — all passed
ValidationSeverityTests (3 tests) — all passed
EnvironmentValidationIssueTests (3 tests) — all passed
```