### PR TITLE
fix(ci): add dSYM upload to TestFlight workflow with correct project slug

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -74,6 +74,15 @@ jobs:
           CHANGELOG: ${{ github.event.inputs.changelog || 'Bug fixes and improvements' }}
         run: bundle exec fastlane beta
 
+      - name: Upload dSYMs to Sentry
+        if: success()
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project dequeue-app build/ || true
+
       - name: Upload IPA Artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Problem

Victor's prior fix (84be1f5) corrected the Sentry project slug in `release.yml`, but `testflight.yml` still had an uncommitted draft adding a dSYM upload step with the wrong slug `dequeue-ios` (which doesn't exist in Sentry).

As a result, **all TestFlight crash reports are unsymbolicated** — the in-app frames show no function names, filenames, or line numbers. This was exposed by two fatal crashes on build 250 (iPad16,6, iOS 26.3.1) that had zero symbolicated app frames.

## Fix

- Adds the `Upload dSYMs to Sentry` step to `testflight.yml` (the primary deployment workflow)
- Uses the correct project slug `dequeue-app` (matching Sentry project ID 4510574643773440)

## Crashes being investigated (unresolvable until dSYMs are in place)

| Issue | Type | Build | Device |
|-------|------|-------|--------|
| DEQUEUE-APP-1B | EXC_BREAKPOINT (main actor isolation violation) | 250 | iPad Pro M4, iOS 26.3.1 |
| DEQUEUE-APP-1D | NSInternalInconsistencyException (parentEnvironment nil) | 250 | iPad Pro M4, iOS 26.3.1 |

Both crashes are on an old build (250 vs current 291) so they may already be resolved in current code. dSYMs are needed to confirm.

## Testing

Next TestFlight deploy will upload dSYMs to `dequeue-app` project. Verify by checking a release in Sentry and confirming `fileCount > 0`.