### PR TITLE
fix(notifications): use correct type label for arc reminders

### DIFF
--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -316,7 +316,12 @@ final class NotificationService: NSObject {
 
     private func formatReminderBody(for reminder: Reminder, parentTitle: String?) -> String {
         let timeString = reminder.remindAt.formatted(date: .omitted, time: .shortened)
-        let typeLabel = reminder.parentType == .task ? "Task" : "Stack"
+        let typeLabel: String
+        switch reminder.parentType {
+        case .task: typeLabel = "Task"
+        case .stack: typeLabel = "Stack"
+        case .arc: typeLabel = "Arc"
+        }
 
         if let title = parentTitle {
             return "\(typeLabel): \(title) at \(timeString)"

--- a/Dequeue/DequeueTests/NotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/NotificationServiceTests.swift
@@ -139,6 +139,20 @@ private struct TestContext {
         createReminder(parentId: task.id, parentType: .task, status: status, remindAt: remindAt)
     }
 
+    func createArc(title: String = "Test Arc") -> Arc {
+        let arc = Arc(title: title)
+        context.insert(arc)
+        return arc
+    }
+
+    func createArcReminder(
+        arc: Arc,
+        status: ReminderStatus = .active,
+        remindAt: Date = Date().addingTimeInterval(3_600)
+    ) -> Reminder {
+        createReminder(parentId: arc.id, parentType: .arc, status: status, remindAt: remindAt)
+    }
+
     func save() throws {
         try context.save()
     }
@@ -428,6 +442,19 @@ struct NotificationServiceTests {
         try await ctx.service.scheduleNotification(for: reminder)
 
         #expect(ctx.mockCenter.addedRequests.first?.content.body.contains("Task:") == true)
+    }
+
+    @Test("notification body includes type label for arc")
+    @MainActor
+    func notificationBodyIncludesArcLabel() async throws {
+        let ctx = try TestContext()
+        let arc = ctx.createArc(title: "Test Arc")
+        let reminder = ctx.createArcReminder(arc: arc)
+        try ctx.save()
+
+        try await ctx.service.scheduleNotification(for: reminder)
+
+        #expect(ctx.mockCenter.addedRequests.first?.content.body.contains("Arc:") == true)
     }
 
     @Test("notification uses fallback title when parent not found")


### PR DESCRIPTION
## Problem
Arc reminders showed "Stack" as the type label in notification bodies instead of "Arc".

```
// Before: always "Stack" for non-task types
let typeLabel = reminder.parentType == .task ? "Task" : "Stack"

// After: explicit switch for all three cases
switch reminder.parentType {
case .task:  typeLabel = "Task"
case .stack: typeLabel = "Stack"
case .arc:   typeLabel = "Arc"
}
```

## Root Cause
`formatReminderBody` used a binary ternary that pre-dated the Arc model. When arcs gained reminder support, this was never updated.

## Fix
- Replace ternary with exhaustive `switch` over `ParentType`
- Add `createArc()` and `createArcReminder()` helpers to `NotificationServiceTests` TestContext
- Add `notificationBodyIncludesArcLabel()` test to catch this regression

## Testing
- All 30 `NotificationServiceTests` pass locally (including new test)
- SwiftLint clean on changed files