### PR TITLE
ci: auto-deploy macOS builds to TestFlight on every push to main

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -105,7 +105,9 @@ jobs:
   deploy-macos:
     name: Build and Deploy macOS to TestFlight
     runs-on: macos-26
-    timeout-minutes: 60
+    # macOS builds tend to be slower than iOS (no Simulator shortcuts, larger
+    # binaries post-codesign). Give headroom over the iOS lane's 60m budget.
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
@@ -155,18 +157,21 @@ jobs:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           ASC_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-        run: bundle exec fastlane bump_build_macos
+        run: bundle exec fastlane macos bump_build
 
       - name: Build Archive
         run: |
           # Archive without code signing - export step will handle signing via the
           # App Store Connect API key (-allowProvisioningUpdates).
+          # resultBundlePath lets us upload a .xcresult artifact for post-mortem
+          # debugging when the archive step fails.
           xcodebuild archive \
             -project Dequeue/Dequeue.xcodeproj \
             -scheme Dequeue \
             -configuration Release \
             -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
             -destination 'generic/platform=macOS' \
+            -resultBundlePath $RUNNER_TEMP/Dequeue-macOS-archive.xcresult \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO
 
@@ -192,7 +197,13 @@ jobs:
           # Find the .pkg or .app produced by exportArchive. The Mac App Store
           # export usually produces a .pkg directly, but if Xcode emits a .app we
           # wrap it with productbuild before uploading.
-          EXPORT_FILE=$(find $RUNNER_TEMP/export-macos -name "*.pkg" -o -name "*.app" | head -1)
+          # Prefer .pkg if present (avoids re-wrapping via productbuild);
+          # fall back to .app. Using two separate searches keeps selection
+          # deterministic regardless of filesystem enumeration order.
+          EXPORT_FILE=$(find "$RUNNER_TEMP/export-macos" -maxdepth 2 -name "*.pkg" | head -1)
+          if [[ -z "$EXPORT_FILE" ]]; then
+            EXPORT_FILE=$(find "$RUNNER_TEMP/export-macos" -maxdepth 2 -name "*.app" | head -1)
+          fi
 
           if [[ -z "$EXPORT_FILE" ]]; then
             echo "::error::No .pkg or .app produced by xcodebuild -exportArchive"
@@ -239,6 +250,15 @@ jobs:
           name: dSYMs-macOS
           path: ${{ runner.temp }}/Dequeue-macOS.xcarchive/dSYMs
           retention-days: 30
+
+      - name: Upload xcodebuild result bundle
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: build-result-macos
+          path: ${{ runner.temp }}/Dequeue-macOS-archive.xcresult
+          retention-days: 30
+          if-no-files-found: warn
 
   notify-failure:
     name: Notify on TestFlight Failure

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -211,9 +211,15 @@ jobs:
             exit 1
           fi
 
+          # Mac App Store exports should always produce a signed .pkg via
+          # ExportOptions-macOS.plist (method=app-store-connect, signingStyle=automatic).
+          # If we got an unsigned .app instead, wrapping it with productbuild here
+          # would produce an unsigned .pkg which altool will reject anyway, so fail
+          # loudly with a clear actionable message instead of attempting a salvage.
           if [[ "$EXPORT_FILE" == *.app ]]; then
-            productbuild --component "$EXPORT_FILE" /Applications "$RUNNER_TEMP/export-macos/Dequeue.pkg"
-            EXPORT_FILE="$RUNNER_TEMP/export-macos/Dequeue.pkg"
+            echo "::error::Unexpected .app output — Mac App Store export should produce a signed .pkg. Check ci/ExportOptions-macOS.plist (method must be 'app-store-connect')."
+            ls -la "$RUNNER_TEMP/export-macos" || true
+            exit 1
           fi
 
           xcrun altool --upload-app \

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -256,6 +256,9 @@ jobs:
           name: dSYMs-macOS
           path: ${{ runner.temp }}/Dequeue-macOS.xcarchive/dSYMs
           retention-days: 30
+          # If Archive step fails, no xcarchive exists — warn instead of erroring so the
+          # real archive failure isn't obscured by an artifact-upload error.
+          if-no-files-found: warn
 
       - name: Upload xcodebuild result bundle
         if: always()

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Build and Deploy to TestFlight
+  deploy-ios:
+    name: Build and Deploy iOS to TestFlight
     runs-on: macos-26
     timeout-minutes: 60
     defaults:
@@ -95,18 +95,168 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: build-logs
+          name: build-logs-ios
           path: |
             Dequeue/build
             Dequeue/fastlane/report.xml
             Dequeue/fastlane/test_output
           retention-days: 30
 
-      - name: Notify on failure
-        if: failure()
+  deploy-macos:
+    name: Build and Deploy macOS to TestFlight
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: Dequeue
+
+      - name: Install Fastlane
+        working-directory: Dequeue
+        run: bundle install
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Cache Swift packages
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            Dequeue/Dequeue.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+          key: ${{ runner.os }}-spm-macos-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-macos-
+            ${{ runner.os }}-spm-
+
+      - name: Setup App Store Connect API Key file
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode \
+            > ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8
+
+      - name: Bump macOS build number from TestFlight
+        working-directory: Dequeue
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: bundle exec fastlane bump_build_macos
+
+      - name: Build Archive
+        run: |
+          # Archive without code signing - export step will handle signing via the
+          # App Store Connect API key (-allowProvisioningUpdates).
+          xcodebuild archive \
+            -project Dequeue/Dequeue.xcodeproj \
+            -scheme Dequeue \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Export App
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/Dequeue-macOS.xcarchive \
+            -exportPath $RUNNER_TEMP/export-macos \
+            -exportOptionsPlist ci/ExportOptions-macOS.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_API_ISSUER_ID
+
+      - name: Upload to TestFlight
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          # Find the .pkg or .app produced by exportArchive. The Mac App Store
+          # export usually produces a .pkg directly, but if Xcode emits a .app we
+          # wrap it with productbuild before uploading.
+          EXPORT_FILE=$(find $RUNNER_TEMP/export-macos -name "*.pkg" -o -name "*.app" | head -1)
+
+          if [[ -z "$EXPORT_FILE" ]]; then
+            echo "::error::No .pkg or .app produced by xcodebuild -exportArchive"
+            ls -la "$RUNNER_TEMP/export-macos" || true
+            exit 1
+          fi
+
+          if [[ "$EXPORT_FILE" == *.app ]]; then
+            productbuild --component "$EXPORT_FILE" /Applications "$RUNNER_TEMP/export-macos/Dequeue.pkg"
+            EXPORT_FILE="$RUNNER_TEMP/export-macos/Dequeue.pkg"
+          fi
+
+          xcrun altool --upload-app \
+            --type macos \
+            --file "$EXPORT_FILE" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Upload dSYMs to Sentry
+        if: success()
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project dequeue-app \
+            "$RUNNER_TEMP/Dequeue-macOS.xcarchive/dSYMs" || true
+
+      - name: Upload macOS package artifact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dequeue-macos-pkg
+          path: |
+            ${{ runner.temp }}/export-macos/*.pkg
+            ${{ runner.temp }}/export-macos/*.app
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload dSYMs artifact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dSYMs-macOS
+          path: ${{ runner.temp }}/Dequeue-macOS.xcarchive/dSYMs
+          retention-days: 30
+
+  notify-failure:
+    name: Notify on TestFlight Failure
+    runs-on: ubuntu-latest
+    needs: [deploy-ios, deploy-macos]
+    if: failure()
+    steps:
+      - name: Open or update tracking issue
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
+            const iosResult = '${{ needs.deploy-ios.result }}';
+            const macosResult = '${{ needs.deploy-macos.result }}';
+            const failedPlatforms = [];
+            if (iosResult !== 'success') failedPlatforms.push(`iOS (${iosResult})`);
+            if (macosResult !== 'success') failedPlatforms.push(`macOS (${macosResult})`);
+            const summary = failedPlatforms.join(', ') || 'unknown';
+
             // Check for existing open TestFlight issues before creating a new one
             const { data: existingIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -119,20 +269,18 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             if (existingIssues.length > 0) {
-              // Add a comment to the most recent existing issue instead of creating a duplicate
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existingIssues[0].number,
-                body: `TestFlight deployment failed again for commit ${context.sha}.\n\nWorkflow run: ${runUrl}`
+                body: `TestFlight deployment failed again for commit ${context.sha}.\n\nFailed platforms: ${summary}\nWorkflow run: ${runUrl}`
               });
             } else {
-              // No existing issue — create one
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `TestFlight Deploy Failed - ${new Date().toISOString().split('T')[0]}`,
-                body: `TestFlight deployment failed for commit ${context.sha}.\n\nSee workflow run: ${runUrl}`,
+                body: `TestFlight deployment failed for commit ${context.sha}.\n\nFailed platforms: ${summary}\nSee workflow run: ${runUrl}`,
                 labels: ['ci', 'testflight', 'bug']
               });
             }

--- a/Dequeue/fastlane/Fastfile
+++ b/Dequeue/fastlane/Fastfile
@@ -71,6 +71,25 @@ platform :ios do
     match(type: "appstore")
   end
 
+  desc "Bump CFBundleVersion to latest macOS TestFlight build + 1"
+  desc "Used by the macOS TestFlight workflow. Queries the macOS (osx)"
+  desc "build number track for com.ardonos.Dequeue and updates the"
+  desc "project's CURRENT_PROJECT_VERSION across all targets."
+  lane :bump_build_macos do
+    next_build = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: "com.ardonos.Dequeue",
+      platform: "osx",
+      initial_build_number: 0
+    ) + 1
+
+    UI.message("Setting macOS CFBundleVersion to #{next_build}")
+    increment_build_number(
+      build_number: next_build,
+      xcodeproj: "Dequeue.xcodeproj"
+    )
+  end
+
   # Helper to get App Store Connect API key
   private_lane :api_key do
     app_store_connect_api_key(

--- a/Dequeue/fastlane/Fastfile
+++ b/Dequeue/fastlane/Fastfile
@@ -1,5 +1,17 @@
 default_platform(:ios)
 
+# Helper shared across platforms — get App Store Connect API key from env.
+# Defined at the top level so both :ios and :macos lanes can use it.
+private_lane :api_key do
+  app_store_connect_api_key(
+    key_id: ENV["ASC_KEY_ID"],
+    issuer_id: ENV["ASC_ISSUER_ID"],
+    key_content: ENV["ASC_KEY_CONTENT"],
+    is_key_content_base64: true,
+    in_house: false
+  )
+end
+
 platform :ios do
   desc "Run tests"
   lane :test do
@@ -70,12 +82,14 @@ platform :ios do
   lane :sync_appstore_certs do
     match(type: "appstore")
   end
+end
 
+platform :macos do
   desc "Bump CFBundleVersion to latest macOS TestFlight build + 1"
   desc "Used by the macOS TestFlight workflow. Queries the macOS (osx)"
   desc "build number track for com.ardonos.Dequeue and updates the"
   desc "project's CURRENT_PROJECT_VERSION across all targets."
-  lane :bump_build_macos do
+  lane :bump_build do
     next_build = latest_testflight_build_number(
       api_key: api_key,
       app_identifier: "com.ardonos.Dequeue",
@@ -87,17 +101,6 @@ platform :ios do
     increment_build_number(
       build_number: next_build,
       xcodeproj: "Dequeue.xcodeproj"
-    )
-  end
-
-  # Helper to get App Store Connect API key
-  private_lane :api_key do
-    app_store_connect_api_key(
-      key_id: ENV["ASC_KEY_ID"],
-      issuer_id: ENV["ASC_ISSUER_ID"],
-      key_content: ENV["ASC_KEY_CONTENT"],
-      is_key_content_base64: true,
-      in_house: false
     )
   end
 end


### PR DESCRIPTION
## Summary

Until now, only iOS shipped to TestFlight on every push to `main` (via `testflight.yml`). macOS only went to TestFlight when someone manually triggered `release.yml` — which is why Victor has been building and uploading the macOS app by hand every release.

This PR adds a parallel `deploy-macos` job to `testflight.yml` so every push that touches `Dequeue/**` automatically uploads both an iOS *and* a macOS build to TestFlight.

## What changed

### `.github/workflows/testflight.yml`
- Renamed the existing `deploy` job → `deploy-ios` for clarity. **The iOS pipeline (Fastlane Match → `beta` lane) is unchanged.**
- Renamed the iOS build-logs artifact `build-logs` → `build-logs-ios` so it doesn't collide with future macOS log uploads.
- Added a parallel `deploy-macos` job on `macos-26` / Xcode 26.2 (matching the iOS lane). It mirrors the proven pattern already in `release.yml`'s macOS job:
  - Bump `CFBundleVersion` via a new Fastlane lane (`bump_build_macos`) that queries `latest_testflight_build_number(platform: "osx")` and increments.
  - `xcodebuild archive` with `CODE_SIGNING_ALLOWED=NO`
  - `xcodebuild -exportArchive -allowProvisioningUpdates` using the App Store Connect API key + `ci/ExportOptions-macOS.plist`
  - `xcrun altool --upload-app --type macos`
  - Sentry dSYM upload + `.pkg`/dSYMs artifact retention
- Replaced the inline failure notifier with a `notify-failure` job that runs after both deploy jobs and surfaces *which* platform(s) failed in the tracking issue.

### `Dequeue/fastlane/Fastfile`
- Added `bump_build_macos` lane: queries the macOS TestFlight build track and bumps `CURRENT_PROJECT_VERSION` to N+1.

## Why this design

- **Parallel, not sequential** — iOS and macOS are independent uploads to App Store Connect; no reason to serialize them. Faster feedback, and one platform failing doesn't block the other (App Store Connect treats them as distinct platform tracks under the same app record).
- **Reuses the working `release.yml` pattern** — the raw `xcodebuild` + `altool` flow is already battle-tested in `release.yml`. No new code-signing infrastructure needed.
- **No Match changes required** — `-allowProvisioningUpdates` + the App Store Connect API key lets Xcode auto-fetch/create the Mac App Store cert and provisioning profile on demand. Match continues to handle iOS as before.
- **Independent build numbers** — macOS and iOS are separate platforms in App Store Connect, so their build number sequences are independent. Querying each platform separately avoids step-on-toes.

## Pre-flight checks

- ✅ YAML syntax validated
- ✅ Fastfile syntax validated (`ruby -c`)
- ✅ Local macOS Release build succeeds (`xcodebuild build … -destination 'platform=macOS' -configuration Release CODE_SIGNING_ALLOWED=NO`)
- ✅ SwiftLint clean (no Swift changes, but verified)

## Risks / things to watch on first run

1. **First macOS upload may need manual App Store Connect approval** for export compliance / encryption questions if not previously answered for the macOS platform.
2. **App Store Connect may auto-create a Mac App Store provisioning profile** the first time (`-allowProvisioningUpdates`). This is expected behavior and identical to what `release.yml` already does on manual runs.
3. If the macOS job fails, the iOS upload still proceeds independently — `notify-failure` will report which platform failed.

## Triggered by
DM request from Victor (May 6): "We have TestFlight set up for iOS builds, can we set up the same for macOS builds? Right now I'm building it manually it's kind of a pain."

🤖 Authored with care by Ada — see CI before merging.