### PR TITLE
feat(search): add arc support to iOS unified search

### DIFF
--- a/Dequeue/Dequeue/Services/SearchService.swift
+++ b/Dequeue/Dequeue/Services/SearchService.swift
@@ -13,17 +13,20 @@ private let logger = Logger(subsystem: "com.dequeue", category: "SearchService")
 
 // MARK: - Search Models
 
-/// A single search result that can be either a task or a stack
+/// A single search result that can be a task, stack, or arc
 struct SearchResultItem: Identifiable, Codable, Sendable {
-    let type: String // "task" or "stack"
+    let type: String // "task", "stack", or "arc"
     let task: SearchTask?
     let stack: SearchStack?
+    let arc: SearchArc?
 
     var id: String {
         if let task {
             return "task-\(task.id)"
         } else if let stack {
             return "stack-\(stack.id)"
+        } else if let arc {
+            return "arc-\(arc.id)"
         }
         return UUID().uuidString
     }
@@ -87,6 +90,44 @@ struct SearchStack: Codable, Sendable, Identifiable {
         guard taskCount > 0 else { return 0 }
         return Double(completedTaskCount) / Double(taskCount)
     }
+}
+
+/// Arc data returned from search
+struct SearchArc: Codable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let description: String?
+    let status: String
+    let colorHex: String?
+    let sortOrder: Int
+    let stackCount: Int
+    let completedStackCount: Int
+    let startAt: Int64?
+    let dueAt: Int64?
+    let createdAt: Int64
+    let updatedAt: Int64
+    let completedAt: Int64?
+
+    var dueAtDate: Date? {
+        guard let dueAt else { return nil }
+        return Date(timeIntervalSince1970: Double(dueAt) / 1_000.0)
+    }
+
+    var createdAtDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1_000.0)
+    }
+
+    var updatedAtDate: Date {
+        Date(timeIntervalSince1970: Double(updatedAt) / 1_000.0)
+    }
+
+    /// Progress as a fraction (0.0 to 1.0)
+    var progress: Double {
+        guard stackCount > 0 else { return 0 }
+        return Double(completedStackCount) / Double(stackCount)
+    }
+
+    var isCompleted: Bool { status == "completed" }
 }
 
 /// The complete search response from the API

--- a/Dequeue/Dequeue/Views/Search/SearchView.swift
+++ b/Dequeue/Dequeue/Views/Search/SearchView.swift
@@ -35,7 +35,7 @@ struct SearchView: View {
                 }
             }
             .navigationTitle("Search")
-            .searchable(text: $searchText, prompt: "Search tasks and stacks...")
+            .searchable(text: $searchText, prompt: "Search tasks, stacks, and arcs...")
             .onChange(of: searchText) { _, newValue in
                 performDebouncedSearch(query: newValue)
             }
@@ -63,7 +63,7 @@ struct SearchView: View {
         ContentUnavailableView {
             Label("Search Dequeue", systemImage: "magnifyingglass")
         } description: {
-            Text("Find tasks and stacks by name, notes, or content.")
+            Text("Find tasks, stacks, and arcs by name, notes, or content.")
         }
     }
 
@@ -91,12 +91,13 @@ struct SearchView: View {
 
             let taskResults = results.filter { $0.type == "task" }
             let stackResults = results.filter { $0.type == "stack" }
+            let arcResults = results.filter { $0.type == "arc" }
 
-            if !taskResults.isEmpty {
-                Section("Tasks (\(taskResults.count))") {
-                    ForEach(taskResults) { result in
-                        if let task = result.task {
-                            TaskSearchRow(task: task)
+            if !arcResults.isEmpty {
+                Section("Arcs (\(arcResults.count))") {
+                    ForEach(arcResults) { result in
+                        if let arc = result.arc {
+                            ArcSearchRow(arc: arc)
                         }
                     }
                 }
@@ -107,6 +108,16 @@ struct SearchView: View {
                     ForEach(stackResults) { result in
                         if let stack = result.stack {
                             StackSearchRow(stack: stack)
+                        }
+                    }
+                }
+            }
+
+            if !taskResults.isEmpty {
+                Section("Tasks (\(taskResults.count))") {
+                    ForEach(taskResults) { result in
+                        if let task = result.task {
+                            TaskSearchRow(task: task)
                         }
                     }
                 }
@@ -303,6 +314,69 @@ struct StackSearchRow: View {
             }
         }
         .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Arc Search Row
+
+struct ArcSearchRow: View {
+    let arc: SearchArc
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                arcIcon
+                Text(arc.title)
+                    .font(.body)
+                    .strikethrough(arc.isCompleted)
+                    .foregroundStyle(arc.isCompleted ? .secondary : .primary)
+                Spacer()
+                if arc.isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                }
+            }
+
+            HStack {
+                Label(
+                    "\(arc.completedStackCount)/\(arc.stackCount) stacks",
+                    systemImage: "square.stack"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if arc.stackCount > 0 {
+                    ProgressView(value: arc.progress)
+                        .frame(maxWidth: 60)
+                }
+
+                Spacer()
+
+                if let dueDate = arc.dueAtDate {
+                    Label(dueDate.formatted(date: .abbreviated, time: .omitted), systemImage: "calendar")
+                        .font(.caption2)
+                        .foregroundStyle(dueDate < Date() && !arc.isCompleted ? .red : .secondary)
+                } else {
+                    Text(arc.updatedAtDate.formatted(date: .abbreviated, time: .omitted))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var arcIcon: some View {
+        if let colorHex = arc.colorHex, let color = Color(hex: colorHex) {
+            Circle()
+                .fill(color)
+                .frame(width: 10, height: 10)
+        } else {
+            Image(systemName: "archivebox")
+                .foregroundStyle(.purple)
+                .font(.caption)
+        }
     }
 }
 

--- a/Dequeue/DequeueTests/SearchServiceTests.swift
+++ b/Dequeue/DequeueTests/SearchServiceTests.swift
@@ -79,6 +79,49 @@ struct SearchServiceTests {
 
     // MARK: - Success Cases
 
+    @Test("Search returns tasks, stacks, and arcs")
+    func searchReturnsArcResults() async throws {
+        let json = """
+        {
+            "query": "project",
+            "results": [
+                {
+                    "type": "arc",
+                    "arc": {
+                        "id": "arc-1",
+                        "title": "Big Project Arc",
+                        "status": "active",
+                        "sortOrder": 0,
+                        "stackCount": 5,
+                        "completedStackCount": 2,
+                        "isDeleted": false,
+                        "createdAt": 1708000000000,
+                        "updatedAt": 1708000000000
+                    }
+                }
+            ],
+            "total": 1
+        }
+        """
+
+        SearchMockURLProtocolStorage.shared.requestHandler = { _ in
+            self.makeResponse(statusCode: 200, json: json)
+        }
+
+        let service = makeService()
+        let response = try await service.search(query: "project")
+
+        #expect(response.total == 1)
+        #expect(response.results.count == 1)
+        #expect(response.results[0].type == "arc")
+        #expect(response.results[0].arc?.title == "Big Project Arc")
+        #expect(response.results[0].arc?.stackCount == 5)
+        #expect(response.results[0].arc?.completedStackCount == 2)
+        #expect(response.results[0].arc?.progress == 0.4)
+        #expect(response.results[0].arc?.isCompleted == false)
+        #expect(response.results[0].id == "arc-arc-1")
+    }
+
     @Test("Search returns tasks and stacks")
     func searchReturnsResults() async throws {
         let json = """
@@ -282,5 +325,28 @@ struct SearchServiceTests {
             createdAt: 1_708_000_000_000, updatedAt: 1_708_000_000_000
         )
         #expect(emptyStack.progress == 0.0)
+    }
+
+    @Test("SearchArc progress and completion")
+    func searchArcModel() {
+        let arc = SearchArc(
+            id: "a1", title: "Test Arc", description: "desc", status: "active",
+            colorHex: "#FF5733", sortOrder: 0, stackCount: 4, completedStackCount: 2,
+            startAt: nil, dueAt: 1_708_000_000_000,
+            createdAt: 1_708_000_000_000, updatedAt: 1_708_000_000_000, completedAt: nil
+        )
+        #expect(arc.progress == 0.5)
+        #expect(arc.isCompleted == false)
+        #expect(arc.dueAtDate != nil)
+
+        let completedArc = SearchArc(
+            id: "a2", title: "Done Arc", description: nil, status: "completed",
+            colorHex: nil, sortOrder: 1, stackCount: 0, completedStackCount: 0,
+            startAt: nil, dueAt: nil,
+            createdAt: 1_708_000_000_000, updatedAt: 1_708_000_000_000, completedAt: 1_708_000_000_000
+        )
+        #expect(completedArc.progress == 0.0)
+        #expect(completedArc.isCompleted == true)
+        #expect(completedArc.dueAtDate == nil)
     }
 }


### PR DESCRIPTION
## Summary

The dequeue-api now returns arcs in unified search results (merged in [#197](https://github.com/DequeueApp/dequeue-api/pull/197)). This PR wires up the iOS client to decode and display arc results.

## Changes

### SearchService.swift
- Added `SearchArc` model matching the `ArcResponse` shape returned by the API
- Updated `SearchResultItem` to include an `arc: SearchArc?` field (type can now be "task", "stack", or "arc")

### SearchView.swift
- Added `ArcSearchRow` component with:
  - Color dot (from arc's colorHex) or fallback archivebox icon
  - Progress bar (completed stacks / total stacks)
  - Due date label (red if overdue) 
  - Completion checkmark
- Arc results shown in a dedicated "Arcs" section above stacks for logical hierarchy
- Updated search bar placeholder and empty state text to mention arcs

### SearchServiceTests.swift
- Added `searchReturnsArcResults` test — decodes arc from JSON response, validates all fields
- Added `searchArcModel` unit test — covers progress, isCompleted, dueAtDate conversions

## Test Results
- All new tests pass ✅
- Pre-existing network tests have a flakiness issue (global `SearchMockURLProtocolStorage.shared` singleton gets clobbered under parallel test execution) — this is a pre-existing issue unrelated to this PR