### PR TITLE
test(sync): cover parseISO8601 and dateFromUnixMs date-parsing utilities

### DIFF
--- a/Dequeue/DequeueTests/SyncManagerProjectionParserTests.swift
+++ b/Dequeue/DequeueTests/SyncManagerProjectionParserTests.swift
@@ -193,7 +193,7 @@ struct SyncManagerDateParsersTests {
             let sm = try SyncManagerDateParsersTests.makeSyncManager()
             // Build the expected date from components to avoid hardcoding a timestamp.
             var cal = Calendar(identifier: .gregorian)
-            cal.timeZone = TimeZone(identifier: "UTC")!
+            cal.timeZone = try #require(TimeZone(identifier: "UTC"))
             let comps = DateComponents(year: 2024, month: 1, day: 15, hour: 10, minute: 30, second: 45)
             let expected = try #require(cal.date(from: comps))
             let result = sm.parseISO8601("2024-01-15T10:30:45Z")


### PR DESCRIPTION
## Summary

Adds test coverage for the two nonisolated date-parsing helpers used throughout the projection sync pipeline:

- `parseISO8601(_:)` — maps raw API ISO8601 strings → `Date?`
- `dateFromUnixMs(_:)` — converts Unix millisecond timestamps → `Date`

Both helpers are called on every sync pull to convert raw API date values into Swift `Date` objects, so correctness here is critical.

## Tests Added

**`SyncManagerDateParsersTests`** suite covering:

### parseISO8601
- Returns nil for nil input
- Returns nil for empty string
- Returns nil for invalid/garbage strings
- Correctly parses a known UTC ISO8601 date string (with 1s tolerance)
- Parses Unix epoch correctly
- Round-trips through `SyncManager.iso8601Standard` formatter

### dateFromUnixMs (non-optional overload)
- Epoch ms 0 → Unix epoch
- 1,000,000,000,000 ms → correct date
- 1000 ms → exactly 1.0s
- Large timestamp (year ~2100) stays within Double precision

### dateFromUnixMs (optional overload)
- nil input → nil output
- Non-nil input converts correctly
- Epoch 0 in optional overload returns epoch date

## Lint Fix

Replaced a force-unwrap (`TimeZone(identifier: "UTC")!`) with `try #require(...)` to satisfy SwiftLint's `force_unwrapping` rule.