### PR TITLE
test(filters): cover missing DateRangeFilter.dateRange() cases

### DIFF
--- a/Dequeue/DequeueTests/TaskFilterTests.swift
+++ b/Dequeue/DequeueTests/TaskFilterTests.swift
@@ -195,6 +195,83 @@ struct DateRangeFilterTests {
         #expect(range.end == nil)
     }
 
+    @Test("Tomorrow range covers 24 hours starting from tomorrow")
+    func tomorrowRange() {
+        let now = Date()
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: now)
+        let range = DateRangeFilter.tomorrow.dateRange(from: now)
+
+        let expectedStart = calendar.date(byAdding: .day, value: 1, to: startOfToday)
+        let expectedEnd = calendar.date(byAdding: .day, value: 2, to: startOfToday)
+
+        #expect(range.start == expectedStart)
+        #expect(range.end == expectedEnd)
+
+        // Exactly 24 hours
+        if let start = range.start, let end = range.end {
+            let diff = end.timeIntervalSince(start)
+            #expect(abs(diff - 86400) < 1)
+        }
+    }
+
+    @Test("Next week covers days 7-14 from today")
+    func nextWeekRange() {
+        let now = Date()
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: now)
+        let range = DateRangeFilter.nextWeek.dateRange(from: now)
+
+        let expectedStart = calendar.date(byAdding: .day, value: 7, to: startOfToday)
+        let expectedEnd = calendar.date(byAdding: .day, value: 14, to: startOfToday)
+
+        #expect(range.start == expectedStart)
+        #expect(range.end == expectedEnd)
+
+        // Exactly 7 days span
+        if let start = range.start, let end = range.end {
+            let diff = end.timeIntervalSince(start)
+            #expect(abs(diff - 7 * 86400) < 1)
+        }
+    }
+
+    @Test("This month covers start of today to 1 month out")
+    func thisMonthRange() {
+        let now = Date()
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: now)
+        let range = DateRangeFilter.thisMonth.dateRange(from: now)
+
+        let expectedEnd = calendar.date(byAdding: .month, value: 1, to: startOfToday)
+
+        #expect(range.start == startOfToday)
+        #expect(range.end == expectedEnd)
+        #expect(range.end != nil)
+    }
+
+    @Test("Custom returns nil bounds (handled separately)")
+    func customRange() {
+        let range = DateRangeFilter.custom.dateRange()
+        #expect(range.start == nil)
+        #expect(range.end == nil)
+    }
+
+    @Test("Overdue end equals start of today")
+    func overdueEndIsStartOfToday() {
+        let now = Date()
+        let startOfToday = Calendar.current.startOfDay(for: now)
+        let range = DateRangeFilter.overdue.dateRange(from: now)
+        #expect(range.start == nil)
+        #expect(range.end == startOfToday)
+    }
+
+    @Test("DateRangeFilter id equals rawValue")
+    func idEqualsRawValue() {
+        for filter in DateRangeFilter.allCases {
+            #expect(filter.id == filter.rawValue)
+        }
+    }
+
     @Test("All cases have display names")
     func displayNames() {
         for range in DateRangeFilter.allCases {


### PR DESCRIPTION
## What

Adds 7 missing unit tests for `DateRangeFilter.dateRange()` in `TaskFilterTests.swift`.

## Why

The existing `DateRangeFilterTests` suite covered `.any`, `.overdue` (partially), `.today`, `.thisWeek`, and `.noDueDate` — but four cases had no direct `dateRange()` coverage:

| Case | Was tested? |
|------|------------|
| `.tomorrow` | ❌ |
| `.nextWeek` | ❌ |
| `.thisMonth` | ❌ |
| `.custom` | ❌ |
| `.overdue` exact end | ❌ |
| `id` == rawValue | ❌ |

## Changes

- `tomorrowRange()` — verifies start = startOfTomorrow, end = endOfTomorrow, exactly 24h span
- `nextWeekRange()` — verifies start = +7 days, end = +14 days, exactly 7-day span
- `thisMonthRange()` — verifies start = startOfToday, end = +1 month
- `customRange()` — verifies both bounds are nil (handled separately in UI)
- `overdueEndIsStartOfToday()` — verifies exact end date, not just non-nil
- `idEqualsRawValue()` — covers the `Identifiable` conformance

## Tests

All 13 `DateRangeFilterTests` pass locally. Zero SwiftLint violations.