### PR TITLE
fix(sentry): use SyncManager.isAuthenticationError in connectSyncWithRetry (DEQUEUE-APP-1A)

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -603,9 +603,15 @@ struct RootView: View {
                 // ClerkAPIError with authentication_invalid is also expected: iOS fires background
                 // tasks to sync while the Clerk session is inactive (app in background). This is
                 // normal iOS behaviour, not a code bug — suppress to avoid noise (DEQUEUE-APP-1A).
+                //
+                // Use SyncManager.isAuthenticationError which checks BOTH localizedDescription
+                // AND String(describing:) — Clerk's localizedDescription returns the human-readable
+                // message ("Invalid authentication"), NOT the machine-readable code
+                // ("authentication_invalid"), so a localizedDescription-only check misses events.
+                // This was the root cause of DEQUEUE-APP-1A leaking into Sentry.
                 let isExpectedAuthError = (error as? AuthError) == .notAuthenticated
                     || (error as? AuthError) == .noToken
-                    || error.localizedDescription.contains("authentication_invalid")
+                    || SyncManager.isAuthenticationError(error)
                 if !isExpectedAuthError {
                     ErrorReportingService.capture(
                         error: error,


### PR DESCRIPTION
## Problem

`DEQUEUE-APP-1A` (ClerkKit `authentication_invalid` errors) keeps leaking into Sentry despite the suppression code in `connectSyncWithRetry`.

**Root cause:** The check in `DequeueApp.swift` was:
```swift
|| error.localizedDescription.contains("authentication_invalid")
```
But Clerk's `localizedDescription` returns the **human-readable message** (`"Invalid authentication"`), NOT the machine-readable code (`"authentication_invalid"`). So the check always returned `false`, and the error fell through to Sentry.

This is **the exact same bug** that caused the earlier DEQUEUE-APP-T incident (2,200+ events). `SyncManager` already documented this and has a proper fix (`isAuthenticationError()` checks both `localizedDescription` AND `String(describing:)`), but `DequeueApp.swift` wasn't updated to match.

## Fix

Replace the manual string check with `SyncManager.isAuthenticationError(error)`, which correctly handles all Clerk error variants.

## Testing

- Build passes ✅
- SwiftLint clean ✅
- No logic change for non-auth errors

## Impact

Stops DEQUEUE-APP-1A from generating Sentry noise on every background sync attempt when the Clerk session is inactive.