### PR TITLE
fix(sync): suppress Clerk authentication_invalid errors from Sentry in background sync

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -598,10 +598,14 @@ struct RootView: View {
                 return // Success, exit retry loop
             } catch {
                 os_log("[Sync] Connection attempt \(attempt) failed: \(error.localizedDescription)")
-                // AuthError.notAuthenticated is expected at app startup before Clerk finishes
-                // loading — skip Sentry to avoid chronic noise (DEQUEUE-APP-10).
+                // AuthError.notAuthenticated/.noToken is expected at app startup before Clerk
+                // finishes loading — skip Sentry to avoid chronic noise (DEQUEUE-APP-10).
+                // ClerkAPIError with authentication_invalid is also expected: iOS fires background
+                // tasks to sync while the Clerk session is inactive (app in background). This is
+                // normal iOS behaviour, not a code bug — suppress to avoid noise (DEQUEUE-APP-1A).
                 let isExpectedAuthError = (error as? AuthError) == .notAuthenticated
                     || (error as? AuthError) == .noToken
+                    || error.localizedDescription.contains("authentication_invalid")
                 if !isExpectedAuthError {
                     ErrorReportingService.capture(
                         error: error,


### PR DESCRIPTION
## Problem

Sentry is receiving `ClerkKit.ClerkAPIError: authentication_invalid` errors from `connectSyncWithRetry` in `DequeueApp.swift` (DEQUEUE-APP-1A). These fire when iOS wakes the app in the background to sync while the Clerk session is inactive — this is expected iOS behaviour, not a code bug.

## Root Cause

`connectSyncWithRetry` suppresses `AuthError.notAuthenticated` and `AuthError.noToken` from Sentry (fix for DEQUEUE-APP-10), but did not cover `ClerkKit.ClerkAPIError` with `code: "authentication_invalid"`. The Clerk SDK throws this when `session.getToken()` is called with no active session (background execution context).

## Fix

Extend the `isExpectedAuthError` check to also match errors whose `localizedDescription` contains `"authentication_invalid"`. This mirrors the existing pattern in `SyncManager.isAuthenticationError()`.

## Testing

- Build passes, SwiftLint clean
- Pattern mirrors `SyncManager.isAuthenticationError()` (already battle-tested)

Closes DEQUEUE-APP-1A