### PR TITLE
feat(notifications): Time Sensitive interruption level + 64-pending cap fix (PR 1/6 reminder push)

### DIFF
--- a/Dequeue/Dequeue/Dequeue.entitlements
+++ b/Dequeue/Dequeue/Dequeue.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:expert-halibut-82.clerk.accounts.dev</string>

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -37,6 +37,12 @@ enum NotificationConstants: Sendable {
         nonisolated static let fifteenMinutes: TimeInterval = 15 * 60
         nonisolated static let oneHour: TimeInterval = 60 * 60
     }
+
+    /// Maximum number of pending `UNNotificationRequest` entries we'll register
+    /// at once. iOS enforces a hard limit of 64 across all trigger types per
+    /// app; we leave a few slots for system overhead and any future non-reminder
+    /// notifications the app may schedule.
+    nonisolated static let maxPendingNotifications: Int = 60
 }
 
 // MARK: - Notification Center Protocol
@@ -181,6 +187,14 @@ final class NotificationService: NSObject {
         let content = UNMutableNotificationContent()
         content.sound = .default
         content.categoryIdentifier = NotificationConstants.categoryIdentifier
+        // Time Sensitive ensures the notification breaks through Focus modes
+        // (Work, Personal, Sleep, custom) and scheduled notification summary.
+        // For reminder-app semantics this is required: if Victor has any Focus
+        // mode active, a default (.active) reminder gets routed to the summary
+        // and may not display until the next summary delivery (hours later).
+        // Requires the com.apple.developer.usernotifications.time-sensitive
+        // entitlement, which is set in Dequeue.entitlements.
+        content.interruptionLevel = .timeSensitive
 
         // Get parent title for notification content
         let parentTitle = try fetchParentTitle(for: reminder)
@@ -240,6 +254,13 @@ final class NotificationService: NSObject {
 
     /// Reschedules all notifications to match current reminder state
     /// Call this on app launch or when reminders are synced
+    ///
+    /// iOS imposes a hard limit of 64 pending UNNotificationRequest entries per
+    /// app across all trigger types (including one-shot `UNCalendarNotificationTrigger`).
+    /// If we exceed it, additional `add(_:)` calls silently fail. We sort by
+    /// soonest-first and cap at `maxPendingNotifications` to leave headroom for
+    /// system-managed notifications and any non-reminder notifications the app
+    /// may schedule in the future (smart digests, focus timer, etc.).
     func rescheduleAllNotifications() async {
         // Remove all existing notifications first
         notificationCenter.removeAllPendingNotificationRequests()
@@ -247,7 +268,21 @@ final class NotificationService: NSObject {
         // Fetch all active, upcoming reminders
         do {
             let reminders = try fetchActiveUpcomingReminders()
-            for reminder in reminders {
+                .sorted { $0.remindAt < $1.remindAt }
+            let capped = Array(reminders.prefix(NotificationConstants.maxPendingNotifications))
+            if reminders.count > capped.count {
+                // Log so we can detect users hitting the cap in Sentry.
+                ErrorReportingService.addBreadcrumb(
+                    category: "notifications",
+                    message: "Reminder count exceeds pending-notification cap; dropping farthest-future entries.",
+                    data: [
+                        "total": reminders.count,
+                        "scheduled": capped.count,
+                        "cap": NotificationConstants.maxPendingNotifications
+                    ]
+                )
+            }
+            for reminder in capped {
                 try? await scheduleNotification(for: reminder)
             }
         } catch {

--- a/Dequeue/Dequeue/Services/SmartNotificationService.swift
+++ b/Dequeue/Dequeue/Services/SmartNotificationService.swift
@@ -205,6 +205,8 @@ final class SmartNotificationService {
         content.body = formatDueDateBody(task: task, dueTime: dueTime)
         content.sound = .default
         content.categoryIdentifier = SmartNotificationCategory.dueDateCategory
+        // Due-date alerts are time-critical: break through Focus / Summary.
+        content.interruptionLevel = .timeSensitive
         content.userInfo = [
             "type": "smart-due-date",
             "taskId": task.id
@@ -371,6 +373,8 @@ final class SmartNotificationService {
             content.body = "\"\(task.title)\" was due \(formatRelativeTime(task.dueTime ?? Date()))"
             content.sound = .default
             content.categoryIdentifier = SmartNotificationCategory.overdueCategory
+            // Overdue is by definition time-sensitive; bypass Focus / Summary.
+            content.interruptionLevel = .timeSensitive
             content.userInfo = [
                 "type": "smart-overdue",
                 "taskId": task.id

--- a/Dequeue/DequeueTests/NotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/NotificationServiceTests.swift
@@ -402,7 +402,52 @@ struct NotificationServiceTests {
         #expect(ctx.mockCenter.addedRequests.isEmpty)
     }
 
+    @Test("rescheduleAllNotifications sorts by soonest-first and caps at maxPendingNotifications")
+    @MainActor
+    func rescheduleAllSortsAndCaps() async throws {
+        let ctx = try TestContext()
+        let stack = ctx.createStack()
+
+        // Create more reminders than the cap, in reverse chronological order so
+        // we can verify the implementation sorts correctly (not just truncates
+        // in insertion order).
+        let cap = NotificationConstants.maxPendingNotifications
+        let total = cap + 5
+        var expectedSoonestIds: [String] = []
+        for i in 0..<total {
+            // i=0 -> farthest in future, i=total-1 -> soonest
+            let secondsAhead = TimeInterval((total - i) * 60)
+            let reminder = ctx.createStackReminder(
+                stack: stack,
+                remindAt: Date().addingTimeInterval(secondsAhead)
+            )
+            if (total - i) <= cap {
+                expectedSoonestIds.append(reminder.id)
+            }
+        }
+        try ctx.save()
+
+        await ctx.service.rescheduleAllNotifications()
+
+        #expect(ctx.mockCenter.addedRequests.count == cap)
+        let scheduledIds = Set(ctx.mockCenter.addedRequests.map(\.identifier))
+        #expect(scheduledIds == Set(expectedSoonestIds))
+    }
+
     // MARK: - Notification Content Tests
+
+    @Test("notification uses time-sensitive interruption level so Focus modes don't swallow it")
+    @MainActor
+    func notificationIsTimeSensitive() async throws {
+        let ctx = try TestContext()
+        let stack = ctx.createStack()
+        let reminder = ctx.createStackReminder(stack: stack)
+        try ctx.save()
+
+        try await ctx.service.scheduleNotification(for: reminder)
+
+        #expect(ctx.mockCenter.addedRequests.first?.content.interruptionLevel == .timeSensitive)
+    }
 
     @Test("notification content has sound enabled")
     @MainActor


### PR DESCRIPTION
## Summary

First PR in a six-part reminder-delivery overhaul.

The core symptom: agents create stacks with reminders via the API; the reminder never fires on the user's iPhone when `remindAt` hits. Multi-layer root cause; expert panel review at `memory/reminder-delivery-design.md`. This PR ships the highest-leverage, lowest-risk slice — two changes that may resolve the immediate symptom even before the push pipeline lands.

## Changes

### 1. `.timeSensitive` interruption level

Reminders, due-date alerts, and overdue alerts now use `UNNotificationInterruptionLevel.timeSensitive`. With the default `.active` level, notifications fired during any Focus mode (Work / Personal / Sleep / custom) are diverted into the *scheduled notification summary* — which means they don't surface immediately, can be delayed by hours, and look identical to "the notification never fired."

Time-sensitive notifications break through Focus and Summary. For a productivity app where reminders are by definition time-critical, this is required, not optional.

Digest notifications (morning/end-of-day summaries) intentionally remain `.active` — those are by nature not time-sensitive.

### 2. 64-pending notification cap fix

`UNUserNotificationCenter` enforces a hard limit of 64 pending `UNNotificationRequest` entries across all trigger types per app. Beyond 64, `add(_:)` silently fails. The existing `rescheduleAllNotifications` registered every active future reminder without sorting or capping — so users with >64 reminders would see the farthest-future ones registered and may not get the imminent ones.

Now sorted by soonest-first and capped at 60 (leaving headroom for system overhead). A Sentry breadcrumb fires when we drop entries so we can see who's hitting the cap.

### 3. Entitlement

Adds `com.apple.developer.usernotifications.time-sensitive` to `Dequeue.entitlements`.

## ⚠️ Capability provisioning needed

The Time-Sensitive Notifications capability must be enabled on the Apple Developer portal for the `com.ardonos.Dequeue` App ID before this can be signed for TestFlight. It's a separate checkbox in the capabilities list. Xcode automatic signing should regenerate the profile once it's flipped on.

If a TestFlight build fails entitlement validation after this lands, that's why.

## Test plan

- ✅ Existing 51 `NotificationServiceTests` still pass.
- ✅ New test: `notificationIsTimeSensitive` — asserts every scheduled reminder carries `.timeSensitive`.
- ✅ New test: `rescheduleAllSortsAndCaps` — creates 65 reminders in reverse-chronological order, verifies only the 60 soonest get registered.
- Manual on device (post-merge): set a Focus mode, create a reminder for 2 minutes from now, force-quit the app, verify the banner breaks through Focus.

## Subsequent PRs in this series

| PR | Repo | Scope |
|----|------|-------|
| 2 | dequeue-api | Device-token endpoint + APNs sender via `apns2` (no scheduling yet) |
| 3 | dequeue-api | `pending_pushes` scheduler worker + `sync.Processor` hook + reconciliation cron |
| 4 | dequeue-ios | Silent-push handler + local/remote dedup via `UNUserNotificationCenterDelegate` + REST-only BG sync |
| 5 | dequeue-ios | Auth: Clerk 422 retry-before-signout in foreground, never sign-out in background context |
| 6 | dequeue-ios | macOS push parity |

See `~/clawd-dequeue/memory/reminder-delivery-design.md` (v2) for the full design and panel review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)