### PR TITLE
test(projector): add 18 stack CRUD and lifecycle projection tests

### DIFF
--- a/Dequeue/DequeueTests/ProjectorServiceStackTests.swift
+++ b/Dequeue/DequeueTests/ProjectorServiceStackTests.swift
@@ -3,6 +3,7 @@
 //  DequeueTests
 //
 //  Tests for ProjectorService stack event projection:
+//  stackCreated, stackUpdated, stackDeleted, stackActivated, stackDeactivated,
 //  stackCompleted, stackDiscarded, stackClosed, stackReordered
 //
 
@@ -541,5 +542,554 @@ struct ProjectorServiceStackTests {
 
         // Known stack's sortOrder should be updated (index 1 → sortOrder 10)
         #expect(stack.sortOrder == 10)
+    }
+
+    // MARK: - stackCreated Tests
+
+    @Test("stackCreated: creates stack with correct fields from event")
+    func createdBuildsStackFromPayload() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let payload = try makeStackCreatedPayload(id: stackId, title: "My Stack", status: "active", sortOrder: 3)
+        let event = Event(
+            eventType: .stackCreated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        let predicate = #Predicate<Stack> { $0.id == stackId }
+        let stacks = try context.fetch(FetchDescriptor<Stack>(predicate: predicate))
+        let stack = try #require(stacks.first)
+        #expect(stack.title == "My Stack")
+        #expect(stack.status == .active)
+        #expect(stack.sortOrder == 3)
+        #expect(stack.syncState == .synced)
+        #expect(stack.isDeleted == false)
+    }
+
+    @Test("stackCreated: uses payload createdAt timestamp when provided")
+    func createdUsesPayloadCreatedAt() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let originalCreatedAt = Date(timeIntervalSinceNow: -3600)  // 1 hour ago
+        let createdAtMs = Int64(originalCreatedAt.timeIntervalSince1970 * 1_000)
+        let payloadDict: [String: Any] = [
+            "id": stackId,
+            "title": "Timestamped Stack",
+            "status": "active",
+            "sortOrder": 0,
+            "isDraft": false,
+            "isActive": false,
+            "deleted": false,
+            "tagIds": [String](),
+            "createdAt": createdAtMs
+        ]
+        let payload = try JSONSerialization.data(withJSONObject: payloadDict)
+        let event = Event(
+            eventType: .stackCreated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        let predicate = #Predicate<Stack> { $0.id == stackId }
+        let stacks = try context.fetch(FetchDescriptor<Stack>(predicate: predicate))
+        let stack = try #require(stacks.first)
+        // createdAt should match the payload timestamp (within 1s tolerance for ms conversion)
+        #expect(abs(stack.createdAt.timeIntervalSince(originalCreatedAt)) < 1.0)
+    }
+
+    @Test("stackCreated: LWW updates existing stack when event is newer")
+    func createdLwwUpdatesWhenEventIsNewer() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        // Insert an older stack locally
+        let existingStack = Stack(
+            id: stackId, title: "Old Title",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: -200)
+        )
+        context.insert(existingStack)
+        try context.save()
+
+        // stackCreated event is newer → should overwrite
+        let payload = try makeStackCreatedPayload(id: stackId, title: "New Title From Event")
+        let event = Event(
+            eventType: .stackCreated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(existingStack.title == "New Title From Event")
+        #expect(existingStack.syncState == .synced)
+    }
+
+    @Test("stackCreated: LWW skips update when existing stack is newer")
+    func createdLwwSkipsWhenLocalIsNewer() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        // Insert a stack with a future timestamp (local is newer)
+        let existingStack = Stack(
+            id: stackId, title: "Local Title",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: 500)
+        )
+        context.insert(existingStack)
+        try context.save()
+
+        // Stale event — should be ignored
+        let payload = try makeStackCreatedPayload(id: stackId, title: "Stale Title From Event")
+        let event = Event(
+            eventType: .stackCreated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date(timeIntervalSinceNow: -50)
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // Title should remain unchanged
+        #expect(existingStack.title == "Local Title")
+    }
+
+    // MARK: - stackUpdated Tests
+
+    @Test("stackUpdated: updates stack fields from event")
+    func updatedAppliesFieldChanges() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Original",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: -100)
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStackCreatedPayload(id: stackId, title: "Updated Title", status: "active", sortOrder: 7)
+        let event = Event(
+            eventType: .stackUpdated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.title == "Updated Title")
+        #expect(stack.sortOrder == 7)
+        #expect(stack.syncState == .synced)
+    }
+
+    @Test("stackUpdated: LWW skips stale update")
+    func updatedLwwSkipsStaleEvent() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Current Title",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: 300)  // local is newer
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStackCreatedPayload(id: stackId, title: "Stale Update", status: "active")
+        let event = Event(
+            eventType: .stackUpdated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date(timeIntervalSinceNow: -50)  // stale
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.title == "Current Title")
+    }
+
+    @Test("stackUpdated: no-ops when stack not found")
+    func updatedNoOpsForMissingStack() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let payload = try makeStackCreatedPayload(id: CUID.generate(), title: "Ghost Stack")
+        let event = Event(
+            eventType: .stackUpdated,
+            payload: payload,
+            entityId: CUID.generate(),
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        context.insert(event)
+
+        // Should not throw
+        try await ProjectorService.apply(event: event, context: context)
+
+        let allStacks = try context.fetch(FetchDescriptor<Stack>())
+        #expect(allStacks.isEmpty)
+    }
+
+    @Test("stackUpdated: ignores update to deleted stack")
+    func updatedSkipsDeletedStack() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = try await createThenDiscardStack(id: stackId, title: "Deleted Stack", context: context)
+        #expect(stack.isDeleted == true)
+
+        let originalTitle = stack.title
+        let payload = try makeStackCreatedPayload(id: stackId, title: "Should Be Ignored", status: "active")
+        let event = Event(
+            eventType: .stackUpdated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.title == originalTitle)
+    }
+
+    // MARK: - stackDeleted Tests
+
+    @Test("stackDeleted: marks stack as deleted and clears isActive")
+    func deletedMarksStackAndClearsIsActive() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Active Stack",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: -100),
+            isDeleted: false,
+            isActive: true
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeDeletedPayload(stackId: stackId)
+        let event = Event(
+            eventType: .stackDeleted,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.isDeleted == true)
+        #expect(stack.isActive == false)
+        #expect(stack.syncState == .synced)
+    }
+
+    @Test("stackDeleted: LWW skips deletion when local is newer")
+    func deletedLwwSkipsWhenLocalIsNewer() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Stack",
+            updatedAt: Date(timeIntervalSinceNow: 400),  // local is newer
+            isDeleted: false,
+            isActive: true
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeDeletedPayload(stackId: stackId)
+        let event = Event(
+            eventType: .stackDeleted,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date(timeIntervalSinceNow: -50)  // stale
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // Stack should remain intact
+        #expect(stack.isDeleted == false)
+        #expect(stack.isActive == true)
+    }
+
+    @Test("stackDeleted: no-ops when stack not found")
+    func deletedNoOpsForMissingStack() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let payload = try makeDeletedPayload(stackId: CUID.generate())
+        let event = Event(
+            eventType: .stackDeleted,
+            payload: payload,
+            entityId: CUID.generate(),
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        context.insert(event)
+
+        // Should not throw
+        try await ProjectorService.apply(event: event, context: context)
+
+        let allStacks = try context.fetch(FetchDescriptor<Stack>())
+        #expect(allStacks.isEmpty)
+    }
+
+    // MARK: - stackActivated Tests
+
+    @Test("stackActivated: sets isActive to true on the target stack")
+    func activatedSetsIsActive() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Inactive Stack",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: -100),
+            isActive: false
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackActivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.isActive == true)
+        #expect(stack.syncState == .synced)
+    }
+
+    @Test("stackActivated: deactivates all other active stacks (single-active constraint)")
+    func activatedDeactivatesOtherStacks() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let targetId = CUID.generate()
+        let otherId1 = CUID.generate()
+        let otherId2 = CUID.generate()
+
+        let target = Stack(id: targetId, title: "Target",   updatedAt: Date(timeIntervalSinceNow: -100), isActive: false)
+        let other1 = Stack(id: otherId1, title: "Other 1", updatedAt: Date(timeIntervalSinceNow: -200), isActive: true)
+        let other2 = Stack(id: otherId2, title: "Other 2", updatedAt: Date(timeIntervalSinceNow: -200), isActive: true)
+        context.insert(target)
+        context.insert(other1)
+        context.insert(other2)
+        try context.save()
+
+        let payload = try makeStatusPayload(stackId: targetId, status: "active")
+        let event = Event(
+            eventType: .stackActivated,
+            payload: payload,
+            entityId: targetId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // Target becomes active; others are deactivated
+        #expect(target.isActive == true)
+        #expect(other1.isActive == false)
+        #expect(other2.isActive == false)
+    }
+
+    @Test("stackActivated: LWW skips stale event")
+    func activatedLwwSkipsStale() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Stack",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: 300),  // local is newer
+            isActive: false
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackActivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date(timeIntervalSinceNow: -50)  // stale
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // isActive should remain false — stale event skipped
+        #expect(stack.isActive == false)
+    }
+
+    @Test("stackActivated: ignores activation of deleted stack")
+    func activatedSkipsDeletedStack() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = try await createThenDiscardStack(id: stackId, context: context)
+        #expect(stack.isDeleted == true)
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackActivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // Deleted stack should not become active
+        #expect(stack.isActive == false)
+    }
+
+    // MARK: - stackDeactivated Tests
+
+    @Test("stackDeactivated: clears isActive on the target stack")
+    func deactivatedClearsIsActive() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Active Stack",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: -100),
+            isActive: true
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackDeactivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date()
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        #expect(stack.isActive == false)
+        #expect(stack.syncState == .synced)
+    }
+
+    @Test("stackDeactivated: LWW skips stale event")
+    func deactivatedLwwSkipsStale() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        let stack = Stack(
+            id: stackId, title: "Stack",
+            status: .active,
+            updatedAt: Date(timeIntervalSinceNow: 300),  // local is newer
+            isActive: true
+        )
+        context.insert(stack)
+        try context.save()
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackDeactivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        event.timestamp = Date(timeIntervalSinceNow: -50)  // stale
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // isActive should remain true — stale event skipped
+        #expect(stack.isActive == true)
+    }
+
+    @Test("stackDeactivated: ignores deactivation of deleted stack")
+    func deactivatedSkipsDeletedStack() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let stackId = CUID.generate()
+        // Create and discard the stack using event sourcing (the proven pattern).
+        // After the discard, isDeleted = true and isActive = false.
+        let stack = try await createThenDiscardStack(id: stackId, context: context)
+        #expect(stack.isDeleted == true)
+
+        // Record updatedAt before the deactivation event — it must not change.
+        let updatedAtBeforeEvent = stack.updatedAt
+
+        let payload = try makeStatusPayload(stackId: stackId, status: "active")
+        let event = Event(
+            eventType: .stackDeactivated,
+            payload: payload,
+            entityId: stackId,
+            userId: "u", deviceId: "d", appId: "a"
+        )
+        // Event is newer than stack.updatedAt — LWW alone would not block it.
+        // Only the isDeleted guard blocks it.
+        event.timestamp = stack.updatedAt.addingTimeInterval(100)
+        context.insert(event)
+
+        try await ProjectorService.apply(event: event, context: context)
+
+        // Deleted guard fires before any writes — updatedAt must be unchanged
+        #expect(stack.updatedAt == updatedAtBeforeEvent)
+        #expect(stack.isDeleted == true)
     }
 }


### PR DESCRIPTION
## Summary

Fills the test coverage gap in `ProjectorServiceStackTests.swift`. The file previously covered only `stackCompleted`, `stackDiscarded`, `stackClosed`, and `stackReordered` (15 tests). This PR adds tests for the five remaining handlers that had zero coverage.

## New Tests (18)

### `stackCreated` (4 tests)
- Creates stack with correct fields from payload
- Uses payload `createdAt` timestamp when provided
- LWW updates existing stack when event is newer
- LWW skips update when existing stack is newer

### `stackUpdated` (4 tests)
- Updates stack fields from event
- LWW skips stale update
- No-ops when stack not found
- Ignores update to deleted stack

### `stackDeleted` (3 tests)
- Marks stack as deleted and clears `isActive`
- LWW skips deletion when local is newer
- No-ops when stack not found

### `stackActivated` (4 tests)
- Sets `isActive = true` on the target stack
- Deactivates all other active stacks (single-active constraint, DEQ-136)
- LWW skips stale event
- Ignores activation of deleted stack

### `stackDeactivated` (3 tests)
- Clears `isActive` on the target stack
- LWW skips stale event
- Ignores deactivation of deleted stack

## Results

- **33/33 tests pass** (15 existing + 18 new)
- **0 SwiftLint violations**
- All tests run in `@MainActor` in-memory SwiftData containers