### PR TITLE
fix(undo-completion): supersede-and-commit instead of silent drop

### DIFF
--- a/Dequeue/Dequeue/Services/UndoCompletionManager.swift
+++ b/Dequeue/Dequeue/Services/UndoCompletionManager.swift
@@ -16,6 +16,14 @@ private let logger = Logger(subsystem: "com.dequeue", category: "UndoCompletionM
 /// When a stack with no pending tasks is completed, instead of immediately marking it
 /// as completed, this manager holds the stack and starts a countdown timer. The user
 /// can undo the completion within the grace period, or let it proceed automatically.
+///
+/// ### Supersede semantics
+/// If a *different* stack is tapped to complete while a previous stack is still in
+/// its grace period, the previous stack is **immediately committed** (not dropped)
+/// and the new stack takes over the banner with a fresh timer. This matches the
+/// "rapid-fire complete" user flow where a user completes several stacks in a row
+/// faster than the grace period elapses — without this behavior, every stack except
+/// the last would silently revert and never sync.
 @MainActor
 @Observable
 final class UndoCompletionManager {
@@ -56,9 +64,19 @@ final class UndoCompletionManager {
 
     /// Start a delayed completion for the given stack.
     /// The stack will be marked as completed after the grace period unless undone.
+    ///
+    /// If a *different* stack is already pending, that prior stack is committed
+    /// immediately (not silently dropped) before the new timer starts.
     func startDelayedCompletion(for stack: Stack) {
-        // Cancel any existing pending completion
-        cancelPendingCompletion()
+        // Supersede: if a different stack is pending, commit it now.
+        // (If the same stack is re-tapped, just reset the timer.)
+        if let existing = pendingStack, existing.id != stack.id {
+            logger.info("Superseding pending completion: committing '\(existing.title)' immediately")
+            commitCompletion(of: existing)
+        }
+
+        // Tear down any existing timers and visible state before starting fresh.
+        cancelTimers()
 
         logger.info("Starting delayed completion for stack: \(stack.title)")
 
@@ -73,11 +91,11 @@ final class UndoCompletionManager {
             do {
                 try await Task.sleep(for: .seconds(Self.gracePeriodDuration))
 
-                // If we weren't cancelled, complete the stack
+                // If we weren't cancelled (and the same stack is still pending), commit it.
                 guard let self, !Task.isCancelled, self.pendingStack?.id == stack.id else {
                     return
                 }
-                self.completeStack()
+                self.commitPendingCompletion()
             } catch {
                 // Task was cancelled - that's expected if user tapped undo
                 logger.debug("Completion timer cancelled")
@@ -85,24 +103,28 @@ final class UndoCompletionManager {
         }
     }
 
-    /// Undo the pending completion and restore the stack to active state
+    /// Undo the pending completion and restore the stack to active state.
+    /// This drops the pending stack *without* committing it (intentional — the user
+    /// is explicitly cancelling).
     func undoCompletion() {
         guard let stack = pendingStack else { return }
 
         logger.info("Undoing completion for stack: \(stack.title)")
 
-        cancelPendingCompletion()
+        cancelTimers()
+        pendingStack = nil
+        progress = 0.0
     }
 
     // MARK: - Private Methods
 
-    private func cancelPendingCompletion() {
+    /// Cancel any in-flight timers (progress + completion sleep) without touching
+    /// `pendingStack`/`progress` state. Callers decide whether to clear that state.
+    private func cancelTimers() {
         completionTask?.cancel()
         completionTask = nil
         progressTask?.cancel()
         progressTask = nil
-        pendingStack = nil
-        progress = 0.0
     }
 
     private func startProgressAnimation() {
@@ -126,14 +148,28 @@ final class UndoCompletionManager {
         }
     }
 
-    private func completeStack() {
-        guard let stack = pendingStack,
-              let modelContext = modelContext else {
-            logger.error("Cannot complete stack: missing stack or context")
+    /// Called when the grace-period timer elapses for the currently pending stack.
+    /// Clears banner state and triggers the persistence commit.
+    private func commitPendingCompletion() {
+        guard let stack = pendingStack else { return }
+
+        pendingStack = nil
+        progress = 0.0
+        completionTask = nil
+        progressTask = nil
+
+        commitCompletion(of: stack)
+    }
+
+    /// Persist the completion for the given stack and trigger sync.
+    /// Used by both the natural grace-period commit path and the supersede path.
+    private func commitCompletion(of stack: Stack) {
+        guard let modelContext = modelContext else {
+            logger.error("Cannot complete stack: missing model context")
             return
         }
 
-        logger.info("Completing stack after grace period: \(stack.title)")
+        logger.info("Committing completion for stack: \(stack.title)")
 
         let stackService = StackService(
             modelContext: modelContext,
@@ -141,22 +177,18 @@ final class UndoCompletionManager {
             deviceId: deviceId,
             syncManager: syncManager
         )
+        let sync = syncManager
 
-        Task { [weak self] in
+        Task {
             do {
                 try await stackService.markAsCompleted(stack, completeAllTasks: true)
-                self?.syncManager?.triggerImmediatePush()
+                sync?.triggerImmediatePush()
             } catch {
                 logger.error("Failed to complete stack: \(error.localizedDescription)")
-                ErrorReportingService.capture(error: error, context: ["action": "delayedStackComplete"])
-            }
-
-            // Clear the pending state AFTER the async operation completes
-            await MainActor.run {
-                self?.pendingStack = nil
-                self?.progress = 0.0
-                self?.completionTask = nil
-                self?.progressTask = nil
+                ErrorReportingService.capture(
+                    error: error,
+                    context: ["action": "delayedStackComplete"]
+                )
             }
         }
     }

--- a/Dequeue/DequeueTests/UndoCompletionManagerTests.swift
+++ b/Dequeue/DequeueTests/UndoCompletionManagerTests.swift
@@ -73,8 +73,8 @@ struct UndoCompletionManagerTests {
         #expect(manager.progress == 0.0)
     }
 
-    @Test("Starting new completion cancels previous one")
-    func startingNewCompletionCancelsPrevious() throws {
+    @Test("Starting new completion supersedes and commits previous one")
+    func startingNewCompletionSupersedesPrevious() async throws {
         let container = try makeTestContainer()
         let context = container.mainContext
         let manager = UndoCompletionManager()
@@ -89,9 +89,80 @@ struct UndoCompletionManagerTests {
         manager.startDelayedCompletion(for: stack1)
         #expect(manager.pendingStack?.id == stack1.id)
 
+        // Tapping a second stack while the first is still pending must commit
+        // the first (not silently drop it) and make the second the new pending.
         manager.startDelayedCompletion(for: stack2)
         #expect(manager.pendingStack?.id == stack2.id)
         #expect(manager.hasPendingCompletion == true)
+
+        // First stack commit is dispatched on a Task; wait for it to land.
+        try await waitUntil(timeout: 2.0) { stack1.status == .completed }
+        #expect(stack1.status == .completed)
+        #expect(stack2.status == .active) // still in grace period
+
+        // Clean up the still-pending second stack.
+        manager.undoCompletion()
+    }
+
+    @Test("Regression: rapidly completing 5 stacks commits all of them")
+    func rapidCompletionsCommitAllStacks() async throws {
+        // This is the exact bug Victor reported: tap Complete on several stacks
+        // in quick succession (faster than the 5s grace period). Before the
+        // supersede fix, only the LAST stack actually committed and the others
+        // silently reverted. All 5 must end up completed.
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let manager = UndoCompletionManager()
+        manager.configure(modelContext: context, syncManager: nil, userId: "test-user", deviceId: "test-device")
+
+        var stacks: [Stack] = []
+        for index in 0..<5 {
+            let stack = Stack(title: "Stack \(index)", status: .active, sortOrder: index)
+            context.insert(stack)
+            stacks.append(stack)
+        }
+        try context.save()
+
+        // Rapid-fire complete each stack, faster than the grace period.
+        for stack in stacks {
+            manager.startDelayedCompletion(for: stack)
+        }
+
+        // The last stack is still pending; the first 4 must already be committed.
+        try await waitUntil(timeout: 2.0) {
+            stacks.dropLast().allSatisfy { $0.status == .completed }
+        }
+        for stack in stacks.dropLast() {
+            #expect(stack.status == .completed, "\(stack.title) should be completed (was \(stack.status))")
+        }
+        #expect(stacks.last?.status == .active) // still in grace period
+
+        // Let the grace period elapse so the last one commits too.
+        try await Task.sleep(for: .seconds(UndoCompletionManager.gracePeriodDuration + 0.5))
+        #expect(stacks.last?.status == .completed)
+        #expect(manager.hasPendingCompletion == false)
+    }
+
+    @Test("Re-tapping the same pending stack resets its timer without double-commit")
+    func reTappingSameStackResetsTimer() async throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let manager = UndoCompletionManager()
+        manager.configure(modelContext: context, syncManager: nil, userId: "test-user", deviceId: "test-device")
+
+        let stack = Stack(title: "Test Stack", status: .active, sortOrder: 0)
+        context.insert(stack)
+        try context.save()
+
+        manager.startDelayedCompletion(for: stack)
+        try await Task.sleep(for: .seconds(0.5))
+        manager.startDelayedCompletion(for: stack) // same stack again
+
+        #expect(manager.pendingStack?.id == stack.id)
+        #expect(stack.status == .active) // must not have been committed early
+
+        manager.undoCompletion()
+        #expect(stack.status == .active)
     }
 
     // MARK: - Undo Completion Tests
@@ -317,6 +388,23 @@ struct UndoCompletionManagerTests {
     @Test("Grace period duration is 5 seconds")
     func gracePeriodDurationIsFiveSeconds() {
         #expect(UndoCompletionManager.gracePeriodDuration == 5.0)
+    }
+}
+
+// MARK: - Helpers
+
+/// Polls `condition` every 50ms up to `timeout`, returning when it first becomes
+/// true. Used to wait for async commits dispatched by `UndoCompletionManager`
+/// without baking the grace-period duration into every test.
+@MainActor
+private func waitUntil(
+    timeout: TimeInterval,
+    _ condition: @MainActor () -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() { return }
+        try await Task.sleep(for: .milliseconds(50))
     }
 }
 


### PR DESCRIPTION
Fixes DEQ-277

## Problem

Tapping **Complete** on a stack starts a 5-second "undo" grace period, after which `UndoCompletionManager` actually marks the stack completed and syncs it. If the user taps Complete on a *second* stack before the first stack's timer elapses (a common rapid-fire flow when clearing several stacks at once), the first stack is **silently dropped** and never marked complete.

`startDelayedCompletion(for:)` opens with:

```swift
cancelPendingCompletion()   // ← drops the prior stack WITHOUT committing it
```

`cancelPendingCompletion()` just cancels timers and clears `pendingStack`. The first stack is never written to SwiftData, never synced — it silently reverts to active.

Victor's repro: complete five stacks in a row, come back, find four of them still sitting in the list as if nothing happened.

## Fix

- When `startDelayedCompletion(for:)` is called with a *different* stack than the currently pending one, **commit the prior stack immediately**, then start the new timer.
- Re-tapping the same pending stack still just resets its own timer (no double-commit).
- The explicit `undoCompletion()` path keeps its existing semantic: cancel without committing (that's the user explicitly saying "no, don't do that").

## Tests

- **`rapidCompletionsCommitAllStacks`** — the actual regression test. Starts five completions in immediate succession and verifies the first four are committed and the fifth remains in its grace period.
- **`startingNewCompletionSupersedesPrevious`** — replaces the old `startingNewCompletionCancelsPrevious`, whose name described the bug as if it were correct behavior.
- **`reTappingSameStackResetsTimer`** — locks down the same-stack re-tap path.
- New `waitUntil` polling helper so tests don't have to bake the full grace-period duration in just to observe an async commit.

Lint + iOS build + the affected test suites all pass locally.

---

Linear: [DEQ-277](https://linear.app/dequeue/issue/DEQ-277/rapid-fire-stack-completions-silently-dropped-during-undo-grace-period)