### PR TITLE
fix(ci): correct Sentry project slug from dequeue-ios to dequeue-app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: dequeue-ios
+          SENTRY_PROJECT: dequeue-app
         with:
           environment: production
           version: ${{ github.sha }}
@@ -286,4 +286,4 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
 
           # Upload dSYMs
-          sentry-cli debug-files upload --org $SENTRY_ORG --project dequeue-ios ${{ runner.temp }}/dSYMs || true
+          sentry-cli debug-files upload --org $SENTRY_ORG --project dequeue-app ${{ runner.temp }}/dSYMs || true


### PR DESCRIPTION
## Problem

The `sentry-release` CI job was uploading dSYMs and creating Sentry releases under `--project dequeue-ios`, which **does not exist** in Sentry. The actual project is `dequeue-app` (ID: `4510574643773440`).

This caused every crash report to have `symbolicatorStatus: missing` for all in-app frames, making crashes completely undebuggable.

## Root Cause

Discovered via the Sentry self-healing monitor during routine check (March 15, 2026): two fatal crashes were reported on build 250 (iPad16,6, iOS 26.3.1), but **zero app frames were symbolicated** — all showed `missing`. 

Traced back to the CI `sentry-cli debug-files upload` command using the wrong project slug.

## Fix

Change both references in `release.yml`:
- `SENTRY_PROJECT: dequeue-ios` → `SENTRY_PROJECT: dequeue-app`
- `--project dequeue-ios` → `--project dequeue-app`

## The Crashes

Two fatal crashes triggered this discovery (both on same device, ~2h ago):
- `DEQUEUE-APP-1B`: `EXC_BREAKPOINT` — Swift concurrency `@MainActor` isolation violation (dispatch_assert_queue_fail)
- `DEQUEUE-APP-1D`: `NSInternalInconsistencyException` — UIKit Focus Engine: `parentEnvironment != nil` assertion

Both are on build 250 (current is 291), so they may already be fixed. Once dSYMs are properly uploaded going forward, we'll be able to confirm.