### PR TITLE
fix(webhooks): show all 21 supported event types grouped by entity

### DIFF
--- a/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
+++ b/Dequeue/Dequeue/Views/Settings/WebhooksView.swift
@@ -510,6 +510,32 @@ struct DeliveryDetailView: View {
 
 // MARK: - Create Webhook View
 
+/// Groups related webhook event types under a single entity label.
+private struct WebhookEventGroup {
+    let entity: String
+    let icon: String
+    let events: [String]
+}
+
+private let webhookEventGroups: [WebhookEventGroup] = [
+    WebhookEventGroup(entity: "Tasks", icon: "checkmark.square", events: [
+        "task.created", "task.updated", "task.completed",
+        "task.uncompleted", "task.deleted", "task.moved"
+    ]),
+    WebhookEventGroup(entity: "Stacks", icon: "square.stack", events: [
+        "stack.created", "stack.updated", "stack.completed", "stack.deleted"
+    ]),
+    WebhookEventGroup(entity: "Arcs", icon: "arrow.trianglepath", events: [
+        "arc.created", "arc.updated", "arc.completed", "arc.deleted"
+    ]),
+    WebhookEventGroup(entity: "Reminders", icon: "bell", events: [
+        "reminder.created", "reminder.updated", "reminder.completed", "reminder.deleted"
+    ]),
+    WebhookEventGroup(entity: "Tags", icon: "tag", events: [
+        "tag.created", "tag.updated", "tag.deleted"
+    ])
+]
+
 struct CreateWebhookView: View {
     @Environment(\.webhookService) private var webhookService
     @Environment(\.dismiss) private var dismiss
@@ -523,21 +549,13 @@ struct CreateWebhookView: View {
     @State private var createdSecret: String?
     @State private var showSecret = false
 
-    private let availableEvents = [
-        "task.created",
-        "task.updated",
-        "task.completed",
-        "task.deleted",
-        "stack.created",
-        "stack.updated",
-        "stack.deleted"
-    ]
+    private var allLeafEvents: [String] { webhookEventGroups.flatMap(\.events) }
 
     var body: some View {
         NavigationStack {
             Form {
                 endpointSection
-                eventsSection
+                eventsSections
                 secretSection
             }
             .navigationTitle("New Webhook")
@@ -575,11 +593,20 @@ struct CreateWebhookView: View {
         }
     }
 
-    private var eventsSection: some View {
-        Section("Events") {
-            ForEach(Array(availableEvents), id: \.self) { (event: String) in
-                eventRow(event)
+    @ViewBuilder
+    private var eventsSections: some View {
+        ForEach(webhookEventGroups, id: \.entity) { group in
+            Section {
+                ForEach(group.events, id: \.self) { event in
+                    eventRow(event)
+                }
+                groupToggleButton(group)
+            } header: {
+                Label(group.entity, systemImage: group.icon)
             }
+        }
+
+        Section {
             toggleAllButton
         }
     }
@@ -595,6 +622,7 @@ struct CreateWebhookView: View {
             HStack {
                 Text(event)
                     .foregroundStyle(.primary)
+                    .font(.system(.subheadline, design: .monospaced))
                 Spacer()
                 if selectedEvents.contains(event) {
                     Image(systemName: "checkmark")
@@ -604,15 +632,31 @@ struct CreateWebhookView: View {
         }
     }
 
-    private var toggleAllButton: some View {
-        Button(selectedEvents.count == availableEvents.count ? "Deselect All" : "Select All") {
-            if selectedEvents.count == availableEvents.count {
-                selectedEvents.removeAll()
+    private func groupToggleButton(_ group: WebhookEventGroup) -> some View {
+        let groupSet = Set(group.events)
+        let allSelected = groupSet.isSubset(of: selectedEvents)
+        return Button(allSelected ? "Deselect All \(group.entity)" : "Select All \(group.entity)") {
+            if allSelected {
+                selectedEvents.subtract(groupSet)
             } else {
-                selectedEvents = Set(availableEvents)
+                selectedEvents.formUnion(groupSet)
             }
         }
         .font(.caption)
+        .foregroundStyle(Color.accentColor)
+    }
+
+    private var toggleAllButton: some View {
+        let all = Set(allLeafEvents)
+        let allSelected = all.isSubset(of: selectedEvents)
+        return Button(allSelected ? "Deselect All Events" : "Select All Events") {
+            if allSelected {
+                selectedEvents.removeAll()
+            } else {
+                selectedEvents = all
+            }
+        }
+        .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem

The Create Webhook UI only listed 7 event types, missing 14 that the API already supports:

**Missing events:**
- `task.uncompleted`, `task.moved`
- `stack.completed`
- All arc events: `arc.created/updated/completed/deleted`
- All reminder events: `reminder.created/updated/completed/deleted`
- All tag events: `tag.created/updated/deleted`

Users who created webhooks from the iOS app couldn't subscribe to any arc, reminder, or tag events at all.

## Solution

- Introduced `WebhookEventGroup` struct to model grouped event sets
- Replaced the flat 7-item array with 5 grouped sections (Tasks, Stacks, Arcs, Reminders, Tags)
- Each section has an icon header and a per-entity 'Select All' toggle
- Added global 'Select All Events' button at the bottom
- Event labels rendered in monospaced font for readability
- All 21 events now match `isValidEventPattern()` in `dequeue-api`

## Testing

- `swiftlint`: 0 violations
- Build: `** BUILD SUCCEEDED **` (iOS Simulator, iPhone 17 Pro)