### PR TITLE
fix(sync): detect auth errors via String(describing:) and make isAuthenticationError static

### DIFF
--- a/Dequeue/Dequeue/Sync/SyncManager.swift
+++ b/Dequeue/Dequeue/Sync/SyncManager.swift
@@ -489,11 +489,16 @@ actor SyncManager {
                 // background while Clerk's token refresh is in-flight, which causes the
                 // refresh to time out. This is expected behaviour, not a real auth failure.
                 let suspended = isSuspendedForBackground
+                // Also suppress authentication_invalid: fired when a Clerk session is revoked
+                // or expired — handled downstream by the session-invalidation flow (sign-out /
+                // re-login prompt), not a sync code bug. Reporting here generates DEQUEUE-APP-1
+                // noise identical to the background-task race (DEQUEUE-APP-1A).
+                let isAuthInvalid = Self.isAuthenticationError(error)
                 await MainActor.run {
                     ErrorReportingService.logAuthTokenRefresh(
                         success: false,
                         error: error.localizedDescription,
-                        isSuppressed: suspended
+                        isSuppressed: suspended || isAuthInvalid
                     )
                 }
                 throw error
@@ -1749,7 +1754,13 @@ actor SyncManager {
             if needsInitialSync {
                 isInitialSyncActive = false
             }
-            await ErrorReportingService.capture(error: error, context: ["source": "initial_pull"])
+            // Auth errors (e.g. authentication_invalid) are handled by the session-invalidation
+            // flow — no need to flood Sentry with them here. Clerk infra errors (530,
+            // internal_clerk_error, 429) are already handled via cooldown backoff.
+            // Only report genuinely unexpected errors that warrant investigation.
+            if !Self.isAuthenticationError(error) && !Self.isClerkInfrastructureError(error) {
+                await ErrorReportingService.capture(error: error, context: ["source": "initial_pull"])
+            }
         }
     }
 
@@ -1781,7 +1792,7 @@ actor SyncManager {
                 } catch {
                     // Auth errors are permanent — stop the loop to avoid spamming Sentry
                     // (e.g. Clerk session revoked: repeating every 5s generates thousands of events)
-                    if await self.isAuthenticationError(error) {
+                    if SyncManager.isAuthenticationError(error) {
                         os_log("[Sync] Periodic push: auth failure, disconnecting to stop retry loop")
                         await self.disconnect()
                         break
@@ -1846,7 +1857,7 @@ actor SyncManager {
                     try await self.pullEvents()
                 } catch {
                     // Auth errors are permanent — stop the loop to avoid spamming Sentry
-                    if await self.isAuthenticationError(error) {
+                    if SyncManager.isAuthenticationError(error) {
                         os_log("[Sync] Fallback pull: auth failure, disconnecting to stop retry loop")
                         await self.disconnect()
                         break
@@ -1869,12 +1880,26 @@ actor SyncManager {
     ///
     /// When auth is permanently broken (e.g. Clerk session revoked/expired), periodic sync
     /// loops should stop rather than retrying — each retry produces a Sentry event.
-    private func isAuthenticationError(_ error: Error) -> Bool {
+    static func isAuthenticationError(_ error: Error) -> Bool {
         if case SyncError.notAuthenticated = error { return true }
         if case AuthError.notAuthenticated = error { return true }
-        // Clerk errors with authentication_invalid code are permanent (session revoked)
-        let description = error.localizedDescription
-        if description.contains("authentication_invalid") || description.contains("Unable to authenticate") {
+        // Clerk errors with authentication_invalid code are permanent (session revoked).
+        //
+        // IMPORTANT: Clerk SDK's `localizedDescription` returns the human-readable `message`
+        // field ("Invalid authentication") — NOT the machine-readable `code` field
+        // ("authentication_invalid"). We must check BOTH `localizedDescription` and
+        // `String(describing:)` because the full ClerkAPIError struct representation
+        // (which includes the code) only appears in the latter.
+        //
+        // This was the root cause of DEQUEUE-APP-T (2,200+ Sentry events): the auth check
+        // returned false because localizedDescription lacked "authentication_invalid",
+        // so the error fell through to the generic Sentry capture in the periodic push loop.
+        let localizedDesc = error.localizedDescription
+        let fullDesc = String(describing: error)
+        if localizedDesc.contains("authentication_invalid")
+            || localizedDesc.contains("Unable to authenticate")
+            || fullDesc.contains("authentication_invalid")
+            || fullDesc.contains("Unable to authenticate") {
             return true
         }
         return false

--- a/Dequeue/DequeueTests/SyncManagerAuthErrorTests.swift
+++ b/Dequeue/DequeueTests/SyncManagerAuthErrorTests.swift
@@ -1,0 +1,162 @@
+//
+//  SyncManagerAuthErrorTests.swift
+//  DequeueTests
+//
+//  Tests for SyncManager.isAuthenticationError — the helper that classifies
+//  permanent authentication failures so periodic sync loops stop retrying.
+//
+//  Key invariant: Clerk SDK's `localizedDescription` returns the human-readable
+//  `message` field ("Invalid authentication"), NOT the machine-readable `code`
+//  ("authentication_invalid"). We check BOTH localizedDescription AND
+//  String(describing:) to catch both representations.
+//
+
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Test Helpers
+
+/// Simulates Clerk SDK's ClerkAPIError: localizedDescription returns the human-readable
+/// message, while String(describing:) includes the machine-readable error code.
+private struct MockClerkAPIError: Error, CustomStringConvertible {
+    let code: String
+    let message: String
+
+    var localizedDescription: String { message }
+    var description: String { "ClerkAPIError(code: \"\(code)\", message: \"\(message)\")" }
+}
+
+@Suite("SyncManager isAuthenticationError Tests")
+struct SyncManagerAuthErrorTests {
+    // MARK: - SyncError / AuthError typed errors
+
+    @Test("SyncError.notAuthenticated is an authentication error")
+    func testSyncErrorNotAuthenticated() {
+        let error = SyncError.notAuthenticated
+        #expect(SyncManager.isAuthenticationError(error) == true)
+    }
+
+    @Test("AuthError.notAuthenticated is an authentication error")
+    func testAuthErrorNotAuthenticated() {
+        let error = AuthError.notAuthenticated
+        #expect(SyncManager.isAuthenticationError(error) == true)
+    }
+
+    // MARK: - localizedDescription matching
+
+    @Test("Error with 'authentication_invalid' in localizedDescription is an auth error")
+    func testLocalizedDescriptionContainsAuthInvalid() {
+        let error = NSError(
+            domain: "ClerkKit.ClerkAPIError",
+            code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "authentication_invalid: session has been revoked"]
+        )
+        #expect(SyncManager.isAuthenticationError(error) == true)
+    }
+
+    @Test("Error with 'Unable to authenticate' in localizedDescription is an auth error")
+    func testLocalizedDescriptionContainsUnableToAuthenticate() {
+        let error = NSError(
+            domain: "AuthError",
+            code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "Unable to authenticate the user"]
+        )
+        #expect(SyncManager.isAuthenticationError(error) == true)
+    }
+
+    // MARK: - String(describing:) matching (the DEQUEUE-APP-T bug fix)
+
+    /// This is the critical regression test for DEQUEUE-APP-T (2,200+ Sentry events).
+    ///
+    /// Clerk SDK returns localizedDescription = "Invalid authentication" (human-readable),
+    /// but String(describing:) includes code = "authentication_invalid" (machine-readable).
+    /// Without checking String(describing:), the periodic push loop fails to recognise
+    /// the error as permanent auth failure and falls through to the Sentry capture path.
+    @Test("Clerk error with code in String(describing:) but NOT in localizedDescription is an auth error")
+    func testStringDescribingContainsAuthInvalid() {
+        // Simulates Clerk SDK's ClerkAPIError where localizedDescription = human message
+        // but String(describing:) includes the machine-readable code field.
+        let error = MockClerkAPIError(
+            code: "authentication_invalid",
+            message: "Invalid authentication"
+        )
+
+        // Verify that localizedDescription does NOT contain "authentication_invalid"
+        #expect(!error.localizedDescription.contains("authentication_invalid"),
+                "Precondition: localizedDescription should only have human-readable message")
+
+        // Verify that String(describing:) DOES contain "authentication_invalid"
+        #expect(String(describing: error).contains("authentication_invalid"),
+                "Precondition: full description should include the error code")
+
+        // The critical assertion: isAuthenticationError must return true
+        #expect(SyncManager.isAuthenticationError(error) == true,
+                "isAuthenticationError must detect auth_invalid via String(describing:)")
+    }
+
+    @Test("Clerk error with 'Unable to authenticate' in String(describing:) is an auth error")
+    func testStringDescribingContainsUnableToAuthenticate() {
+        let error = MockClerkAPIError(
+            code: "Unable to authenticate",
+            message: "Session is no longer valid"
+        )
+        #expect(SyncManager.isAuthenticationError(error) == true)
+    }
+
+    // MARK: - Non-auth errors (must NOT be classified as auth)
+
+    @Test("Network timeout error is NOT an authentication error")
+    func testNetworkTimeoutNotAuth() {
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [NSLocalizedDescriptionKey: "The request timed out."]
+        )
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+
+    @Test("HTTP 500 server error is NOT an authentication error")
+    func testHttp500NotAuth() {
+        let error = NSError(
+            domain: "HTTPError",
+            code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "Internal server error"]
+        )
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+
+    @Test("Clerk internal_clerk_error is NOT an authentication error")
+    func testClerkInternalErrorNotAuth() {
+        let error = NSError(
+            domain: "ClerkKit.ClerkAPIError",
+            code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "internal_clerk_error: backend unavailable"]
+        )
+        // internal_clerk_error is a transient infra error, not a permanent auth failure
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+
+    @Test("SyncError.clerkInCooldown is NOT an authentication error")
+    func testClerkCooldownNotAuth() {
+        // clerkInCooldown must NOT be classified as auth error — it would
+        // permanently disconnect the sync loop, preventing recovery after cooldown.
+        let error = SyncError.clerkInCooldown
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+
+    @Test("Generic error with unrelated description is NOT an authentication error")
+    func testUnrelatedErrorNotAuth() {
+        let error = MockClerkAPIError(
+            code: "not_found",
+            message: "Resource not found"
+        )
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+
+    @Test("Empty error description is NOT an authentication error")
+    func testEmptyDescriptionNotAuth() {
+        let error = NSError(domain: "SomeError", code: 0, userInfo: [:])
+        #expect(SyncManager.isAuthenticationError(error) == false)
+    }
+}


### PR DESCRIPTION
## Problem

Sentry was flooded with 2,200+ `authentication_invalid` events from the periodic push and fallback pull loops (DEQUEUE-APP-T). The existing `isAuthenticationError` check was returning `false` for these errors, letting them fall through to the generic `ErrorReportingService.capture` call.

## Root Cause

Clerk SDK's `localizedDescription` returns the **human-readable message** (`"Invalid authentication"`), **not** the machine-readable code (`"authentication_invalid"`). The classifier only checked `localizedDescription`, so it missed the code entirely.

`String(describing: error)` on a `ClerkAPIError` includes the full struct representation, which **does** contain `authentication_invalid` — but we weren't checking it.

## Fix

1. **Check both `localizedDescription` and `String(describing:)`** in `isAuthenticationError` — catches errors regardless of which representation Clerk uses.
2. **Make `isAuthenticationError` static** — removes the actor-isolation `await` requirement, simplifying call sites in the periodic push and fallback pull loops.
3. **Suppress auth + infra errors in initial pull** — same pattern applied to `initial_pull` Sentry capture for consistency.

## Tests

Added `SyncManagerAuthErrorTests.swift` with 12 unit tests including a regression test for the exact DEQUEUE-APP-T scenario:

```swift
// MockClerkAPIError where localizedDescription = "Invalid authentication"
// but String(describing:) includes "authentication_invalid"
let error = MockClerkAPIError(code: "authentication_invalid", message: "Invalid authentication")
#expect(SyncManager.isAuthenticationError(error) == true)
```

Closes DEQUEUE-APP-T