### PR TITLE
feat(push): iOS silent-push handler + APNs dedup + token registration (PR 4/6)

### DIFF
--- a/Dequeue/Dequeue.xcodeproj/project.pbxproj
+++ b/Dequeue/Dequeue.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				APS_ENVIRONMENT = development;
 				CODE_SIGN_ENTITLEMENTS = Dequeue/Dequeue.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 351;
@@ -469,6 +470,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				APS_ENVIRONMENT = production;
 				CODE_SIGN_ENTITLEMENTS = Dequeue/Dequeue.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 351;

--- a/Dequeue/Dequeue.xcodeproj/project.pbxproj
+++ b/Dequeue/Dequeue.xcodeproj/project.pbxproj
@@ -426,6 +426,8 @@
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Dequeue uses your calendar to show events alongside your tasks.";
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphoneos*]" = "remote-notification";
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphonesimulator*]" = "remote-notification";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -479,6 +481,8 @@
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Dequeue uses your calendar to show events alongside your tasks.";
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphoneos*]" = "remote-notification";
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphonesimulator*]" = "remote-notification";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Dequeue/Dequeue/Dequeue.entitlements
+++ b/Dequeue/Dequeue/Dequeue.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>$(APS_ENVIRONMENT)</string>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
 	<key>com.apple.developer.associated-domains</key>

--- a/Dequeue/Dequeue/Dequeue.entitlements
+++ b/Dequeue/Dequeue/Dequeue.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
 	<key>com.apple.developer.associated-domains</key>

--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -165,6 +165,16 @@ struct DequeueApp: App {
         notificationService = NotificationService(modelContext: sharedModelContainer.mainContext)
         UNUserNotificationCenter.current().delegate = notificationService
         notificationService.configureNotificationCategories()
+
+        // Wire AppContext so AppDelegate / NotificationService can reach the
+        // live services from non-MainActor callbacks (DEQ-283). The auth
+        // service is captured as the protocol type so the mock substitution
+        // for tests propagates here too.
+        AppContext.shared.configure(
+            syncManager: syncManager,
+            authService: authService,
+            pushService: PushNotificationService.shared
+        )
     }
 
     // MARK: - Store Migration
@@ -475,6 +485,13 @@ struct RootView: View {
                         await handleAppBecameActive()
                         await notificationService.updateAppBadge()
 
+                        // Push-token freshness check on foreground (DEQ-283).
+                        // No-op if last_registered_at is within the 7-day
+                        // window; otherwise re-POSTs to refresh server-side
+                        // last_seen_at. Catches OS token rotation, restore-
+                        // from-backup, and reinstall edge cases.
+                        await AppContext.shared.pushService?.refreshTokenIfStale()
+
                         // Update home screen quick action shortcuts with current context
                         #if os(iOS)
                         let activeStackName = QuickActionService.fetchActiveStackName(modelContext: modelContext)
@@ -581,6 +598,12 @@ struct RootView: View {
 
             // Connect to sync with retry
             await connectSyncWithRetry(userId: userId, maxRetries: 3)
+
+            // Register for APNs now that the user is signed in (DEQ-283).
+            // Registering pre-auth is pointless — the backend can't attach
+            // the token to a user — so we always gate registration on this
+            // path. Idempotent thanks to PushNotificationService.
+            await AppContext.shared.pushService?.registerIfSignedIn()
         } else {
             os_log("[Auth] handleAuthStateChange: Not authenticated, disconnecting sync")
             await syncManager.disconnect()

--- a/Dequeue/Dequeue/Services/AppContext.swift
+++ b/Dequeue/Dequeue/Services/AppContext.swift
@@ -1,0 +1,51 @@
+//
+//  AppContext.swift
+//  Dequeue
+//
+//  Minimal global registry that bridges UIKit / AppDelegate / UNUserNotification
+//  delegate callbacks to the live SwiftUI-owned services. Set during
+//  `DequeueApp.init()` after services are constructed.
+//
+//  Kept deliberately small: no business logic, no observable state, no
+//  initialisation order surprises. Callers always treat the properties as
+//  optional and bail safely when they're nil (e.g. very early launch race or
+//  test environment that hasn't wired AppContext).
+//
+
+import Foundation
+
+/// Minimal global registry so background callbacks (AppDelegate, push
+/// handlers, UNUserNotification delegate) can reach the live `SyncManager`,
+/// `AuthService`, and `PushNotificationService` without threading them through
+/// every UIKit shim.
+///
+/// Set during `DequeueApp.init()` after services are constructed.
+@MainActor
+final class AppContext {
+    static let shared = AppContext()
+
+    private(set) var syncManager: SyncManager?
+    private(set) var authService: (any AuthServiceProtocol)?
+    private(set) var pushService: (any PushNotificationServiceProtocol)?
+
+    private init() {}
+
+    func configure(
+        syncManager: SyncManager,
+        authService: any AuthServiceProtocol,
+        pushService: any PushNotificationServiceProtocol
+    ) {
+        self.syncManager = syncManager
+        self.authService = authService
+        self.pushService = pushService
+    }
+
+    /// Test-only reset hook.
+    #if DEBUG
+    func resetForTesting() {
+        syncManager = nil
+        authService = nil
+        pushService = nil
+    }
+    #endif
+}

--- a/Dequeue/Dequeue/Services/AppContext.swift
+++ b/Dequeue/Dequeue/Services/AppContext.swift
@@ -13,6 +13,7 @@
 //
 
 import Foundation
+import os.log
 
 /// Minimal global registry so background callbacks (AppDelegate, push
 /// handlers, UNUserNotification delegate) can reach the live `SyncManager`,
@@ -24,17 +25,30 @@ import Foundation
 final class AppContext {
     static let shared = AppContext()
 
+    private static let logger = Logger(subsystem: "com.dequeue", category: "AppContext")
+
     private(set) var syncManager: SyncManager?
     private(set) var authService: (any AuthServiceProtocol)?
     private(set) var pushService: (any PushNotificationServiceProtocol)?
 
     private init() {}
 
+    /// Configure the registry exactly once during `DequeueApp.init()`. A
+    /// second call (e.g. a misconfigured test path that re-instantiates the
+    /// app without calling `resetForTesting()` first) logs a warning so the
+    /// silent-overwrite bug class is visible in os.log instead of producing
+    /// confusing service-locator stale-reference symptoms downstream.
     func configure(
         syncManager: SyncManager,
         authService: any AuthServiceProtocol,
         pushService: any PushNotificationServiceProtocol
     ) {
+        if self.syncManager != nil {
+            Self.logger.warning("""
+                AppContext.configure called twice; overwriting prior services. \
+                This is usually a test-environment misconfiguration.
+                """)
+        }
         self.syncManager = syncManager
         self.authService = authService
         self.pushService = pushService

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -34,20 +34,23 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         return config
     }
 
-    /// App-level cold-launch hook. We register for remote notifications only
-    /// when the user is already signed in — registering at launch when not
-    /// signed in is a UX antipattern (prompts the user for push perms before
-    /// they've even seen the app) and the device token would be useless to the
-    /// backend without a Clerk user to attach it to. The sign-in completion
-    /// path handles first-time registration via `PushNotificationService`.
+    /// App-level cold-launch hook. Best-effort attempt to register for
+    /// remote notifications when the user is already signed in.
+    ///
+    /// `@UIApplicationDelegateAdaptor` does NOT guarantee that the SwiftUI
+    /// `App.init()` (which wires `AppContext`) completes before this delegate
+    /// callback fires. In practice the guard often hits a nil `pushService`
+    /// and silently no-ops on cold launch. That's intentional and harmless:
+    /// both the sign-in completion path (`handleAuthStateChange`) and the
+    /// foreground-active path (`refreshTokenIfStale`) call
+    /// `registerIfSignedIn` again, covering the registration regardless of
+    /// init ordering. We keep the call here as belt-and-suspenders for warm
+    /// launches where `AppContext` is already wired.
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         Task { @MainActor in
-            // AppContext is wired during DequeueApp.init() which runs before
-            // this delegate method. The guard is defensive: if a future change
-            // moves wiring later, we'd rather skip than crash.
             guard let push = AppContext.shared.pushService else { return }
             await push.registerIfSignedIn()
         }

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -95,12 +95,22 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
+        // `userInfo` is `[AnyHashable: Any]` which is not Sendable. Extract
+        // the Sendable values we need (reminder_id, sent_at) before the
+        // `Task { @MainActor }` boundary so we satisfy Swift 6 strict
+        // concurrency cleanly without leaking Any across actors.
+        let reminderId = (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
+            ?? (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
+        let sentAtMs = userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? Double
+            ?? userInfo[NotificationConstants.UserInfoKey.localSentAtMs] as? Double
+        let payload = SilentPushPayload(reminderId: reminderId, sentAtMs: sentAtMs)
+
         Task { @MainActor in
             guard let push = AppContext.shared.pushService else {
                 completionHandler(.noData)
                 return
             }
-            let result = await push.handleSilentPush(userInfo: userInfo)
+            let result = await push.handleSilentPush(payload: payload)
             switch result {
             case .newData: completionHandler(.newData)
             case .noData: completionHandler(.noData)

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -108,14 +108,7 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         // value is Unix milliseconds; coerce via `NSNumber.int64Value` so we
         // never lose precision regardless of whether iOS hands us an Int,
         // Double, or NSNumber under the hood.
-        let sentAtMs: Int64? = {
-            let key = NotificationConstants.UserInfoKey.remoteSentAtMs
-            let legacyKey = NotificationConstants.UserInfoKey.localSentAtMs
-            if let nsNumber = (userInfo[key] as? NSNumber) ?? (userInfo[legacyKey] as? NSNumber) {
-                return nsNumber.int64Value
-            }
-            return nil
-        }()
+        let sentAtMs: Int64? = (userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? NSNumber)?.int64Value
         let payload = SilentPushPayload(reminderId: reminderId, sentAtMs: sentAtMs)
 
         Task { @MainActor in

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -2,8 +2,9 @@
 //  AppDelegate.swift
 //  Dequeue
 //
-//  UIKit App Delegate for handling system callbacks that require UIApplicationDelegate,
-//  such as home screen Quick Actions (3D Touch / Haptic Touch shortcuts).
+//  UIKit App Delegate for handling system callbacks that require UIApplicationDelegate:
+//   • Home screen quick actions (3D Touch / Haptic Touch shortcuts).
+//   • APNs remote-notification registration and silent push delivery (DEQ-283).
 //
 
 #if os(iOS)
@@ -11,6 +12,8 @@ import UIKit
 import os.log
 
 final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
+    private let logger = Logger(subsystem: "com.dequeue", category: "AppDelegate")
+
     /// Called when the app is launched via a quick action (cold launch).
     /// For warm launches, `windowScene(_:performActionFor:)` is called instead.
     func application(
@@ -29,6 +32,81 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         )
         config.delegateClass = DequeueSceneDelegate.self
         return config
+    }
+
+    /// App-level cold-launch hook. We register for remote notifications only
+    /// when the user is already signed in — registering at launch when not
+    /// signed in is a UX antipattern (prompts the user for push perms before
+    /// they've even seen the app) and the device token would be useless to the
+    /// backend without a Clerk user to attach it to. The sign-in completion
+    /// path handles first-time registration via `PushNotificationService`.
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        Task { @MainActor in
+            // AppContext is wired during DequeueApp.init() which runs before
+            // this delegate method. The guard is defensive: if a future change
+            // moves wiring later, we'd rather skip than crash.
+            guard let push = AppContext.shared.pushService else { return }
+            await push.registerIfSignedIn()
+        }
+        return true
+    }
+
+    // MARK: - APNs registration callbacks
+
+    /// Apple-callback: device token successfully provisioned by the OS.
+    /// We hand the raw bytes to `PushNotificationService` which hex-encodes,
+    /// caches, and uploads to the API.
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            await push.handleAPNsTokenRegistered(deviceToken)
+        }
+    }
+
+    /// Apple-callback: OS failed to provision a token (e.g. user denied perms,
+    /// network unavailable). Telemetry only — Apple will call us again the
+    /// next time we ask.
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            push.handleAPNsRegistrationFailed(error)
+        }
+    }
+
+    /// Apple-callback: silent / background push arrived.
+    ///
+    /// Per the reminder-delivery design, this is the pre-wake path: at
+    /// `remindAt - 30s` the backend sends a `content-available: 1` push
+    /// carrying the reminderId; we run a REST-only projection sync (no
+    /// WebSocket — too slow to establish in BG) and call the completion
+    /// handler with `.newData` / `.noData` / `.failed`. The 20s hard timeout
+    /// lives in `PushNotificationService.handleSilentPush`.
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else {
+                completionHandler(.noData)
+                return
+            }
+            let result = await push.handleSilentPush(userInfo: userInfo)
+            switch result {
+            case .newData: completionHandler(.newData)
+            case .noData: completionHandler(.noData)
+            case .failed: completionHandler(.failed)
+            }
+        }
     }
 }
 

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -101,8 +101,18 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         // concurrency cleanly without leaking Any across actors.
         let reminderId = (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
             ?? (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
-        let sentAtMs = userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? Double
-            ?? userInfo[NotificationConstants.UserInfoKey.localSentAtMs] as? Double
+        // APNs serialises JSON numbers as `NSNumber`. Per CLAUDE.md the wire
+        // value is Unix milliseconds; coerce via `NSNumber.int64Value` so we
+        // never lose precision regardless of whether iOS hands us an Int,
+        // Double, or NSNumber under the hood.
+        let sentAtMs: Int64? = {
+            let key = NotificationConstants.UserInfoKey.remoteSentAtMs
+            let legacyKey = NotificationConstants.UserInfoKey.localSentAtMs
+            if let nsNumber = (userInfo[key] as? NSNumber) ?? (userInfo[legacyKey] as? NSNumber) {
+                return nsNumber.int64Value
+            }
+            return nil
+        }()
         let payload = SilentPushPayload(reminderId: reminderId, sentAtMs: sentAtMs)
 
         Task { @MainActor in

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -118,11 +118,13 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         // defer in the Task can see mutations.
         let completion = OneShotCompletion(handler: completionHandler)
         Task { @MainActor in
+            // Single-style approach: `defer` handles all exit paths (including
+            // task cancellation between the `guard` and the result switch).
+            // Each `callIfNeeded` below is idempotent thanks to
+            // `OneShotCompletion`, so the defer's `.noData` fallback only
+            // fires when no explicit result was recorded.
             defer { completion.callIfNeeded(.noData) }
-            guard let push = AppContext.shared.pushService else {
-                completion.callIfNeeded(.noData)
-                return
-            }
+            guard let push = AppContext.shared.pushService else { return }
             let result = await push.handleSilentPush(payload: payload)
             switch result {
             case .newData: completion.callIfNeeded(.newData)

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -111,18 +111,50 @@ final class DequeueAppDelegate: NSObject, UIApplicationDelegate {
         let sentAtMs: Int64? = (userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? NSNumber)?.int64Value
         let payload = SilentPushPayload(reminderId: reminderId, sentAtMs: sentAtMs)
 
+        // Apple terminates the app if the completion handler is never called.
+        // Wrap delivery in a one-shot guard so any path — success, early-
+        // return, or task cancellation — still fires the callback exactly
+        // once. The guard is captured by reference via a class wrapper so the
+        // defer in the Task can see mutations.
+        let completion = OneShotCompletion(handler: completionHandler)
         Task { @MainActor in
+            defer { completion.callIfNeeded(.noData) }
             guard let push = AppContext.shared.pushService else {
-                completionHandler(.noData)
+                completion.callIfNeeded(.noData)
                 return
             }
             let result = await push.handleSilentPush(payload: payload)
             switch result {
-            case .newData: completionHandler(.newData)
-            case .noData: completionHandler(.noData)
-            case .failed: completionHandler(.failed)
+            case .newData: completion.callIfNeeded(.newData)
+            case .noData: completion.callIfNeeded(.noData)
+            case .failed: completion.callIfNeeded(.failed)
             }
         }
+    }
+}
+
+/// Tiny class wrapper that ensures a `UIBackgroundFetchResult` completion
+/// handler is invoked exactly once, even if the surrounding Task is cancelled
+/// or returns via multiple paths. Apple terminates the app if the handler
+/// never fires, so this is belt-and-suspenders for the silent-push wake.
+private final class OneShotCompletion: @unchecked Sendable {
+    private let handler: (UIBackgroundFetchResult) -> Void
+    private var fired = false
+    private let lock = NSLock()
+
+    init(handler: @escaping (UIBackgroundFetchResult) -> Void) {
+        self.handler = handler
+    }
+
+    func callIfNeeded(_ result: UIBackgroundFetchResult) {
+        lock.lock()
+        if fired {
+            lock.unlock()
+            return
+        }
+        fired = true
+        lock.unlock()
+        handler(result)
     }
 }
 

--- a/Dequeue/Dequeue/Services/AuthService.swift
+++ b/Dequeue/Dequeue/Services/AuthService.swift
@@ -599,10 +599,17 @@ final class ClerkAuthService: AuthServiceProtocol {
 
     /// Shared teardown invoked from `signOut()`, `handleDeferredSignOut()`,
     /// and the foreground double-422 path. Keeps the three sign-out flows in
-    /// sync so none leaves Sentry user context, the session-state stream, or
-    /// the background refresh task dangling.
+    /// sync so none leaves Sentry user context, the session-state stream,
+    /// the background refresh task, or APNs device-token registration
+    /// dangling.
     @MainActor
     private func tearDownSignedOutState() {
+        // Best-effort APNs deregistration. Fire-and-forget so a slow network
+        // doesn't block local state cleanup. PushNotificationService swallows
+        // failures into telemetry breadcrumbs. (DEQ-283)
+        if let pushService = AppContext.shared.pushService {
+            Task { @MainActor in await pushService.deregisterOnSignOut() }
+        }
         // Cancel any in-flight session refresh — belt-and-suspenders. The
         // task's own session-nil guard would also bail, but explicit cancel
         // avoids any chance of it touching Clerk against a nil session.

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -39,9 +39,13 @@ enum NotificationConstants: Sendable {
         /// Key under which the backend emits the dispatch timestamp.
         /// Per CLAUDE.md the value is Unix **milliseconds**.
         nonisolated static let remoteSentAtMs = "sent_at"
-        /// Legacy camelCase spelling of `sent_at` accepted defensively in
-        /// case a non-backend path (e.g. a future Notification Service
-        /// Extension) re-keys the payload before delegate handlers see it.
+        /// Legacy camelCase spelling of `sent_at` accepted defensively. The
+        /// dequeue-api APNs sender (PR 3, dequeue-api#201) emits the
+        /// canonical `remoteSentAtMs` (`sent_at`); this fallback is a
+        /// belt-and-suspenders for any future Notification Service Extension
+        /// that re-keys the payload before delegate handlers see it.
+        /// Tracked in DEQ-284 (delivery-reconciliation telemetry) — if NSE
+        /// is not on the roadmap we can remove this fallback then.
         nonisolated static let localSentAtMs = "sentAt"
     }
 

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -39,14 +39,6 @@ enum NotificationConstants: Sendable {
         /// Key under which the backend emits the dispatch timestamp.
         /// Per CLAUDE.md the value is Unix **milliseconds**.
         nonisolated static let remoteSentAtMs = "sent_at"
-        /// Legacy camelCase spelling of `sent_at` accepted defensively. The
-        /// dequeue-api APNs sender (PR 3, dequeue-api#201) emits the
-        /// canonical `remoteSentAtMs` (`sent_at`); this fallback is a
-        /// belt-and-suspenders for any future Notification Service Extension
-        /// that re-keys the payload before delegate handlers see it.
-        /// Tracked in DEQ-284 (delivery-reconciliation telemetry) — if NSE
-        /// is not on the roadmap we can remove this fallback then.
-        nonisolated static let localSentAtMs = "sentAt"
     }
 
     /// Snooze durations in seconds

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -409,8 +409,13 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
         if let reminderId {
             if isRemote {
-                // Remote-first: cancel the pending local twin if any.
-                center.removePendingNotificationRequests(withIdentifiers: [reminderId])
+                // Remote-first: stamp the dedup cache BEFORE cancelling the
+                // pending local twin. If the local twin fires on a parallel
+                // queue between these two operations and enters `willPresent`
+                // on a separate thread, having the cache stamp in place first
+                // lets the local-first branch suppress it. Otherwise the
+                // ordering would briefly allow a double-banner in the
+                // single-runloop-tick race window.
                 await MainActor.run {
                     AppContext.shared.pushService?.markRemoteDelivered(reminderId: reminderId)
                     ErrorReportingService.addBreadcrumb(
@@ -419,6 +424,7 @@ extension NotificationService: UNUserNotificationCenterDelegate {
                         data: ["reminderId": reminderId]
                     )
                 }
+                center.removePendingNotificationRequests(withIdentifiers: [reminderId])
             } else {
                 // Local-first: suppress if a remote landed inside the window.
                 // Single MainActor hop — we both probe the dedup cache and

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -369,11 +369,59 @@ final class NotificationService: NSObject {
 // MARK: - Notification Delegate Support
 
 extension NotificationService: UNUserNotificationCenterDelegate {
+    /// Foreground delegate: decides whether to present a notification and
+    /// arbitrates the local-vs-remote dedup contract (DEQ-283).
+    ///
+    /// Three paths:
+    ///  1. Remote push arrived (trigger is `UNPushNotificationTrigger`):
+    ///     cancel any pending *local* request for the same reminderId so we
+    ///     don't double-fire. Then present the remote normally.
+    ///  2. Local fire arrived but a remote for the same reminderId landed
+    ///     within the last 60s: suppress the local with `[]`.
+    ///  3. Otherwise present normally with banner/sound/badge.
+    ///
+    /// Local `UNNotificationRequest.identifier` is already the `reminder.id`
+    /// (see `scheduleNotification(for:)`); the remote push carries the same
+    /// id in `userInfo["reminder_id"]` per the APNs payload contract.
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.banner, .sound, .badge]
+        let userInfo = notification.request.content.userInfo
+        let reminderId = (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
+            ?? (userInfo["reminder_id"] as? String)
+        let isRemote = notification.request.trigger is UNPushNotificationTrigger
+
+        if let reminderId {
+            if isRemote {
+                // Remote-first: cancel the pending local twin if any.
+                center.removePendingNotificationRequests(withIdentifiers: [reminderId])
+                await MainActor.run {
+                    AppContext.shared.pushService?.markRemoteDelivered(reminderId: reminderId)
+                    ErrorReportingService.addBreadcrumb(
+                        category: "push",
+                        message: "reminder_push_dedup_local_canceled",
+                        data: ["reminderId": reminderId]
+                    )
+                }
+            } else {
+                // Local-first: suppress if a remote landed inside the window.
+                let isRecent = await MainActor.run {
+                    AppContext.shared.pushService?.isRemoteRecentlyDelivered(reminderId: reminderId) ?? false
+                }
+                if isRecent {
+                    await MainActor.run {
+                        ErrorReportingService.addBreadcrumb(
+                            category: "push",
+                            message: "reminder_push_dedup_remote_ignored",
+                            data: ["reminderId": reminderId]
+                        )
+                    }
+                    return []
+                }
+            }
+        }
+        return [.banner, .sound, .badge]
     }
 
     nonisolated func userNotificationCenter(

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -39,6 +39,10 @@ enum NotificationConstants: Sendable {
         /// Key under which the backend emits the dispatch timestamp.
         /// Per CLAUDE.md the value is Unix **milliseconds**.
         nonisolated static let remoteSentAtMs = "sent_at"
+        /// Legacy camelCase spelling of `sent_at` accepted defensively in
+        /// case a non-backend path (e.g. a future Notification Service
+        /// Extension) re-keys the payload before delegate handlers see it.
+        nonisolated static let localSentAtMs = "sentAt"
     }
 
     /// Snooze durations in seconds
@@ -421,17 +425,23 @@ extension NotificationService: UNUserNotificationCenterDelegate {
                 }
             } else {
                 // Local-first: suppress if a remote landed inside the window.
-                let isRecent = await MainActor.run {
-                    AppContext.shared.pushService?.isRemoteRecentlyDelivered(reminderId: reminderId) ?? false
-                }
-                if isRecent {
-                    await MainActor.run {
+                // Single MainActor hop — we both probe the dedup cache and
+                // (if we're suppressing) emit telemetry in the same
+                // synchronous block to minimise actor-hop overhead on the
+                // foreground notification-delivery hot path.
+                let suppress: Bool = await MainActor.run {
+                    let pushService = AppContext.shared.pushService
+                    let recent = pushService?.isRemoteRecentlyDelivered(reminderId: reminderId) ?? false
+                    if recent {
                         ErrorReportingService.addBreadcrumb(
                             category: "push",
                             message: "reminder_push_dedup_remote_ignored",
                             data: ["reminderId": reminderId]
                         )
                     }
+                    return recent
+                }
+                if suppress {
                     return []
                 }
             }

--- a/Dequeue/Dequeue/Services/NotificationService.swift
+++ b/Dequeue/Dequeue/Services/NotificationService.swift
@@ -26,9 +26,19 @@ enum NotificationConstants: Sendable {
     }
 
     enum UserInfoKey: Sendable {
+        /// Key under which the local-notification path stores the reminder id.
+        /// Local pending notifications were already using this camelCase key
+        /// in production prior to DEQ-283, so it must stay stable to dedup
+        /// against existing scheduled notifications across an app update.
         nonisolated static let reminderId = "reminderId"
         nonisolated static let parentType = "parentType"
         nonisolated static let parentId = "parentId"
+        /// Key under which the backend APNs sender (PR 3, dequeue-api#201)
+        /// emits the reminder id. Snake-case is the API-wide convention.
+        nonisolated static let remoteReminderId = "reminder_id"
+        /// Key under which the backend emits the dispatch timestamp.
+        /// Per CLAUDE.md the value is Unix **milliseconds**.
+        nonisolated static let remoteSentAtMs = "sent_at"
     }
 
     /// Snooze durations in seconds
@@ -388,8 +398,13 @@ extension NotificationService: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
+        // Two key spellings, one canonical concept. Local notifications
+        // produced by `scheduleNotification(for:)` use the camelCase key
+        // (`UserInfoKey.reminderId`). Remote APNs payloads from the backend
+        // emit the snake_case key (`UserInfoKey.remoteReminderId`). Looking
+        // up both makes the dedup contract source-agnostic.
         let reminderId = (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
-            ?? (userInfo["reminder_id"] as? String)
+            ?? (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
         let isRemote = notification.request.trigger is UNPushNotificationTrigger
 
         if let reminderId {

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -588,7 +588,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                         // sync API does not yet return a per-call fetched
                         // count. Refining this to a true fetched-count
                         // (and emitting `.noData` when zero events were
-                        // applied) is the follow-up tracked in DEQ-286
+                        // applied) is the follow-up tracked in DEQ-284
                         // (delivery-reconciliation telemetry).
                         return .success(fetchedCount: 1)
                     } catch {

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -492,8 +492,10 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         }
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
 
-        // One retry on transient 5xx.
-        for attempt in 1...2 {
+        // One retry on transient 5xx. Named constant keeps the range and
+        // retry-bound check coupled in one place.
+        let maxAttempts = 2
+        for attempt in 1...maxAttempts {
             let outcome = await attemptPost(request: request)
             switch outcome {
             case .success(let status):
@@ -505,7 +507,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                 )
                 return
             case let .retryable(status, error):
-                if attempt < 2 {
+                if attempt < maxAttempts {
                     ErrorReportingService.addBreadcrumb(
                         category: "push",
                         message: "device_token_register transient failure, retrying",

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -1,0 +1,639 @@
+//
+//  PushNotificationService.swift
+//  Dequeue
+//
+//  APNs device-token registration + remote-push dedup bookkeeping for the
+//  reminder delivery pipeline (DEQ-283, parent DEQ-276).
+//
+//  Responsibilities:
+//   • POST /v1/devices/push-token on launch + auth state change + 7d stale.
+//   • DELETE /v1/devices/push-token on sign-out (across all three teardown paths).
+//   • Track recently-arrived remote reminderIds in a 60s NSCache so the
+//     `UNUserNotificationCenterDelegate` can suppress redundant local fires.
+//   • Emit structured Sentry breadcrumbs for every interesting transition.
+//
+//  All persistent state (cached token, last-registered timestamp) lives under
+//  the `dequeue.push.*` UserDefaults namespace so it survives app relaunch
+//  but is wiped on app uninstall along with everything else.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+import os.log
+import Sentry
+
+// MARK: - PushNotificationServiceProtocol
+
+/// Protocol surface used by AppDelegate, AuthService teardown, and tests.
+@MainActor
+protocol PushNotificationServiceProtocol: AnyObject, Sendable {
+    /// Cached device token (hex string), if registered with APNs.
+    var cachedDeviceToken: String? { get }
+
+    /// Whether registration is currently pending the OS callback.
+    var isRegistering: Bool { get }
+
+    /// Apple-callback entry: stash the raw token, then POST to the API.
+    /// Idempotent — subsequent calls with the same token re-POST to refresh
+    /// `last_seen_at` on the server.
+    func handleAPNsTokenRegistered(_ tokenData: Data) async
+
+    /// Apple-callback entry: failed registration. Telemetry only.
+    func handleAPNsRegistrationFailed(_ error: Error)
+
+    /// Called when the user has just signed in. Triggers
+    /// `registerForRemoteNotifications` on the main thread and (once the token
+    /// arrives) the upload to the API.
+    func registerIfSignedIn() async
+
+    /// Called on app foregrounding. Re-POSTs the cached token if `last_registered_at`
+    /// is older than 7 days, otherwise no-op.
+    func refreshTokenIfStale() async
+
+    /// Called on every sign-out path. DELETEs the device-id from the API and
+    /// clears local push state. Idempotent.
+    func deregisterOnSignOut() async
+
+    // MARK: Dedup bookkeeping
+
+    /// Mark a remote-delivered reminderId as recently seen (in-memory, 60s TTL).
+    /// `nonisolated` so the `UNUserNotificationCenter` delegate can call this
+    /// from its `nonisolated async` callback without an actor hop.
+    nonisolated func markRemoteDelivered(reminderId: String)
+
+    /// Whether a remote push for this reminderId arrived within the last 60s.
+    /// `nonisolated` so the `UNUserNotificationCenter` delegate can call this
+    /// from its `nonisolated async` callback without an actor hop.
+    nonisolated func isRemoteRecentlyDelivered(reminderId: String) -> Bool
+
+    // MARK: Background sync entry
+
+    /// Called by `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
+    /// Kicks off REST-only sync with a 20s hard deadline. Returns the appropriate
+    /// `UIBackgroundFetchResult` for the silent-push completion handler.
+    func handleSilentPush(userInfo: [AnyHashable: Any]) async -> SilentPushResult
+}
+
+/// Mirror of `UIBackgroundFetchResult` so cross-platform code can model the
+/// outcome without importing UIKit (tests run on macOS too).
+enum SilentPushResult: Sendable, Equatable {
+    case newData
+    case noData
+    case failed
+}
+
+// MARK: - Constants
+
+private enum PushDefaults {
+    nonisolated static let cachedToken = "dequeue.push.cachedToken"
+    nonisolated static let lastRegisteredAt = "dequeue.push.lastRegisteredAt"
+    /// Stale window after which we re-POST the cached token on foregrounding.
+    nonisolated static let staleInterval: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    /// In-memory dedup window for remote-delivered reminderIds.
+    nonisolated static let dedupWindow: TimeInterval = 60
+    /// Hard cap on the silent-push REST sync. Apple gives BG fetch ~30s; we
+    /// leave ourselves 10s of head room so we always call the completion
+    /// handler before the system kills us.
+    nonisolated static let silentPushSyncTimeout: TimeInterval = 20
+    nonisolated static let registerEndpointPath = "/devices/push-token"
+}
+
+// MARK: - PushNotificationService
+
+@MainActor
+final class PushNotificationService: PushNotificationServiceProtocol {
+    static let shared = PushNotificationService()
+
+    // Dependencies — overridable for tests via the designated init.
+    private let urlSession: URLSession
+    private let userDefaults: UserDefaults
+    private let baseURLProvider: @MainActor () -> URL
+    private let tokenProvider: @MainActor () async throws -> String
+    private let deviceIdProvider: @Sendable () async -> String
+    private let isAuthenticatedProvider: @MainActor () -> Bool
+    private let now: @Sendable () -> Date
+
+    /// In-memory cache of `reminderId -> Date` for remote pushes that landed
+    /// within the dedup window. NSCache is intentionally `nonisolated(unsafe)`
+    /// because UNUserNotificationCenter delegate callbacks are
+    /// `nonisolated async` and need a way to read this state without an
+    /// actor hop (NSCache is documented thread-safe).
+    nonisolated(unsafe) private let recentRemotes = NSCache<NSString, NSDate>()
+
+    private(set) var cachedDeviceToken: String?
+    private(set) var isRegistering: Bool = false
+
+    /// Designated init. Defaults wire production paths; tests use this same
+    /// init with their own URLSession / providers.
+    init(
+        urlSession: URLSession = .shared,
+        userDefaults: UserDefaults = .standard,
+        baseURLProvider: (@MainActor () -> URL)? = nil,
+        tokenProvider: (@MainActor () async throws -> String)? = nil,
+        deviceIdProvider: (@Sendable () async -> String)? = nil,
+        isAuthenticatedProvider: (@MainActor () -> Bool)? = nil,
+        now: (@Sendable () -> Date)? = nil
+    ) {
+        // Resolve defaults inside the init so the closure literals don't need
+        // to capture @MainActor state at the parameter-default position
+        // (Swift 6 doesn't allow actor-isolated default values for non-isolated
+        // parameters and is unhappy with mixed isolation defaults).
+        let resolvedBaseURL: @MainActor () -> URL = baseURLProvider ?? { Configuration.dequeueAPIBaseURL }
+        let resolvedTokenProvider: @MainActor () async throws -> String =
+            tokenProvider ?? { try await ClerkAuthTokenProvider.shared.getToken() }
+        let resolvedDeviceIdProvider: @Sendable () async -> String =
+            deviceIdProvider ?? { await DeviceService.shared.getDeviceId() }
+        let resolvedIsAuthenticated: @MainActor () -> Bool =
+            isAuthenticatedProvider ?? { ClerkAuthTokenProvider.shared.isAuthenticated() }
+        let resolvedNow: @Sendable () -> Date = now ?? { Date() }
+        self.urlSession = urlSession
+        self.userDefaults = userDefaults
+        self.baseURLProvider = resolvedBaseURL
+        self.tokenProvider = resolvedTokenProvider
+        self.deviceIdProvider = resolvedDeviceIdProvider
+        self.isAuthenticatedProvider = resolvedIsAuthenticated
+        self.now = resolvedNow
+        self.cachedDeviceToken = userDefaults.string(forKey: PushDefaults.cachedToken)
+        // Keep the dedup cache modest — we only need the last few seconds of
+        // pushes. 256 entries is well past any plausible burst.
+        recentRemotes.countLimit = 256
+    }
+
+    // MARK: - Public API
+
+    func handleAPNsTokenRegistered(_ tokenData: Data) async {
+        let hex = tokenData.map { String(format: "%02x", $0) }.joined()
+        cachedDeviceToken = hex
+        userDefaults.set(hex, forKey: PushDefaults.cachedToken)
+
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "APNs token received",
+            data: ["token_prefix": String(hex.prefix(8))]
+        )
+
+        // POST to API — fire-and-forget retry loop. We don't block the main
+        // thread on the callback; the OS only cares that we received the
+        // token, not that the server has acknowledged it.
+        await postDeviceToken(hex)
+    }
+
+    func handleAPNsRegistrationFailed(_ error: Error) {
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "APNs registration failed",
+            level: .warning,
+            data: ["error": error.localizedDescription]
+        )
+        ErrorReportingService.capture(
+            error: error,
+            context: ["source": "apns_registration"]
+        )
+    }
+
+    func registerIfSignedIn() async {
+        guard isAuthenticatedProvider() else {
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "Skip APNs registration: not authenticated"
+            )
+            return
+        }
+        guard !isRegistering else { return }
+        isRegistering = true
+        defer { isRegistering = false }
+
+        #if canImport(UIKit) && os(iOS)
+        UIApplication.shared.registerForRemoteNotifications()
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "Requested registerForRemoteNotifications"
+        )
+        #else
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "registerForRemoteNotifications skipped (non-iOS platform)"
+        )
+        #endif
+    }
+
+    func refreshTokenIfStale() async {
+        guard isAuthenticatedProvider() else { return }
+        guard let token = cachedDeviceToken else {
+            // No cached token yet; force a fresh register pass.
+            await registerIfSignedIn()
+            return
+        }
+        let lastRegistered = userDefaults.object(forKey: PushDefaults.lastRegisteredAt) as? Date
+        let isStale: Bool = {
+            guard let lastRegistered else { return true }
+            return now().timeIntervalSince(lastRegistered) > PushDefaults.staleInterval
+        }()
+        guard isStale else { return }
+
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "Device token stale, re-registering",
+            data: [
+                "age_days": Int((now().timeIntervalSince(lastRegistered ?? .distantPast)) / 86_400)
+            ]
+        )
+        await postDeviceToken(token)
+    }
+
+    func deregisterOnSignOut() async {
+        // Clear local state up front so a concurrent re-register can't see
+        // stale-token bookkeeping.
+        let token = cachedDeviceToken
+        cachedDeviceToken = nil
+        userDefaults.removeObject(forKey: PushDefaults.cachedToken)
+        userDefaults.removeObject(forKey: PushDefaults.lastRegisteredAt)
+        recentRemotes.removeAllObjects()
+
+        guard token != nil else {
+            // Nothing to deregister server-side.
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "Sign-out: no cached token to deregister"
+            )
+            return
+        }
+
+        let deviceId = await deviceIdProvider()
+        let baseURL = baseURLProvider()
+        let url = baseURL.appendingPathComponent(PushDefaults.registerEndpointPath)
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return
+        }
+        components.queryItems = [URLQueryItem(name: "deviceId", value: deviceId)]
+        guard let deleteURL = components.url else { return }
+
+        var request = URLRequest(url: deleteURL)
+        request.httpMethod = "DELETE"
+        request.timeoutInterval = 10
+        // Best-effort token fetch — if it fails we still emit telemetry and
+        // bail. The next launch will not be able to re-target this device
+        // record from the API side, but the server-side reconciler will reap
+        // stale tokens via APNs 410s.
+        let authToken: String?
+        do {
+            authToken = try await tokenProvider()
+        } catch {
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "device_token_deregister: token fetch failed",
+                level: .warning,
+                data: ["error": error.localizedDescription]
+            )
+            return
+        }
+        if let authToken {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (_, response) = try await urlSession.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "device_token_deregistered",
+                data: ["status": status]
+            )
+        } catch {
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "device_token_deregister network failure",
+                level: .warning,
+                data: ["error": error.localizedDescription]
+            )
+        }
+    }
+
+    // MARK: - Dedup bookkeeping
+
+    nonisolated func markRemoteDelivered(reminderId: String) {
+        let key = reminderId as NSString
+        recentRemotes.setObject(Date() as NSDate, forKey: key)
+    }
+
+    nonisolated func isRemoteRecentlyDelivered(reminderId: String) -> Bool {
+        let key = reminderId as NSString
+        guard let date = recentRemotes.object(forKey: key) as Date? else { return false }
+        let elapsed = Date().timeIntervalSince(date)
+        if elapsed > PushDefaults.dedupWindow {
+            recentRemotes.removeObject(forKey: key)
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Silent push handler
+
+    func handleSilentPush(userInfo: [AnyHashable: Any]) async -> SilentPushResult {
+        // Extract telemetry props before we kick the sync — Sendable types only.
+        let reminderId = userInfo["reminder_id"] as? String ?? userInfo["reminderId"] as? String
+        let sentAtRaw = userInfo["sentAt"] as? Double ?? userInfo["sent_at"] as? Double
+        let sentAt = sentAtRaw.map { Date(timeIntervalSince1970: $0) }
+        let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
+
+        // Mark this reminder as remote-delivered so the foreground willPresent
+        // delegate can suppress the local twin if it lands within 60s.
+        if let reminderId {
+            markRemoteDelivered(reminderId: reminderId)
+        }
+
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "reminder_push_received",
+            data: [
+                "reminderId": reminderId ?? "<missing>",
+                "ageMs": ageMs ?? -1
+            ]
+        )
+
+        let syncStart = now()
+        let result = await Self.runSilentPushSync(
+            timeout: PushDefaults.silentPushSyncTimeout
+        )
+        let durationMs = Int(now().timeIntervalSince(syncStart) * 1_000)
+
+        switch result {
+        case .success(let fetchedCount):
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "reminder_push_sync_completed",
+                data: ["durationMs": durationMs, "fetchedCount": fetchedCount]
+            )
+            return fetchedCount > 0 ? .newData : .noData
+        case .failure(let kind):
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "reminder_push_sync_failed",
+                level: .warning,
+                data: ["durationMs": durationMs, "errorKind": kind]
+            )
+            return .failed
+        }
+    }
+
+    // MARK: - Internal: POST device token
+
+    /// Posts the cached token to the device-registration endpoint. Retries
+    /// once on transient 5xx; permanent failures become telemetry breadcrumbs
+    /// (we never block the OS callback on this).
+    private func postDeviceToken(_ token: String) async {
+        let deviceId = await deviceIdProvider()
+        let baseURL = baseURLProvider()
+        let url = baseURL.appendingPathComponent(PushDefaults.registerEndpointPath)
+
+        let environment: String = {
+            #if DEBUG
+            return "development"
+            #else
+            return "production"
+            #endif
+        }()
+
+        let platform: String = {
+            #if os(macOS)
+            return "macos"
+            #else
+            return "ios"
+            #endif
+        }()
+
+        let body: [String: Any] = [
+            "deviceId": deviceId,
+            "token": token,
+            "platform": platform,
+            "environment": environment,
+            "bundleId": Configuration.bundleIdentifier,
+            "appVersion": Configuration.appVersion
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "device_token_register_failed",
+                level: .warning,
+                data: ["errorKind": "serialization"]
+            )
+            return
+        }
+
+        let authToken: String?
+        do {
+            authToken = try await tokenProvider()
+        } catch {
+            ErrorReportingService.addBreadcrumb(
+                category: "push",
+                message: "device_token_register_failed",
+                level: .warning,
+                data: ["errorKind": "token_unavailable", "error": error.localizedDescription]
+            )
+            return
+        }
+        if let authToken {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        // One retry on transient 5xx.
+        for attempt in 1...2 {
+            let outcome = await attemptPost(request: request)
+            switch outcome {
+            case .success(let status):
+                userDefaults.set(now(), forKey: PushDefaults.lastRegisteredAt)
+                ErrorReportingService.addBreadcrumb(
+                    category: "push",
+                    message: "device_token_registered",
+                    data: ["status": status, "attempt": attempt]
+                )
+                return
+            case let .retryable(status, error):
+                if attempt < 2 {
+                    ErrorReportingService.addBreadcrumb(
+                        category: "push",
+                        message: "device_token_register transient failure, retrying",
+                        level: .warning,
+                        data: [
+                            "status": status,
+                            "error": error?.localizedDescription ?? "",
+                            "attempt": attempt
+                        ]
+                    )
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    continue
+                }
+                ErrorReportingService.addBreadcrumb(
+                    category: "push",
+                    message: "device_token_register_failed",
+                    level: .warning,
+                    data: [
+                        "errorKind": "transient_5xx",
+                        "status": status,
+                        "error": error?.localizedDescription ?? "",
+                        "attempt": attempt
+                    ]
+                )
+            case let .permanent(status, error):
+                ErrorReportingService.addBreadcrumb(
+                    category: "push",
+                    message: "device_token_register_failed",
+                    level: .warning,
+                    data: [
+                        "errorKind": "permanent",
+                        "status": status,
+                        "error": error?.localizedDescription ?? ""
+                    ]
+                )
+                return
+            }
+        }
+    }
+
+    private enum PostOutcome {
+        case success(status: Int)
+        case retryable(status: Int, error: Error?)
+        case permanent(status: Int, error: Error?)
+    }
+
+    private func attemptPost(request: URLRequest) async -> PostOutcome {
+        do {
+            let (_, response) = try await urlSession.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            switch status {
+            case 200...299:
+                return .success(status: status)
+            case 500...599:
+                return .retryable(status: status, error: nil)
+            default:
+                return .permanent(status: status, error: nil)
+            }
+        } catch {
+            // URLSession transport error — treat as retryable on first attempt.
+            return .retryable(status: -1, error: error)
+        }
+    }
+
+    // MARK: - Internal: silent-push REST sync
+
+    enum SilentSyncOutcome: Sendable, Equatable {
+        case success(fetchedCount: Int)
+        case failure(kind: String)
+    }
+
+    /// Kicks off a single REST-only projection sync via the live `SyncManager`
+    /// resolved through the app environment. We intentionally do NOT establish
+    /// a WebSocket — TCP handshake + WebSocket upgrade is slower than the 20s
+    /// silent-push budget, and Apple kills the process if we miss it.
+    ///
+    /// Falls back to `.failure(kind: "timeout")` if the sync exceeds the
+    /// supplied deadline. Falls back to `.failure(kind: "unavailable")` if the
+    /// app context hasn't been wired yet (e.g. very early launch race).
+    static func runSilentPushSync(timeout: TimeInterval) async -> SilentSyncOutcome {
+        let syncManager = await MainActor.run { AppContext.shared.syncManager }
+        guard let syncManager else {
+            return .failure(kind: "unavailable")
+        }
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(timeout))
+        let result: SilentSyncOutcome
+        do {
+            result = try await withThrowingTaskGroup(of: SilentSyncOutcome.self) { group in
+                group.addTask {
+                    do {
+                        try await syncManager.syncViaProjections()
+                        // We don't have a per-call fetched-count yet; surface
+                        // 1 so the OS treats it as fresh data. The detailed
+                        // delivery-reconciliation telemetry lives in
+                        // ErrorReportingService breadcrumbs.
+                        return .success(fetchedCount: 1)
+                    } catch {
+                        return .failure(kind: "sync_error")
+                    }
+                }
+                group.addTask {
+                    try? await Task.sleep(until: deadline, clock: ContinuousClock())
+                    return .failure(kind: "timeout")
+                }
+                guard let first = try await group.next() else {
+                    return .failure(kind: "empty")
+                }
+                group.cancelAll()
+                return first
+            }
+        } catch {
+            return .failure(kind: "task_group_error")
+        }
+        return result
+    }
+}
+
+// MARK: - ClerkAuthTokenProvider
+
+/// Thin static accessor over `ClerkKit` for use from non-MainActor contexts
+/// where we don't have an injected AuthServiceProtocol. We use the bound
+/// reference from `AppContext` first; on first launch (before AppContext is
+/// configured) we surface a soft failure that callers swallow as telemetry.
+@MainActor
+final class ClerkAuthTokenProvider {
+    static let shared = ClerkAuthTokenProvider()
+
+    private init() {}
+
+    func getToken() async throws -> String {
+        if let authService = AppContext.shared.authService {
+            return try await authService.getAuthToken()
+        }
+        throw AuthError.notAuthenticated
+    }
+
+    func isAuthenticated() -> Bool {
+        AppContext.shared.authService?.isAuthenticated ?? false
+    }
+}
+
+// MARK: - AppContext
+
+/// Minimal global registry so background callbacks (AppDelegate, push
+/// handlers) can reach the live `SyncManager` and `AuthService` without
+/// threading them through every UIKit shim.
+///
+/// Set during `DequeueApp.init()` after services are constructed.
+@MainActor
+final class AppContext {
+    static let shared = AppContext()
+
+    private(set) var syncManager: SyncManager?
+    private(set) var authService: (any AuthServiceProtocol)?
+    private(set) var pushService: (any PushNotificationServiceProtocol)?
+
+    private init() {}
+
+    func configure(
+        syncManager: SyncManager,
+        authService: any AuthServiceProtocol,
+        pushService: any PushNotificationServiceProtocol
+    ) {
+        self.syncManager = syncManager
+        self.authService = authService
+        self.pushService = pushService
+    }
+
+    /// Test-only reset hook.
+    #if DEBUG
+    func resetForTesting() {
+        syncManager = nil
+        authService = nil
+        pushService = nil
+    }
+    #endif
+}

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -169,6 +169,14 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// because UNUserNotificationCenter delegate callbacks are
     /// `nonisolated async` and need a way to read this state without an
     /// actor hop (NSCache is documented thread-safe).
+    ///
+    /// **Lifetime caveat:** This cache is process-local. If the app is killed
+    /// and relaunched in the ~30s window between the silent push (remindAt−30s)
+    /// and the alert push (remindAt), the cache resets and the dedup contract
+    /// misses for that one reminder — worst-case a single double-banner. The
+    /// race is extremely unlikely (would require a crash or memory eviction
+    /// inside a 30s window for the *one* reminder being delivered) and the
+    /// failure mode is benign enough that we don't persist the cache.
     nonisolated(unsafe) private let recentRemotes = NSCache<NSString, NSDate>()
 
     /// Optional override for the live SyncManager. When nil we resolve via
@@ -562,6 +570,39 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                     data: ["status": status, "attempt": attempt]
                 )
                 return
+            case let .transport(error):
+                if attempt < maxAttempts {
+                    ErrorReportingService.addBreadcrumb(
+                        category: "push",
+                        message: "device_token_register transport failure, retrying",
+                        level: .warning,
+                        data: ["error": error.localizedDescription, "attempt": attempt]
+                    )
+                    if tokenRegisterRetryDelay > 0 {
+                        do {
+                            try await Task.sleep(
+                                nanoseconds: UInt64(tokenRegisterRetryDelay * 1_000_000_000)
+                            )
+                        } catch {
+                            return
+                        }
+                    }
+                    if Task.isCancelled { return }
+                    continue
+                }
+                Self.logger.warning(
+                    "device_token_register transport failure exhausted: \(error.localizedDescription, privacy: .public)"
+                )
+                ErrorReportingService.addBreadcrumb(
+                    category: "push",
+                    message: "device_token_register_failed",
+                    level: .warning,
+                    data: [
+                        "errorKind": "transport",
+                        "error": error.localizedDescription,
+                        "attempt": attempt
+                    ]
+                )
             case let .retryable(status, error):
                 if attempt < maxAttempts {
                     ErrorReportingService.addBreadcrumb(
@@ -621,8 +662,15 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     private enum PostOutcome {
         case success(status: Int)
+        /// HTTP 5xx — retryable; `status` is the actual code.
         case retryable(status: Int, error: Error?)
+        /// HTTP 4xx / unexpected status — don't retry.
         case permanent(status: Int, error: Error?)
+        /// Network transport failure (no response received) — retryable on
+        /// first attempt; surfaced as a distinct telemetry kind so the
+        /// `status: -1` breadcrumb on the final attempt isn't misclassified
+        /// as a 5xx.
+        case transport(error: Error)
     }
 
     private func attemptPost(request: URLRequest) async -> PostOutcome {
@@ -638,8 +686,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                 return .permanent(status: status, error: nil)
             }
         } catch {
-            // URLSession transport error — treat as retryable on first attempt.
-            return .retryable(status: -1, error: error)
+            return .transport(error: error)
         }
     }
 

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -70,7 +70,20 @@ protocol PushNotificationServiceProtocol: AnyObject, Sendable {
     /// Called by `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
     /// Kicks off REST-only sync with a 20s hard deadline. Returns the appropriate
     /// `UIBackgroundFetchResult` for the silent-push completion handler.
-    func handleSilentPush(userInfo: [AnyHashable: Any]) async -> SilentPushResult
+    ///
+    /// `SilentPushPayload` is Sendable; the AppDelegate extracts it from the
+    /// non-Sendable `[AnyHashable: Any]` userInfo dictionary before crossing
+    /// the actor boundary.
+    func handleSilentPush(payload: SilentPushPayload) async -> SilentPushResult
+}
+
+/// Sendable extract of the fields we care about from an APNs userInfo
+/// dictionary. AppDelegate extracts these before crossing the Task boundary
+/// so we don't carry `Any` across actors (Swift 6 strict concurrency).
+struct SilentPushPayload: Sendable, Equatable {
+    let reminderId: String?
+    /// Backend-provided dispatch timestamp in Unix **milliseconds**.
+    let sentAtMs: Double?
 }
 
 /// Mirror of `UIBackgroundFetchResult` so cross-platform code can model the
@@ -95,6 +108,21 @@ private enum PushDefaults {
     /// handler before the system kills us.
     nonisolated static let silentPushSyncTimeout: TimeInterval = 20
     nonisolated static let registerEndpointPath = "/devices/push-token"
+}
+
+// MARK: - Wire bodies
+
+/// Wire shape for `POST /v1/devices/push-token`. Mirrors the request struct
+/// shipped in dequeue-api#200 (`DeviceTokenRequest`). Encodable so the body
+/// stays type-safe end-to-end — per CLAUDE.md no `[String: Any]` in service
+/// code.
+private struct DeviceTokenRegistrationBody: Encodable, Sendable {
+    let deviceId: String
+    let token: String
+    let platform: String
+    let environment: String
+    let bundleId: String
+    let appVersion: String
 }
 
 // MARK: - PushNotificationService
@@ -125,6 +153,10 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// `SilentPushSyncing` without dragging in the full SyncManager surface.
     private let silentPushSyncer: SilentPushSyncing?
 
+    /// Silent-push REST sync timeout. Production uses `PushDefaults.silentPushSyncTimeout`
+    /// (20s); tests inject a much smaller value to keep the timeout path fast.
+    private let silentPushSyncTimeout: TimeInterval
+
     private(set) var cachedDeviceToken: String?
 
     /// Designated init. Defaults wire production paths; tests use this same
@@ -137,6 +169,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         deviceIdProvider: (@Sendable () async -> String)? = nil,
         isAuthenticatedProvider: (@MainActor () -> Bool)? = nil,
         silentPushSyncer: SilentPushSyncing? = nil,
+        silentPushSyncTimeout: TimeInterval = PushDefaults.silentPushSyncTimeout,
         now: (@Sendable () -> Date)? = nil
     ) {
         // Resolve defaults inside the init so the closure literals don't need
@@ -144,12 +177,16 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // (Swift 6 doesn't allow actor-isolated default values for non-isolated
         // parameters and is unhappy with mixed isolation defaults).
         let resolvedBaseURL: @MainActor () -> URL = baseURLProvider ?? { Configuration.dequeueAPIBaseURL }
-        let resolvedTokenProvider: @MainActor () async throws -> String =
-            tokenProvider ?? { try await ClerkAuthTokenProvider.shared.getToken() }
+        let resolvedTokenProvider: @MainActor () async throws -> String = tokenProvider ?? {
+            guard let authService = AppContext.shared.authService else {
+                throw AuthError.notAuthenticated
+            }
+            return try await authService.getAuthToken()
+        }
         let resolvedDeviceIdProvider: @Sendable () async -> String =
             deviceIdProvider ?? { await DeviceService.shared.getDeviceId() }
         let resolvedIsAuthenticated: @MainActor () -> Bool =
-            isAuthenticatedProvider ?? { ClerkAuthTokenProvider.shared.isAuthenticated() }
+            isAuthenticatedProvider ?? { AppContext.shared.authService?.isAuthenticated ?? false }
         let resolvedNow: @Sendable () -> Date = now ?? { Date() }
         self.urlSession = urlSession
         self.userDefaults = userDefaults
@@ -158,6 +195,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         self.deviceIdProvider = resolvedDeviceIdProvider
         self.isAuthenticatedProvider = resolvedIsAuthenticated
         self.silentPushSyncer = silentPushSyncer
+        self.silentPushSyncTimeout = silentPushSyncTimeout
         self.now = resolvedNow
         self.cachedDeviceToken = userDefaults.string(forKey: PushDefaults.cachedToken)
         // Keep the dedup cache modest — we only need the last few seconds of
@@ -337,20 +375,13 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     // MARK: - Silent push handler
 
-    func handleSilentPush(userInfo: [AnyHashable: Any]) async -> SilentPushResult {
-        // Extract telemetry props before we kick the sync — Sendable types only.
-        // Backend (PR 3, dequeue-api#201) emits snake_case keys; we also accept
-        // the local camelCase spelling for symmetry with the local-notification
-        // userInfo dictionaries we control on this side.
-        let reminderId = (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
-            ?? (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
+    func handleSilentPush(payload: SilentPushPayload) async -> SilentPushResult {
+        let reminderId = payload.reminderId
         // `sent_at` is Unix **milliseconds** per the project-wide CLAUDE.md
         // convention (matches the dequeue-api wire format). Parsing this as
         // seconds would yield a Date ~50,000 years in the future and a
         // wildly negative ageMs.
-        let sentAtRawMs = userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? Double
-            ?? userInfo[NotificationConstants.UserInfoKey.localSentAtMs] as? Double
-        let sentAt = sentAtRawMs.map { Date(timeIntervalSince1970: $0 / 1_000.0) }
+        let sentAt = payload.sentAtMs.map { Date(timeIntervalSince1970: $0 / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
         // Mark this reminder as remote-delivered so the foreground willPresent
@@ -369,7 +400,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         )
 
         let syncStart = now()
-        let result = await runSilentPushSync(timeout: PushDefaults.silentPushSyncTimeout)
+        let result = await runSilentPushSync(timeout: silentPushSyncTimeout)
         let durationMs = Int(now().timeIntervalSince(syncStart) * 1_000)
 
         switch result {
@@ -627,30 +658,6 @@ struct SyncManagerSilentPushAdapter: SilentPushSyncing {
     let syncManager: SyncManager
     func runRESTProjectionSync() async throws {
         try await syncManager.syncViaProjections()
-    }
-}
-
-// MARK: - ClerkAuthTokenProvider
-
-/// Thin static accessor over `ClerkKit` for use from non-MainActor contexts
-/// where we don't have an injected AuthServiceProtocol. We use the bound
-/// reference from `AppContext` first; on first launch (before AppContext is
-/// configured) we surface a soft failure that callers swallow as telemetry.
-@MainActor
-final class ClerkAuthTokenProvider {
-    static let shared = ClerkAuthTokenProvider()
-
-    private init() {}
-
-    func getToken() async throws -> String {
-        if let authService = AppContext.shared.authService {
-            return try await authService.getAuthToken()
-        }
-        throw AuthError.notAuthenticated
-    }
-
-    func isAuthenticated() -> Bool {
-        AppContext.shared.authService?.isAuthenticated ?? false
     }
 }
 

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -136,9 +136,19 @@ private struct DeviceTokenRegistrationBody: Encodable, Sendable {
 
 // MARK: - PushNotificationService
 
+/// `@MainActor` (not `actor`) because `UIApplication.shared.registerForRemoteNotifications()`
+/// must be called on the main thread and we call it directly from
+/// `registerIfSignedIn`. Putting that single `MainActor.run` inside an `actor`
+/// would work too, but the rest of the service touches `@MainActor` services
+/// (`AppContext.shared.authService.getAuthToken`, `Configuration`) so the
+/// pragmatic choice is to keep the whole class on the main actor. All public
+/// methods are async, so callers context-switch correctly.
 @MainActor
 final class PushNotificationService: PushNotificationServiceProtocol {
     static let shared = PushNotificationService()
+
+    /// Category-scoped logger matching the pattern in other Dequeue services.
+    private static let logger = Logger(subsystem: "com.dequeue", category: "PushNotificationService")
 
     // Dependencies — overridable for tests via the designated init.
     private let urlSession: URLSession
@@ -226,6 +236,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         cachedDeviceToken = hex
         userDefaults.set(hex, forKey: PushDefaults.cachedToken)
 
+        Self.logger.info("APNs token received (prefix=\(hex.prefix(8), privacy: .public))")
         ErrorReportingService.addBreadcrumb(
             category: "push",
             message: "APNs token received",
@@ -239,6 +250,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     }
 
     func handleAPNsRegistrationFailed(_ error: Error) {
+        Self.logger.warning("APNs registration failed: \(error.localizedDescription, privacy: .public)")
         ErrorReportingService.addBreadcrumb(
             category: "push",
             message: "APNs registration failed",
@@ -267,6 +279,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // attempt.
         #if canImport(UIKit) && os(iOS)
         UIApplication.shared.registerForRemoteNotifications()
+        Self.logger.info("Requested registerForRemoteNotifications")
         ErrorReportingService.addBreadcrumb(
             category: "push",
             message: "Requested registerForRemoteNotifications"
@@ -286,19 +299,19 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             await registerIfSignedIn()
             return
         }
-        let lastRegistered = userDefaults.object(forKey: PushDefaults.lastRegisteredAt) as? Date
+        let lastRegistered = Self.readLastRegisteredAt(from: userDefaults)
         let isStale: Bool = {
             guard let lastRegistered else { return true }
             return now().timeIntervalSince(lastRegistered) > PushDefaults.staleInterval
         }()
         guard isStale else { return }
 
+        let ageDays = Int((now().timeIntervalSince(lastRegistered ?? .distantPast)) / 86_400)
+        Self.logger.info("Device token stale (age=\(ageDays, privacy: .public)d), re-registering")
         ErrorReportingService.addBreadcrumb(
             category: "push",
             message: "Device token stale, re-registering",
-            data: [
-                "age_days": Int((now().timeIntervalSince(lastRegistered ?? .distantPast)) / 86_400)
-            ]
+            data: ["age_days": ageDays]
         )
         await postDeviceToken(token)
     }
@@ -314,6 +327,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
         guard token != nil else {
             // Nothing to deregister server-side.
+            Self.logger.info("Sign-out: no cached token to deregister")
             ErrorReportingService.addBreadcrumb(
                 category: "push",
                 message: "Sign-out: no cached token to deregister"
@@ -354,12 +368,16 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         do {
             let (_, response) = try await urlSession.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            Self.logger.info("device_token_deregistered status=\(status)")
             ErrorReportingService.addBreadcrumb(
                 category: "push",
                 message: "device_token_deregistered",
                 data: ["status": status]
             )
         } catch {
+            Self.logger.warning(
+                "device_token_deregister network failure: \(error.localizedDescription, privacy: .public)"
+            )
             ErrorReportingService.addBreadcrumb(
                 category: "push",
                 message: "device_token_deregister network failure",
@@ -367,6 +385,24 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                 data: ["error": error.localizedDescription]
             )
         }
+    }
+
+    /// Reads the persisted `lastRegisteredAt` timestamp. Stored as Int64
+    /// milliseconds (per CLAUDE.md), with a one-time fallback for the legacy
+    /// Date storage shape so an app update doesn't force every device through
+    /// a refresh-then-rewrite cycle. Returns nil when no value is set.
+    private static func readLastRegisteredAt(from userDefaults: UserDefaults) -> Date? {
+        // Modern: Int64 ms.
+        if let raw = userDefaults.object(forKey: PushDefaults.lastRegisteredAt) {
+            if let nsNumber = raw as? NSNumber {
+                return Date(timeIntervalSince1970: nsNumber.doubleValue / 1_000.0)
+            }
+            // Legacy fallback: previous builds wrote NSDate directly.
+            if let date = raw as? Date {
+                return date
+            }
+        }
+        return nil
     }
 
     // MARK: - Dedup bookkeeping
@@ -516,7 +552,10 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             let outcome = await attemptPost(request: request)
             switch outcome {
             case .success(let status):
-                userDefaults.set(now(), forKey: PushDefaults.lastRegisteredAt)
+                // Persist as Int64 milliseconds per CLAUDE.md storage convention.
+                let nowMs = Int64(now().timeIntervalSince1970 * 1_000)
+                userDefaults.set(nowMs, forKey: PushDefaults.lastRegisteredAt)
+                Self.logger.info("device_token_registered status=\(status) attempt=\(attempt)")
                 ErrorReportingService.addBreadcrumb(
                     category: "push",
                     message: "device_token_registered",

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -150,6 +150,11 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// Category-scoped logger matching the pattern in other Dequeue services.
     private static let logger = Logger(subsystem: "com.dequeue", category: "PushNotificationService")
 
+    /// Shared `JSONEncoder` instance. Allocating one per token-registration
+    /// attempt is harmless but wasteful; this class is `@MainActor` so
+    /// sharing a static instance is safe.
+    private static let jsonEncoder = JSONEncoder()
+
     // Dependencies — overridable for tests via the designated init.
     private let urlSession: URLSession
     private let userDefaults: UserDefaults
@@ -347,6 +352,9 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         var request = URLRequest(url: deleteURL)
         request.httpMethod = "DELETE"
         request.timeoutInterval = 10
+        // Align hygiene with the POST handler. The 204 success path has no
+        // body but a non-2xx response may include an error envelope.
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         // Best-effort token fetch — if it fails we still emit telemetry and
         // bail. The next launch will not be able to re-target this device
         // record from the API side, but the server-side reconciler will reap
@@ -387,22 +395,14 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         }
     }
 
-    /// Reads the persisted `lastRegisteredAt` timestamp. Stored as Int64
-    /// milliseconds (per CLAUDE.md), with a one-time fallback for the legacy
-    /// Date storage shape so an app update doesn't force every device through
-    /// a refresh-then-rewrite cycle. Returns nil when no value is set.
+    /// Reads the persisted `lastRegisteredAt` timestamp. Stored as `Int64`
+    /// milliseconds per the CLAUDE.md storage convention. Returns nil when
+    /// no value is set (first launch, sign-out wipe, or wrong type).
     private static func readLastRegisteredAt(from userDefaults: UserDefaults) -> Date? {
-        // Modern: Int64 ms.
-        if let raw = userDefaults.object(forKey: PushDefaults.lastRegisteredAt) {
-            if let nsNumber = raw as? NSNumber {
-                return Date(timeIntervalSince1970: nsNumber.doubleValue / 1_000.0)
-            }
-            // Legacy fallback: previous builds wrote NSDate directly.
-            if let date = raw as? Date {
-                return date
-            }
+        guard let nsNumber = userDefaults.object(forKey: PushDefaults.lastRegisteredAt) as? NSNumber else {
+            return nil
         }
-        return nil
+        return Date(timeIntervalSince1970: nsNumber.doubleValue / 1_000.0)
     }
 
     // MARK: - Dedup bookkeeping
@@ -520,7 +520,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // an all-`String` Encodable. We still surface a defensive telemetry
         // breadcrumb if Swift surprises us.
         do {
-            request.httpBody = try JSONEncoder().encode(body)
+            request.httpBody = try Self.jsonEncoder.encode(body)
         } catch {
             ErrorReportingService.addBreadcrumb(
                 category: "push",

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -82,8 +82,11 @@ protocol PushNotificationServiceProtocol: AnyObject, Sendable {
 /// so we don't carry `Any` across actors (Swift 6 strict concurrency).
 struct SilentPushPayload: Sendable, Equatable {
     let reminderId: String?
-    /// Backend-provided dispatch timestamp in Unix **milliseconds**.
-    let sentAtMs: Double?
+    /// Backend-provided dispatch timestamp in Unix **milliseconds**. Modelled
+    /// as `Int64` to match the project-wide CLAUDE.md timestamp convention.
+    /// Conversion to `Date` happens internally inside `handleSilentPush` by
+    /// dividing by 1_000.0 to land on a Double for `TimeInterval`.
+    let sentAtMs: Int64?
 }
 
 /// Mirror of `UIBackgroundFetchResult` so cross-platform code can model the
@@ -321,7 +324,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // bail. The next launch will not be able to re-target this device
         // record from the API side, but the server-side reconciler will reap
         // stale tokens via APNs 410s.
-        let authToken: String?
+        let authToken: String
         do {
             authToken = try await tokenProvider()
         } catch {
@@ -333,9 +336,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             )
             return
         }
-        if let authToken {
-            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        }
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
 
         do {
             let (_, response) = try await urlSession.data(for: request)
@@ -377,11 +378,12 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     func handleSilentPush(payload: SilentPushPayload) async -> SilentPushResult {
         let reminderId = payload.reminderId
-        // `sent_at` is Unix **milliseconds** per the project-wide CLAUDE.md
-        // convention (matches the dequeue-api wire format). Parsing this as
-        // seconds would yield a Date ~50,000 years in the future and a
-        // wildly negative ageMs.
-        let sentAt = payload.sentAtMs.map { Date(timeIntervalSince1970: $0 / 1_000.0) }
+        // `sentAtMs` carries Unix **milliseconds** per the project-wide
+        // CLAUDE.md convention (matches the dequeue-api wire format). Convert
+        // to a Date by dividing into seconds-since-epoch; parsing it as
+        // seconds directly would yield a Date ~50,000 years in the future
+        // and a wildly negative ageMs.
+        let sentAt = payload.sentAtMs.map { Date(timeIntervalSince1970: Double($0) / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
         // Mark this reminder as remote-delivered so the foreground willPresent
@@ -448,21 +450,24 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             #endif
         }()
 
-        let body: [String: Any] = [
-            "deviceId": deviceId,
-            "token": token,
-            "platform": platform,
-            "environment": environment,
-            "bundleId": Configuration.bundleIdentifier,
-            "appVersion": Configuration.appVersion
-        ]
+        let body = DeviceTokenRegistrationBody(
+            deviceId: deviceId,
+            token: token,
+            platform: platform,
+            environment: environment,
+            bundleId: Configuration.bundleIdentifier,
+            appVersion: Configuration.appVersion
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 15
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // JSONEncoder can only throw `EncodingError`, which is unreachable for
+        // an all-`String` Encodable. We still surface a defensive telemetry
+        // breadcrumb if Swift surprises us.
         do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            request.httpBody = try JSONEncoder().encode(body)
         } catch {
             ErrorReportingService.addBreadcrumb(
                 category: "push",
@@ -473,7 +478,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             return
         }
 
-        let authToken: String?
+        let authToken: String
         do {
             authToken = try await tokenProvider()
         } catch {
@@ -485,9 +490,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             )
             return
         }
-        if let authToken {
-            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        }
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
 
         // One retry on transient 5xx.
         for attempt in 1...2 {
@@ -578,12 +581,10 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     // MARK: - Internal: silent-push REST sync
 
-    /// Internal outcome enum for the silent-push REST sync. Exposed at
-    /// `internal` visibility (not `private`) only because the test target uses
-    /// `@testable import Dequeue` to assert on it directly in
-    /// `testSilentPushSyncTimesOut`. Kept inside the type so callers must go
-    /// through `runSilentPushSync` rather than constructing it themselves.
-    enum SilentSyncOutcome: Sendable, Equatable {
+    /// Internal outcome enum for the silent-push REST sync. Callers go
+    /// through `handleSilentPush` (which maps to `SilentPushResult`); tests
+    /// assert on `SilentPushResult` only.
+    private enum SilentSyncOutcome: Sendable, Equatable {
         case success(fetchedCount: Int)
         case failure(kind: String)
     }
@@ -598,7 +599,11 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// Returns `.failure(kind: "timeout")` if the sync exceeds the supplied
     /// deadline; `.failure(kind: "unavailable")` if the app context hasn't
     /// been wired yet (e.g. very early launch race).
-    func runSilentPushSync(timeout: TimeInterval) async -> SilentSyncOutcome {
+    ///
+    /// Private — callers should go through `handleSilentPush` which uses the
+    /// `silentPushSyncTimeout` injected at init. Tests inject a tiny timeout
+    /// via that init parameter rather than reaching in here directly.
+    private func runSilentPushSync(timeout: TimeInterval) async -> SilentSyncOutcome {
         let syncer: SilentPushSyncing? = silentPushSyncer
             ?? AppContext.shared.syncManager.map(SyncManagerSilentPushAdapter.init)
         guard let syncer else {
@@ -659,41 +664,4 @@ struct SyncManagerSilentPushAdapter: SilentPushSyncing {
     func runRESTProjectionSync() async throws {
         try await syncManager.syncViaProjections()
     }
-}
-
-// MARK: - AppContext
-
-/// Minimal global registry so background callbacks (AppDelegate, push
-/// handlers) can reach the live `SyncManager` and `AuthService` without
-/// threading them through every UIKit shim.
-///
-/// Set during `DequeueApp.init()` after services are constructed.
-@MainActor
-final class AppContext {
-    static let shared = AppContext()
-
-    private(set) var syncManager: SyncManager?
-    private(set) var authService: (any AuthServiceProtocol)?
-    private(set) var pushService: (any PushNotificationServiceProtocol)?
-
-    private init() {}
-
-    func configure(
-        syncManager: SyncManager,
-        authService: any AuthServiceProtocol,
-        pushService: any PushNotificationServiceProtocol
-    ) {
-        self.syncManager = syncManager
-        self.authService = authService
-        self.pushService = pushService
-    }
-
-    /// Test-only reset hook.
-    #if DEBUG
-    func resetForTesting() {
-        syncManager = nil
-        authService = nil
-        pushService = nil
-    }
-    #endif
 }

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -349,7 +349,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // seconds would yield a Date ~50,000 years in the future and a
         // wildly negative ageMs.
         let sentAtRawMs = userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? Double
-            ?? userInfo["sentAt"] as? Double
+            ?? userInfo[NotificationConstants.UserInfoKey.localSentAtMs] as? Double
         let sentAt = sentAtRawMs.map { Date(timeIntervalSince1970: $0 / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
@@ -482,7 +482,16 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                             "attempt": attempt
                         ]
                     )
-                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    // Don't swallow cancellation — if the enclosing task got
+                    // cancelled (e.g. sign-out racing a pending retry), break
+                    // out of the loop cleanly instead of issuing a doomed
+                    // second POST against torn-down credentials.
+                    do {
+                        try await Task.sleep(nanoseconds: 500_000_000)
+                    } catch {
+                        return
+                    }
+                    if Task.isCancelled { return }
                     continue
                 }
                 ErrorReportingService.addBreadcrumb(
@@ -538,6 +547,11 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     // MARK: - Internal: silent-push REST sync
 
+    /// Internal outcome enum for the silent-push REST sync. Exposed at
+    /// `internal` visibility (not `private`) only because the test target uses
+    /// `@testable import Dequeue` to assert on it directly in
+    /// `testSilentPushSyncTimesOut`. Kept inside the type so callers must go
+    /// through `runSilentPushSync` rather than constructing it themselves.
     enum SilentSyncOutcome: Sendable, Equatable {
         case success(fetchedCount: Int)
         case failure(kind: String)
@@ -567,10 +581,15 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                 group.addTask {
                     do {
                         try await syncer.runRESTProjectionSync()
-                        // We don't have a per-call fetched-count yet; surface
-                        // 1 so the OS treats it as fresh data. The detailed
-                        // delivery-reconciliation telemetry lives in
-                        // ErrorReportingService breadcrumbs.
+                        // We surface `fetchedCount: 1` so `handleSilentPush`
+                        // maps to `UIBackgroundFetchResult.newData`. Returning
+                        // `.noData` here would over time deprioritise the
+                        // app's silent-push wake budget, and the projection
+                        // sync API does not yet return a per-call fetched
+                        // count. Refining this to a true fetched-count
+                        // (and emitting `.noData` when zero events were
+                        // applied) is the follow-up tracked in DEQ-286
+                        // (delivery-reconciliation telemetry).
                         return .success(fetchedCount: 1)
                     } catch {
                         return .failure(kind: "sync_error")

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -111,6 +111,8 @@ private enum PushDefaults {
     /// handler before the system kills us.
     nonisolated static let silentPushSyncTimeout: TimeInterval = 20
     nonisolated static let registerEndpointPath = "/devices/push-token"
+    /// Backoff between the original POST and its retry on transient 5xx.
+    nonisolated static let tokenRegisterRetryDelay: TimeInterval = 0.5
 }
 
 // MARK: - Wire bodies
@@ -160,6 +162,11 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// (20s); tests inject a much smaller value to keep the timeout path fast.
     private let silentPushSyncTimeout: TimeInterval
 
+    /// Backoff between the original POST and its retry on transient 5xx.
+    /// Production uses `PushDefaults.tokenRegisterRetryDelay` (500ms); tests
+    /// inject `0` so the retry test doesn't sleep for half a second.
+    private let tokenRegisterRetryDelay: TimeInterval
+
     private(set) var cachedDeviceToken: String?
 
     /// Designated init. Defaults wire production paths; tests use this same
@@ -173,6 +180,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         isAuthenticatedProvider: (@MainActor () -> Bool)? = nil,
         silentPushSyncer: SilentPushSyncing? = nil,
         silentPushSyncTimeout: TimeInterval = PushDefaults.silentPushSyncTimeout,
+        tokenRegisterRetryDelay: TimeInterval = PushDefaults.tokenRegisterRetryDelay,
         now: (@Sendable () -> Date)? = nil
     ) {
         // Resolve defaults inside the init so the closure literals don't need
@@ -199,6 +207,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         self.isAuthenticatedProvider = resolvedIsAuthenticated
         self.silentPushSyncer = silentPushSyncer
         self.silentPushSyncTimeout = silentPushSyncTimeout
+        self.tokenRegisterRetryDelay = tokenRegisterRetryDelay
         self.now = resolvedNow
         self.cachedDeviceToken = userDefaults.string(forKey: PushDefaults.cachedToken)
         // Keep the dedup cache modest — we only need the last few seconds of
@@ -521,11 +530,17 @@ final class PushNotificationService: PushNotificationServiceProtocol {
                     // Don't swallow cancellation — if the enclosing task got
                     // cancelled (e.g. sign-out racing a pending retry), break
                     // out of the loop cleanly instead of issuing a doomed
-                    // second POST against torn-down credentials.
-                    do {
-                        try await Task.sleep(nanoseconds: 500_000_000)
-                    } catch {
-                        return
+                    // second POST against torn-down credentials. Backoff is
+                    // injectable so tests can short-circuit it (default 500ms
+                    // in production).
+                    if tokenRegisterRetryDelay > 0 {
+                        do {
+                            try await Task.sleep(
+                                nanoseconds: UInt64(tokenRegisterRetryDelay * 1_000_000_000)
+                            )
+                        } catch {
+                            return
+                        }
                     }
                     if Task.isCancelled { return }
                     continue

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -32,9 +32,6 @@ protocol PushNotificationServiceProtocol: AnyObject, Sendable {
     /// Cached device token (hex string), if registered with APNs.
     var cachedDeviceToken: String? { get }
 
-    /// Whether registration is currently pending the OS callback.
-    var isRegistering: Bool { get }
-
     /// Apple-callback entry: stash the raw token, then POST to the API.
     /// Idempotent — subsequent calls with the same token re-POST to refresh
     /// `last_seen_at` on the server.
@@ -122,8 +119,13 @@ final class PushNotificationService: PushNotificationServiceProtocol {
     /// actor hop (NSCache is documented thread-safe).
     nonisolated(unsafe) private let recentRemotes = NSCache<NSString, NSDate>()
 
+    /// Optional override for the live SyncManager. When nil we resolve via
+    /// `AppContext.shared.syncManager` at call time. The protocol-level type
+    /// erasure is intentional — tests inject a stub conforming to
+    /// `SilentPushSyncing` without dragging in the full SyncManager surface.
+    private let silentPushSyncer: SilentPushSyncing?
+
     private(set) var cachedDeviceToken: String?
-    private(set) var isRegistering: Bool = false
 
     /// Designated init. Defaults wire production paths; tests use this same
     /// init with their own URLSession / providers.
@@ -134,6 +136,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         tokenProvider: (@MainActor () async throws -> String)? = nil,
         deviceIdProvider: (@Sendable () async -> String)? = nil,
         isAuthenticatedProvider: (@MainActor () -> Bool)? = nil,
+        silentPushSyncer: SilentPushSyncing? = nil,
         now: (@Sendable () -> Date)? = nil
     ) {
         // Resolve defaults inside the init so the closure literals don't need
@@ -154,6 +157,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         self.tokenProvider = resolvedTokenProvider
         self.deviceIdProvider = resolvedDeviceIdProvider
         self.isAuthenticatedProvider = resolvedIsAuthenticated
+        self.silentPushSyncer = silentPushSyncer
         self.now = resolvedNow
         self.cachedDeviceToken = userDefaults.string(forKey: PushDefaults.cachedToken)
         // Keep the dedup cache modest — we only need the last few seconds of
@@ -201,10 +205,12 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             )
             return
         }
-        guard !isRegistering else { return }
-        isRegistering = true
-        defer { isRegistering = false }
 
+        // Apple's `registerForRemoteNotifications` is itself idempotent and
+        // it's intended to be called freely on launch / re-auth / etc., so we
+        // don't need a local re-entrancy guard here. The OS will only emit
+        // one `didRegisterForRemoteNotifications...` callback per provisioning
+        // attempt.
         #if canImport(UIKit) && os(iOS)
         UIApplication.shared.registerForRemoteNotifications()
         ErrorReportingService.addBreadcrumb(
@@ -315,13 +321,13 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     nonisolated func markRemoteDelivered(reminderId: String) {
         let key = reminderId as NSString
-        recentRemotes.setObject(Date() as NSDate, forKey: key)
+        recentRemotes.setObject(now() as NSDate, forKey: key)
     }
 
     nonisolated func isRemoteRecentlyDelivered(reminderId: String) -> Bool {
         let key = reminderId as NSString
         guard let date = recentRemotes.object(forKey: key) as Date? else { return false }
-        let elapsed = Date().timeIntervalSince(date)
+        let elapsed = now().timeIntervalSince(date)
         if elapsed > PushDefaults.dedupWindow {
             recentRemotes.removeObject(forKey: key)
             return false
@@ -333,9 +339,18 @@ final class PushNotificationService: PushNotificationServiceProtocol {
 
     func handleSilentPush(userInfo: [AnyHashable: Any]) async -> SilentPushResult {
         // Extract telemetry props before we kick the sync — Sendable types only.
-        let reminderId = userInfo["reminder_id"] as? String ?? userInfo["reminderId"] as? String
-        let sentAtRaw = userInfo["sentAt"] as? Double ?? userInfo["sent_at"] as? Double
-        let sentAt = sentAtRaw.map { Date(timeIntervalSince1970: $0) }
+        // Backend (PR 3, dequeue-api#201) emits snake_case keys; we also accept
+        // the local camelCase spelling for symmetry with the local-notification
+        // userInfo dictionaries we control on this side.
+        let reminderId = (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
+            ?? (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
+        // `sent_at` is Unix **milliseconds** per the project-wide CLAUDE.md
+        // convention (matches the dequeue-api wire format). Parsing this as
+        // seconds would yield a Date ~50,000 years in the future and a
+        // wildly negative ageMs.
+        let sentAtRawMs = userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? Double
+            ?? userInfo["sentAt"] as? Double
+        let sentAt = sentAtRawMs.map { Date(timeIntervalSince1970: $0 / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
         // Mark this reminder as remote-delivered so the foreground willPresent
@@ -354,9 +369,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         )
 
         let syncStart = now()
-        let result = await Self.runSilentPushSync(
-            timeout: PushDefaults.silentPushSyncTimeout
-        )
+        let result = await runSilentPushSync(timeout: PushDefaults.silentPushSyncTimeout)
         let durationMs = Int(now().timeIntervalSince(syncStart) * 1_000)
 
         switch result {
@@ -530,17 +543,20 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         case failure(kind: String)
     }
 
-    /// Kicks off a single REST-only projection sync via the live `SyncManager`
-    /// resolved through the app environment. We intentionally do NOT establish
-    /// a WebSocket — TCP handshake + WebSocket upgrade is slower than the 20s
-    /// silent-push budget, and Apple kills the process if we miss it.
+    /// Kicks off a single REST-only projection sync via the injected
+    /// `silentPushSyncer` (or the live `SyncManager` resolved through the app
+    /// environment when no override is provided). We intentionally do NOT
+    /// establish a WebSocket — TCP handshake + WebSocket upgrade is slower
+    /// than the 20s silent-push budget, and Apple kills the process if we
+    /// miss it.
     ///
-    /// Falls back to `.failure(kind: "timeout")` if the sync exceeds the
-    /// supplied deadline. Falls back to `.failure(kind: "unavailable")` if the
-    /// app context hasn't been wired yet (e.g. very early launch race).
-    static func runSilentPushSync(timeout: TimeInterval) async -> SilentSyncOutcome {
-        let syncManager = await MainActor.run { AppContext.shared.syncManager }
-        guard let syncManager else {
+    /// Returns `.failure(kind: "timeout")` if the sync exceeds the supplied
+    /// deadline; `.failure(kind: "unavailable")` if the app context hasn't
+    /// been wired yet (e.g. very early launch race).
+    func runSilentPushSync(timeout: TimeInterval) async -> SilentSyncOutcome {
+        let syncer: SilentPushSyncing? = silentPushSyncer
+            ?? AppContext.shared.syncManager.map(SyncManagerSilentPushAdapter.init)
+        guard let syncer else {
             return .failure(kind: "unavailable")
         }
 
@@ -550,7 +566,7 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             result = try await withThrowingTaskGroup(of: SilentSyncOutcome.self) { group in
                 group.addTask {
                     do {
-                        try await syncManager.syncViaProjections()
+                        try await syncer.runRESTProjectionSync()
                         // We don't have a per-call fetched-count yet; surface
                         // 1 so the OS treats it as fresh data. The detailed
                         // delivery-reconciliation telemetry lives in
@@ -574,6 +590,24 @@ final class PushNotificationService: PushNotificationServiceProtocol {
             return .failure(kind: "task_group_error")
         }
         return result
+    }
+}
+
+// MARK: - Silent-push sync abstraction
+
+/// Minimal protocol the silent-push handler relies on. Decouples
+/// `PushNotificationService` from the full `SyncManager` surface so tests
+/// can supply a fake without staging the entire sync stack.
+protocol SilentPushSyncing: Sendable {
+    func runRESTProjectionSync() async throws
+}
+
+/// Production adapter that bridges `SyncManager.syncViaProjections()` to the
+/// silent-push protocol. Sendable because `SyncManager` is itself an actor.
+struct SyncManagerSilentPushAdapter: SilentPushSyncing {
+    let syncManager: SyncManager
+    func runRESTProjectionSync() async throws {
+        try await syncManager.syncViaProjections()
     }
 }
 

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -110,7 +110,11 @@ private enum PushDefaults {
     /// leave ourselves 10s of head room so we always call the completion
     /// handler before the system kills us.
     nonisolated static let silentPushSyncTimeout: TimeInterval = 20
-    nonisolated static let registerEndpointPath = "/devices/push-token"
+    /// Path component appended to `dequeueAPIBaseURL` for the device-token
+    /// endpoint. No leading slash: `URL.appendingPathComponent` normalises
+    /// a leading slash anyway, but omitting it is conventional and avoids
+    /// mental overhead at the call site.
+    nonisolated static let registerEndpointPath = "devices/push-token"
     /// Backoff between the original POST and its retry on transient 5xx.
     nonisolated static let tokenRegisterRetryDelay: TimeInterval = 0.5
 }
@@ -395,8 +399,14 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         let sentAt = payload.sentAtMs.map { Date(timeIntervalSince1970: Double($0) / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
-        // Mark this reminder as remote-delivered so the foreground willPresent
-        // delegate can suppress the local twin if it lands within 60s.
+        // Mark this reminder as remote-delivered up front — BEFORE we know
+        // the sync outcome. The dedup cache only gates the *local-first*
+        // branch of `NotificationService.willPresent`; remote notifications
+        // (including the alert push that follows this silent push at
+        // remindAt) always display via the remote-first branch regardless
+        // of cache contents. So this early stamp can only ever suppress a
+        // duplicate local twin, never the alert push itself, even if the
+        // sync below fails or times out.
         if let reminderId {
             markRemoteDelivered(reminderId: reminderId)
         }

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -399,17 +399,15 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         let sentAt = payload.sentAtMs.map { Date(timeIntervalSince1970: Double($0) / 1_000.0) }
         let ageMs: Int? = sentAt.map { Int(now().timeIntervalSince($0) * 1_000) }
 
-        // Mark this reminder as remote-delivered up front — BEFORE we know
-        // the sync outcome. The dedup cache only gates the *local-first*
-        // branch of `NotificationService.willPresent`; remote notifications
-        // (including the alert push that follows this silent push at
-        // remindAt) always display via the remote-first branch regardless
-        // of cache contents. So this early stamp can only ever suppress a
-        // duplicate local twin, never the alert push itself, even if the
-        // sync below fails or times out.
-        if let reminderId {
-            markRemoteDelivered(reminderId: reminderId)
-        }
+        // Intentionally do NOT stamp the dedup cache here. The silent push
+        // arrives at remindAt-30s but the *alert* push at remindAt is the
+        // event that should suppress a local twin. If APNs fails to deliver
+        // the alert push (transient outage), stamping the cache on silent-push
+        // receipt would still suppress the local fallback and the user would
+        // miss the reminder entirely. `NotificationService.willPresent`
+        // already calls `markRemoteDelivered` from path 1 (remote-first)
+        // when the alert push is actually being presented, which is the
+        // correct moment to start the 60s suppression window.
 
         ErrorReportingService.addBreadcrumb(
             category: "push",

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -437,11 +437,14 @@ struct PushNotificationServiceTests {
     @MainActor
     func refreshTokenIfStaleNoopWhenSignedOut() async throws {
         let env = TestEnv()
-        let service = env.makeService(isAuthenticatedProvider: { false })
-        // Even if we'd previously cached a token + a stale timestamp, refresh
-        // should bail when the auth provider says we're signed out.
+        // Pre-populate the suite so a service built later with
+        // `isAuthenticatedProvider: { false }` reads the cached token but
+        // still bails on the auth guard. This exercises the guard at the
+        // top of `refreshTokenIfStale` even when local state otherwise
+        // looks ready to refresh.
         env.defaults.set("cached-old", forKey: "dequeue.push.cachedToken")
         env.defaults.set(Date.distantPast, forKey: "dequeue.push.lastRegisteredAt")
+        let service = env.makeService(isAuthenticatedProvider: { false })
 
         await service.refreshTokenIfStale()
 

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -360,16 +360,34 @@ struct PushNotificationServiceTests {
         #expect(result == .failed)
     }
 
-    @Test("Missing reminder_id in payload is handled gracefully")
+    @Test("nil reminderId leaves no side-effects in the dedup cache")
     @MainActor
-    func missingReminderIdIsHandledGracefully() async throws {
+    func nilReminderIdNoDedupCacheSideEffects() async throws {
         let env = TestEnv()
-        // No silentPushSyncer + AppContext unconfigured → handleSilentPush
-        // surfaces .failed (kind: "unavailable") without crashing on the
-        // missing reminder_id.
-        let service = env.makeService()
+        let syncer = FakeSyncer(behavior: .success)
+        let service = env.makeService(silentPushSyncer: syncer)
+
         let result = await service.handleSilentPush(
             payload: SilentPushPayload(reminderId: nil, sentAtMs: nil)
+        )
+
+        // Sync still ran (the silent push wakes us regardless of payload).
+        #expect(result == .newData)
+        #expect(syncer.callCount == 1)
+        // No reminderId was supplied, so nothing should have been stamped
+        // into the dedup cache.
+        #expect(!service.isRemoteRecentlyDelivered(reminderId: ""))
+    }
+
+    @Test("Unavailable syncer surfaces .failed cleanly")
+    @MainActor
+    func unavailableSyncerReturnsFailed() async throws {
+        let env = TestEnv()
+        // No injected syncer + AppContext not wired in tests → service falls
+        // through to .failure(kind: "unavailable") which maps to .failed.
+        let service = env.makeService()
+        let result = await service.handleSilentPush(
+            payload: SilentPushPayload(reminderId: "rem-1", sentAtMs: nil)
         )
         #expect(result == .failed)
     }

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -322,7 +322,7 @@ struct PushNotificationServiceTests {
         let service = env.makeService(silentPushSyncer: syncer)
 
         let result = await service.handleSilentPush(
-            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+            payload: SilentPushPayload(reminderId: "rem-1", sentAtMs: nil)
         )
 
         #expect(result == .newData)
@@ -338,37 +338,84 @@ struct PushNotificationServiceTests {
         let service = env.makeService(silentPushSyncer: syncer)
 
         let result = await service.handleSilentPush(
-            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+            payload: SilentPushPayload(reminderId: "rem-1", sentAtMs: nil)
         )
 
         #expect(result == .failed)
     }
 
-    @Test("Silent-push sync timeout surfaces .failure(kind: timeout)")
+    @Test("Silent-push sync timeout surfaces .failed via tiny injected timeout")
     @MainActor
     func silentPushSyncTimesOut() async throws {
         let env = TestEnv()
         let syncer = FakeSyncer(behavior: .hang)
-        let service = env.makeService(silentPushSyncer: syncer)
+        // Inject a tiny timeout via init so we exercise the timeout path
+        // through `handleSilentPush` rather than poking at internals.
+        let service = env.makeService(silentPushSyncer: syncer, silentPushSyncTimeout: 0.2)
 
-        // Use a tiny custom timeout via the underlying runSilentPushSync to
-        // keep the test fast; handleSilentPush always uses the production
-        // 20s value so we exercise runSilentPushSync directly.
-        let outcome = await service.runSilentPushSync(timeout: 0.2)
+        let result = await service.handleSilentPush(
+            payload: SilentPushPayload(reminderId: "rem-1", sentAtMs: nil)
+        )
 
-        #expect(outcome == .failure(kind: "timeout"))
+        #expect(result == .failed)
     }
 
-    @Test("Missing reminder_id in userInfo is handled gracefully")
+    @Test("Missing reminder_id in payload is handled gracefully")
     @MainActor
-    func missingReminderIdInUserInfoIsHandledGracefully() async throws {
+    func missingReminderIdIsHandledGracefully() async throws {
         let env = TestEnv()
         // No silentPushSyncer + AppContext unconfigured → handleSilentPush
         // surfaces .failed (kind: "unavailable") without crashing on the
         // missing reminder_id.
         let service = env.makeService()
-        let result = await service.handleSilentPush(userInfo: ["other": "junk"])
+        let result = await service.handleSilentPush(
+            payload: SilentPushPayload(reminderId: nil, sentAtMs: nil)
+        )
         #expect(result == .failed)
+    }
+
+    // MARK: Coverage gap fills
+
+    @Test("handleAPNsRegistrationFailed emits telemetry without throwing")
+    @MainActor
+    func handleAPNsRegistrationFailedDoesNotThrow() async throws {
+        let env = TestEnv()
+        let service = env.makeService()
+        // Should not crash, should not change cached state.
+        service.handleAPNsRegistrationFailed(URLError(.notConnectedToInternet))
+        #expect(service.cachedDeviceToken == nil)
+    }
+
+    @Test("refreshTokenIfStale is a no-op when not authenticated")
+    @MainActor
+    func refreshTokenIfStaleNoopWhenSignedOut() async throws {
+        let env = TestEnv()
+        let service = env.makeService(isAuthenticatedProvider: { false })
+        // Even if we'd previously cached a token + a stale timestamp, refresh
+        // should bail when the auth provider says we're signed out.
+        env.defaults.set("cached-old", forKey: "dequeue.push.cachedToken")
+        env.defaults.set(Date.distantPast, forKey: "dequeue.push.lastRegisteredAt")
+
+        await service.refreshTokenIfStale()
+
+        let posts = StubURLProtocol.requests.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+    }
+
+    @Test("refreshTokenIfStale falls through to registerIfSignedIn when no cached token")
+    @MainActor
+    func refreshTokenIfStaleFallsThroughToRegister() async throws {
+        let env = TestEnv()
+        // Authenticated but no token cached locally yet. Should hit the
+        // `registerIfSignedIn` path (which on non-iOS test runners is a
+        // breadcrumb-only no-op — the OS callback path isn't reachable from
+        // unit tests). Critically: should not POST anything yet.
+        let service = env.makeService()
+        await service.refreshTokenIfStale()
+
+        let posts = StubURLProtocol.requests.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        #expect(service.cachedDeviceToken == nil)
     }
 }
 
@@ -400,7 +447,9 @@ private final class TestEnv {
     func makeService(
         tokenProvider: @MainActor @escaping () async throws -> String = { "test-token" },
         deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" },
+        isAuthenticatedProvider: @MainActor @escaping () -> Bool = { true },
         silentPushSyncer: SilentPushSyncing? = nil,
+        silentPushSyncTimeout: TimeInterval = 1.0,
         now: @Sendable @escaping () -> Date = { Date() }
     ) -> PushNotificationService {
         PushNotificationService(
@@ -409,8 +458,9 @@ private final class TestEnv {
             baseURLProvider: { URL(string: "https://api.test.dequeue.app/v1")! },
             tokenProvider: tokenProvider,
             deviceIdProvider: deviceIdProvider,
-            isAuthenticatedProvider: { true },
+            isAuthenticatedProvider: isAuthenticatedProvider,
             silentPushSyncer: silentPushSyncer,
+            silentPushSyncTimeout: silentPushSyncTimeout,
             now: now
         )
     }

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -9,6 +9,7 @@
 //
 
 import XCTest
+import os
 @testable import Dequeue
 
 // MARK: - Stub URLProtocol (no real network)
@@ -81,13 +82,14 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 @MainActor
 final class PushNotificationServiceTests: XCTestCase {
     private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
     private var session: URLSession!
 
     override func setUp() async throws {
         try await super.setUp()
         // Use a clean, ephemeral UserDefaults suite so tests don't leak state.
-        let suiteName = "PushNotificationServiceTests-\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suiteName)!
+        defaultsSuiteName = "PushNotificationServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
@@ -96,7 +98,9 @@ final class PushNotificationServiceTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
+        // Tear down the ephemeral defaults suite by its suite NAME (not by
+        // some key inside it) so subsequent tests can't see stale values.
+        UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
         StubURLProtocol.reset()
         try await super.tearDown()
     }
@@ -268,18 +272,62 @@ final class PushNotificationServiceTests: XCTestCase {
     }
 
     func testRemoteDeliveryWindowExpires() async throws {
-        // Use a service whose `now` we can control via the in-memory NSCache;
-        // we test the window by writing into the NSCache directly through the
-        // service then mutating its bookkeeping via reflection-free path: we
-        // re-stamp by calling `markRemoteDelivered` with an old Date through
-        // a custom subclass. Simplest approach: the production cache stores a
-        // wall-clock Date; we can verify the within-window path here and
-        // trust that the >60s branch removes the entry. The threshold logic
-        // is straightforward (Date subtraction); the contract under test is
-        // "exact match returns true while inside the window".
-        let service = makeService()
-        service.markRemoteDelivered(reminderId: "rem-window")
-        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-window"))
+        // Use the injected clock to fast-forward past the 60s dedup window.
+        // After expiry the entry should be cleaned out of the NSCache and
+        // subsequent lookups must return false. `FakeClock` is a Sendable
+        // box around an OSAllocatedUnfairLock so the closure captured by
+        // PushNotificationService stays Sendable under Swift 6.
+        let clock = FakeClock(start: Date())
+        let service = makeService(now: { clock.now() })
+
+        service.markRemoteDelivered(reminderId: "rem-expire")
+        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+
+        // Inside the window.
+        clock.advance(by: 45)
+        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+
+        // Past the window — expired entry should be evicted.
+        clock.advance(by: 20) // total 65s
+        XCTAssertFalse(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+    }
+
+    // MARK: Silent push sync
+
+    func testSilentPushSyncSuccessReturnsNewData() async throws {
+        let syncer = FakeSyncer(behavior: .success)
+        let service = makeService(silentPushSyncer: syncer)
+
+        let result = await service.handleSilentPush(
+            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+        )
+
+        XCTAssertEqual(result, .newData)
+        XCTAssertEqual(syncer.callCount, 1)
+        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
+    }
+
+    func testSilentPushSyncErrorReturnsFailed() async throws {
+        let syncer = FakeSyncer(behavior: .error)
+        let service = makeService(silentPushSyncer: syncer)
+
+        let result = await service.handleSilentPush(
+            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+        )
+
+        XCTAssertEqual(result, .failed)
+    }
+
+    func testSilentPushSyncTimesOut() async throws {
+        let syncer = FakeSyncer(behavior: .hang)
+        let service = makeService(silentPushSyncer: syncer)
+
+        // Use a tiny custom timeout via the underlying runSilentPushSync to
+        // keep the test fast; handleSilentPush always uses the production
+        // 20s value so we exercise runSilentPushSync directly.
+        let outcome = await service.runSilentPushSync(timeout: 0.2)
+
+        XCTAssertEqual(outcome, .failure(kind: "timeout"))
     }
 
     func testMissingReminderIdInUserInfoIsHandledGracefully() async throws {
@@ -295,7 +343,9 @@ final class PushNotificationServiceTests: XCTestCase {
 
     private func makeService(
         tokenProvider: @MainActor @escaping () async throws -> String = { "test-token" },
-        deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" }
+        deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" },
+        silentPushSyncer: SilentPushSyncing? = nil,
+        now: @Sendable @escaping () -> Date = { Date() }
     ) -> PushNotificationService {
         PushNotificationService(
             urlSession: session,
@@ -304,7 +354,61 @@ final class PushNotificationServiceTests: XCTestCase {
             tokenProvider: tokenProvider,
             deviceIdProvider: deviceIdProvider,
             isAuthenticatedProvider: { true },
-            now: { Date() }
+            silentPushSyncer: silentPushSyncer,
+            now: now
         )
+    }
+}
+
+// MARK: - FakeClock
+
+/// Sendable, lock-backed mutable clock for tests. Use via the `now()` closure
+/// passed into `PushNotificationService`. Uses `OSAllocatedUnfairLock` so the
+/// closure can be called from both sync and async contexts under Swift 6.
+final class FakeClock: @unchecked Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: Date.distantPast)
+
+    init(start: Date) { storage.withLock { $0 = start } }
+
+    func now() -> Date { storage.withLock { $0 } }
+
+    func advance(by interval: TimeInterval) {
+        storage.withLock { $0.addTimeInterval(interval) }
+    }
+}
+
+// MARK: - FakeSyncer
+
+/// Test-only `SilentPushSyncing` implementation. Records call count and
+/// dispatches the requested behaviour (success / throwing / hang-until-cancel).
+final class FakeSyncer: SilentPushSyncing, @unchecked Sendable {
+    enum Behavior: Sendable {
+        case success
+        case error
+        case hang
+    }
+
+    private let behavior: Behavior
+    private let counter = OSAllocatedUnfairLock(initialState: 0)
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    var callCount: Int { counter.withLock { $0 } }
+
+    func runRESTProjectionSync() async throws {
+        counter.withLock { $0 += 1 }
+        switch behavior {
+        case .success:
+            return
+        case .error:
+            throw URLError(.timedOut)
+        case .hang:
+            // Sleep beyond any reasonable timeout. Cancellation propagates
+            // from the parent task group so we surrender promptly when the
+            // timeout sibling wins.
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        }
     }
 }

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -5,10 +5,11 @@
 //  Tests for the iOS-side push notification pipeline (DEQ-283):
 //   • Device-token register / deregister, including 1-retry on transient 5xx.
 //   • Local-vs-remote dedup bookkeeping (60s NSCache window).
-//   • Silent-push handler timeout behaviour.
+//   • Silent-push handler success / failure / timeout paths.
 //
 
-import XCTest
+import Testing
+import Foundation
 import os
 @testable import Dequeue
 
@@ -77,290 +78,7 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
     override func stopLoading() {}
 }
 
-// MARK: - Tests
-
-@MainActor
-final class PushNotificationServiceTests: XCTestCase {
-    private var defaults: UserDefaults!
-    private var defaultsSuiteName: String!
-    private var session: URLSession!
-
-    override func setUp() async throws {
-        try await super.setUp()
-        // Use a clean, ephemeral UserDefaults suite so tests don't leak state.
-        defaultsSuiteName = "PushNotificationServiceTests-\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: defaultsSuiteName)!
-
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [StubURLProtocol.self]
-        session = URLSession(configuration: config)
-        StubURLProtocol.reset()
-    }
-
-    override func tearDown() async throws {
-        // Tear down the ephemeral defaults suite by its suite NAME (not by
-        // some key inside it) so subsequent tests can't see stale values.
-        UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
-        StubURLProtocol.reset()
-        try await super.tearDown()
-    }
-
-    // MARK: Token registration
-
-    func testTokenRegistrationPersistsAndPostsToAPI() async throws {
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-abc" }
-        )
-
-        let tokenBytes = Data([0xab, 0xcd, 0xef, 0x01, 0x02, 0x03])
-        await service.handleAPNsTokenRegistered(tokenBytes)
-
-        XCTAssertEqual(service.cachedDeviceToken, "abcdef010203")
-        // last_registered_at should be set after a successful POST.
-        XCTAssertNotNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
-
-        let requests = StubURLProtocol.requests.filter { $0.method == "POST" }
-        XCTAssertEqual(requests.count, 1, "Should POST once on first register")
-        XCTAssertTrue(requests[0].url.absoluteString.contains("/devices/push-token"))
-    }
-
-    func testTokenRegistrationRetriesOnceOnTransient5xx() async throws {
-        // First attempt 503, second attempt 200.
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-xyz" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0x01, 0x02]))
-
-        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(postCount, 2, "Should retry once then succeed")
-        XCTAssertNotNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
-    }
-
-    func testTokenRegistrationDoesNotRetryOn400() async throws {
-        // 400 is permanent — no retry, no last_registered_at write.
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 400))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-xyz" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0x01]))
-
-        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(postCount, 1, "Permanent failure should not retry")
-        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
-    }
-
-    func testTokenRegistrationDoesNotBlockOnRepeatedFailure() async throws {
-        // Both attempts fail with 503 — service must telemetry-only and return.
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-xyz" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0x01]))
-
-        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(postCount, 2, "Should attempt original + 1 retry")
-        // Token still cached locally even though server didn't ack — next launch
-        // will re-attempt.
-        XCTAssertEqual(service.cachedDeviceToken, "01")
-        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
-    }
-
-    // MARK: Deregister
-
-    func testDeregisterIssuesDeleteAndClearsLocalState() async throws {
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-        StubURLProtocol.enqueue(method: "DELETE", response: .init(statusCode: 204))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-zzz" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0xfa]))
-        XCTAssertEqual(service.cachedDeviceToken, "fa")
-
-        await service.deregisterOnSignOut()
-
-        XCTAssertNil(service.cachedDeviceToken)
-        XCTAssertNil(defaults.object(forKey: "dequeue.push.cachedToken"))
-        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
-
-        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
-        XCTAssertEqual(deletes.count, 1)
-        XCTAssertTrue(deletes[0].url.absoluteString.contains("deviceId=device-zzz"))
-    }
-
-    func testDeregisterIsNoopWhenNoTokenCached() async throws {
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-zzz" }
-        )
-
-        await service.deregisterOnSignOut()
-
-        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
-        XCTAssertEqual(deletes.count, 0, "Should not issue DELETE if no token cached")
-    }
-
-    // MARK: Stale-token refresh
-
-    func testRefreshTokenIfStaleSkipsWhenFresh() async throws {
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-fresh" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0x12]))
-        // Drain the post count.
-        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(baseline, 1)
-
-        // No additional canned response: if it tried to POST, it'd get default 200,
-        // which would also increment requests.
-        await service.refreshTokenIfStale()
-
-        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(afterRefresh, baseline, "Fresh token should not re-POST")
-    }
-
-    func testRefreshTokenIfStaleRepostsWhenStale() async throws {
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-
-        let service = makeService(
-            tokenProvider: { "bearer-token" },
-            deviceIdProvider: { "device-stale" }
-        )
-
-        await service.handleAPNsTokenRegistered(Data([0x99]))
-        // Backdate last_registered_at to 10 days ago.
-        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
-        defaults.set(tenDaysAgo, forKey: "dequeue.push.lastRegisteredAt")
-        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-
-        // Queue another 200 response for the refresh POST.
-        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
-        await service.refreshTokenIfStale()
-
-        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
-        XCTAssertEqual(afterRefresh, baseline + 1, "Stale token should trigger one re-POST")
-    }
-
-    // MARK: Dedup bookkeeping
-
-    func testRemoteDeliveryWithinWindowIsRecognized() async throws {
-        let service = makeService()
-
-        service.markRemoteDelivered(reminderId: "rem-1")
-        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
-        XCTAssertFalse(service.isRemoteRecentlyDelivered(reminderId: "rem-2"))
-    }
-
-    func testRemoteDeliveryWindowExpires() async throws {
-        // Use the injected clock to fast-forward past the 60s dedup window.
-        // After expiry the entry should be cleaned out of the NSCache and
-        // subsequent lookups must return false. `FakeClock` is a Sendable
-        // box around an OSAllocatedUnfairLock so the closure captured by
-        // PushNotificationService stays Sendable under Swift 6.
-        let clock = FakeClock(start: Date())
-        let service = makeService(now: { clock.now() })
-
-        service.markRemoteDelivered(reminderId: "rem-expire")
-        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
-
-        // Inside the window.
-        clock.advance(by: 45)
-        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
-
-        // Past the window — expired entry should be evicted.
-        clock.advance(by: 20) // total 65s
-        XCTAssertFalse(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
-    }
-
-    // MARK: Silent push sync
-
-    func testSilentPushSyncSuccessReturnsNewData() async throws {
-        let syncer = FakeSyncer(behavior: .success)
-        let service = makeService(silentPushSyncer: syncer)
-
-        let result = await service.handleSilentPush(
-            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
-        )
-
-        XCTAssertEqual(result, .newData)
-        XCTAssertEqual(syncer.callCount, 1)
-        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
-    }
-
-    func testSilentPushSyncErrorReturnsFailed() async throws {
-        let syncer = FakeSyncer(behavior: .error)
-        let service = makeService(silentPushSyncer: syncer)
-
-        let result = await service.handleSilentPush(
-            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
-        )
-
-        XCTAssertEqual(result, .failed)
-    }
-
-    func testSilentPushSyncTimesOut() async throws {
-        let syncer = FakeSyncer(behavior: .hang)
-        let service = makeService(silentPushSyncer: syncer)
-
-        // Use a tiny custom timeout via the underlying runSilentPushSync to
-        // keep the test fast; handleSilentPush always uses the production
-        // 20s value so we exercise runSilentPushSync directly.
-        let outcome = await service.runSilentPushSync(timeout: 0.2)
-
-        XCTAssertEqual(outcome, .failure(kind: "timeout"))
-    }
-
-    func testMissingReminderIdInUserInfoIsHandledGracefully() async throws {
-        // No reminder_id: handleSilentPush should still complete with .failed
-        // (no sync manager wired) rather than crash on optional unwrap.
-        let service = makeService()
-        let result = await service.handleSilentPush(userInfo: ["other": "junk"])
-        // AppContext is not configured in test → silent sync returns .failed.
-        XCTAssertEqual(result, .failed)
-    }
-
-    // MARK: Helpers
-
-    private func makeService(
-        tokenProvider: @MainActor @escaping () async throws -> String = { "test-token" },
-        deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" },
-        silentPushSyncer: SilentPushSyncing? = nil,
-        now: @Sendable @escaping () -> Date = { Date() }
-    ) -> PushNotificationService {
-        PushNotificationService(
-            urlSession: session,
-            userDefaults: defaults,
-            baseURLProvider: { URL(string: "https://api.test.dequeue.app/v1")! },
-            tokenProvider: tokenProvider,
-            deviceIdProvider: deviceIdProvider,
-            isAuthenticatedProvider: { true },
-            silentPushSyncer: silentPushSyncer,
-            now: now
-        )
-    }
-}
-
-// MARK: - FakeClock
+// MARK: - Test helpers
 
 /// Sendable, lock-backed mutable clock for tests. Use via the `now()` closure
 /// passed into `PushNotificationService`. Uses `OSAllocatedUnfairLock` so the
@@ -376,8 +94,6 @@ final class FakeClock: @unchecked Sendable {
         storage.withLock { $0.addTimeInterval(interval) }
     }
 }
-
-// MARK: - FakeSyncer
 
 /// Test-only `SilentPushSyncing` implementation. Records call count and
 /// dispatches the requested behaviour (success / throwing / hang-until-cancel).
@@ -410,5 +126,292 @@ final class FakeSyncer: SilentPushSyncing, @unchecked Sendable {
             // timeout sibling wins.
             try await Task.sleep(nanoseconds: 60_000_000_000)
         }
+    }
+}
+
+// MARK: - Tests
+
+@Suite("PushNotificationService Tests", .serialized)
+struct PushNotificationServiceTests {
+
+    // MARK: Token registration
+
+    @Test("Token persists locally and POSTs to the registration endpoint")
+    @MainActor
+    func tokenRegistrationPersistsAndPostsToAPI() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+
+        let service = env.makeService(tokenProvider: { "bearer-token" }, deviceIdProvider: { "device-abc" })
+
+        let tokenBytes = Data([0xab, 0xcd, 0xef, 0x01, 0x02, 0x03])
+        await service.handleAPNsTokenRegistered(tokenBytes)
+
+        #expect(service.cachedDeviceToken == "abcdef010203")
+        // last_registered_at should be set after a successful POST.
+        #expect(env.defaults.object(forKey: "dequeue.push.lastRegisteredAt") != nil)
+
+        let requests = StubURLProtocol.requests.filter { $0.method == "POST" }
+        #expect(requests.count == 1)
+        #expect(requests.first?.url.absoluteString.contains("/devices/push-token") == true)
+    }
+
+    @Test("Transient 5xx triggers exactly one retry, then succeeds")
+    @MainActor
+    func tokenRegistrationRetriesOnceOnTransient5xx() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+
+        let service = env.makeService(deviceIdProvider: { "device-xyz" })
+
+        await service.handleAPNsTokenRegistered(Data([0x01, 0x02]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(postCount == 2)
+        #expect(env.defaults.object(forKey: "dequeue.push.lastRegisteredAt") != nil)
+    }
+
+    @Test("Permanent 4xx does not retry and does not persist last_registered_at")
+    @MainActor
+    func tokenRegistrationDoesNotRetryOn400() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 400))
+
+        let service = env.makeService(deviceIdProvider: { "device-xyz" })
+
+        await service.handleAPNsTokenRegistered(Data([0x01]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(postCount == 1)
+        #expect(env.defaults.object(forKey: "dequeue.push.lastRegisteredAt") == nil)
+    }
+
+    @Test("Repeated 5xx telemetry-only, retries once then surrenders")
+    @MainActor
+    func tokenRegistrationDoesNotBlockOnRepeatedFailure() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+
+        let service = env.makeService(deviceIdProvider: { "device-xyz" })
+
+        await service.handleAPNsTokenRegistered(Data([0x01]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(postCount == 2)
+        #expect(service.cachedDeviceToken == "01")
+        #expect(env.defaults.object(forKey: "dequeue.push.lastRegisteredAt") == nil)
+    }
+
+    // MARK: Deregister
+
+    @Test("Deregister issues DELETE and clears local state")
+    @MainActor
+    func deregisterIssuesDeleteAndClearsLocalState() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        StubURLProtocol.enqueue(method: "DELETE", response: .init(statusCode: 204))
+
+        let service = env.makeService(deviceIdProvider: { "device-zzz" })
+
+        await service.handleAPNsTokenRegistered(Data([0xfa]))
+        #expect(service.cachedDeviceToken == "fa")
+
+        await service.deregisterOnSignOut()
+
+        #expect(service.cachedDeviceToken == nil)
+        #expect(env.defaults.object(forKey: "dequeue.push.cachedToken") == nil)
+        #expect(env.defaults.object(forKey: "dequeue.push.lastRegisteredAt") == nil)
+
+        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
+        #expect(deletes.count == 1)
+        #expect(deletes.first?.url.absoluteString.contains("deviceId=device-zzz") == true)
+    }
+
+    @Test("Deregister is a no-op when no token is cached")
+    @MainActor
+    func deregisterIsNoopWhenNoTokenCached() async throws {
+        let env = TestEnv()
+        let service = env.makeService()
+
+        await service.deregisterOnSignOut()
+
+        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
+        #expect(deletes.isEmpty)
+    }
+
+    // MARK: Stale-token refresh
+
+    @Test("Fresh last_registered_at skips re-POST")
+    @MainActor
+    func refreshTokenIfStaleSkipsWhenFresh() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        let service = env.makeService(deviceIdProvider: { "device-fresh" })
+
+        await service.handleAPNsTokenRegistered(Data([0x12]))
+        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(baseline == 1)
+
+        await service.refreshTokenIfStale()
+
+        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(afterRefresh == baseline)
+    }
+
+    @Test("Stale last_registered_at triggers one re-POST")
+    @MainActor
+    func refreshTokenIfStaleRepostsWhenStale() async throws {
+        let env = TestEnv()
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        let service = env.makeService(deviceIdProvider: { "device-stale" })
+
+        await service.handleAPNsTokenRegistered(Data([0x99]))
+        // Backdate last_registered_at to 10 days ago.
+        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
+        env.defaults.set(tenDaysAgo, forKey: "dequeue.push.lastRegisteredAt")
+        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        await service.refreshTokenIfStale()
+
+        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        #expect(afterRefresh == baseline + 1)
+    }
+
+    // MARK: Dedup bookkeeping
+
+    @Test("Remote delivery within window is recognised")
+    @MainActor
+    func remoteDeliveryWithinWindowIsRecognized() async throws {
+        let env = TestEnv()
+        let service = env.makeService()
+
+        service.markRemoteDelivered(reminderId: "rem-1")
+        #expect(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
+        #expect(!service.isRemoteRecentlyDelivered(reminderId: "rem-2"))
+    }
+
+    @Test("Remote delivery cache entry expires after the 60s window")
+    @MainActor
+    func remoteDeliveryWindowExpires() async throws {
+        let env = TestEnv()
+        let clock = FakeClock(start: Date())
+        let service = env.makeService(now: { clock.now() })
+
+        service.markRemoteDelivered(reminderId: "rem-expire")
+        #expect(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+
+        // Inside the window.
+        clock.advance(by: 45)
+        #expect(service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+
+        // Past the window — expired entry should be evicted.
+        clock.advance(by: 20) // total 65s
+        #expect(!service.isRemoteRecentlyDelivered(reminderId: "rem-expire"))
+    }
+
+    // MARK: Silent push sync
+
+    @Test("Silent-push sync success returns .newData")
+    @MainActor
+    func silentPushSyncSuccessReturnsNewData() async throws {
+        let env = TestEnv()
+        let syncer = FakeSyncer(behavior: .success)
+        let service = env.makeService(silentPushSyncer: syncer)
+
+        let result = await service.handleSilentPush(
+            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+        )
+
+        #expect(result == .newData)
+        #expect(syncer.callCount == 1)
+        #expect(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
+    }
+
+    @Test("Silent-push sync throwing returns .failed")
+    @MainActor
+    func silentPushSyncErrorReturnsFailed() async throws {
+        let env = TestEnv()
+        let syncer = FakeSyncer(behavior: .error)
+        let service = env.makeService(silentPushSyncer: syncer)
+
+        let result = await service.handleSilentPush(
+            userInfo: [NotificationConstants.UserInfoKey.remoteReminderId: "rem-1"]
+        )
+
+        #expect(result == .failed)
+    }
+
+    @Test("Silent-push sync timeout surfaces .failure(kind: timeout)")
+    @MainActor
+    func silentPushSyncTimesOut() async throws {
+        let env = TestEnv()
+        let syncer = FakeSyncer(behavior: .hang)
+        let service = env.makeService(silentPushSyncer: syncer)
+
+        // Use a tiny custom timeout via the underlying runSilentPushSync to
+        // keep the test fast; handleSilentPush always uses the production
+        // 20s value so we exercise runSilentPushSync directly.
+        let outcome = await service.runSilentPushSync(timeout: 0.2)
+
+        #expect(outcome == .failure(kind: "timeout"))
+    }
+
+    @Test("Missing reminder_id in userInfo is handled gracefully")
+    @MainActor
+    func missingReminderIdInUserInfoIsHandledGracefully() async throws {
+        let env = TestEnv()
+        // No silentPushSyncer + AppContext unconfigured → handleSilentPush
+        // surfaces .failed (kind: "unavailable") without crashing on the
+        // missing reminder_id.
+        let service = env.makeService()
+        let result = await service.handleSilentPush(userInfo: ["other": "junk"])
+        #expect(result == .failed)
+    }
+}
+
+// MARK: - TestEnv
+
+/// Holds the per-test ephemeral UserDefaults suite + URLSession plumbing so
+/// the @Suite struct stays free of mutable state (Swift Testing prefers per-
+/// test isolation over XCTestCase-style setUp/tearDown).
+@MainActor
+private final class TestEnv {
+    let defaults: UserDefaults
+    let suiteName: String
+    let session: URLSession
+
+    init() {
+        self.suiteName = "PushNotificationServiceTests-\(UUID().uuidString)"
+        self.defaults = UserDefaults(suiteName: suiteName)!
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        self.session = URLSession(configuration: config)
+        StubURLProtocol.reset()
+    }
+
+    deinit {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        StubURLProtocol.reset()
+    }
+
+    func makeService(
+        tokenProvider: @MainActor @escaping () async throws -> String = { "test-token" },
+        deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" },
+        silentPushSyncer: SilentPushSyncing? = nil,
+        now: @Sendable @escaping () -> Date = { Date() }
+    ) -> PushNotificationService {
+        PushNotificationService(
+            urlSession: session,
+            userDefaults: defaults,
+            baseURLProvider: { URL(string: "https://api.test.dequeue.app/v1")! },
+            tokenProvider: tokenProvider,
+            deviceIdProvider: deviceIdProvider,
+            isAuthenticatedProvider: { true },
+            silentPushSyncer: silentPushSyncer,
+            now: now
+        )
     }
 }

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -356,7 +356,11 @@ struct PushNotificationServiceTests {
 
         #expect(result == .newData)
         #expect(syncer.callCount == 1)
-        #expect(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
+        // The dedup cache is intentionally NOT stamped on silent-push
+        // receipt — only on alert-push *presentation* via
+        // `NotificationService.willPresent` path 1. This avoids missing the
+        // local fallback if APNs fails to deliver the alert push at remindAt.
+        #expect(!service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
     }
 
     @Test("Silent-push sync throwing returns .failed")
@@ -403,8 +407,9 @@ struct PushNotificationServiceTests {
         // Sync still ran (the silent push wakes us regardless of payload).
         #expect(result == .newData)
         #expect(syncer.callCount == 1)
-        // No reminderId was supplied, so nothing should have been stamped
-        // into the dedup cache.
+        // The dedup cache is intentionally NOT stamped on silent-push
+        // receipt (see comment in handleSilentPush). Asserting the obvious
+        // empty-string lookup here just confirms no accidental stamp.
         #expect(!service.isRemoteRecentlyDelivered(reminderId: ""))
     }
 

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -297,9 +297,10 @@ struct PushNotificationServiceTests {
         let service = env.makeService(deviceIdProvider: { "device-stale" })
 
         await service.handleAPNsTokenRegistered(Data([0x99]))
-        // Backdate last_registered_at to 10 days ago.
-        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
-        env.defaults.set(tenDaysAgo, forKey: "dequeue.push.lastRegisteredAt")
+        // Backdate last_registered_at to 10 days ago. Stored as Int64 ms
+        // per CLAUDE.md / the production write path.
+        let tenDaysAgoMs = Int64(Date().addingTimeInterval(-10 * 24 * 60 * 60).timeIntervalSince1970 * 1_000)
+        env.defaults.set(tenDaysAgoMs, forKey: "dequeue.push.lastRegisteredAt")
         let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
 
         StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
@@ -446,9 +447,9 @@ struct PushNotificationServiceTests {
         // `isAuthenticatedProvider: { false }` reads the cached token but
         // still bails on the auth guard. This exercises the guard at the
         // top of `refreshTokenIfStale` even when local state otherwise
-        // looks ready to refresh.
+        // looks ready to refresh. Timestamp stored as Int64 ms.
         env.defaults.set("cached-old", forKey: "dequeue.push.cachedToken")
-        env.defaults.set(Date.distantPast, forKey: "dequeue.push.lastRegisteredAt")
+        env.defaults.set(Int64(Date.distantPast.timeIntervalSince1970 * 1_000), forKey: "dequeue.push.lastRegisteredAt")
         let service = env.makeService(isAuthenticatedProvider: { false })
 
         await service.refreshTokenIfStale()

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -241,6 +241,35 @@ struct PushNotificationServiceTests {
         #expect(deletes.isEmpty)
     }
 
+    @Test("Deregister still clears local state when auth-token fetch fails")
+    @MainActor
+    func deregisterClearsLocalStateEvenWhenTokenFetchFails() async throws {
+        let env = TestEnv()
+        // Register normally first so we have local state to clear.
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        let throwOnSignOut = ThrowingTokenProvider()
+        let service = env.makeService(
+            tokenProvider: { try await throwOnSignOut.getToken() },
+            deviceIdProvider: { "device-zzz" }
+        )
+        await service.handleAPNsTokenRegistered(Data([0xfa]))
+        #expect(service.cachedDeviceToken == "fa")
+
+        // Now flip the token provider so the deregister token fetch throws.
+        // This simulates Clerk session being torn down before the deregister
+        // network call (a real race seen in production sign-out).
+        throwOnSignOut.shouldThrow = true
+
+        await service.deregisterOnSignOut()
+
+        // Local state must be cleared regardless of the token-fetch failure —
+        // server-side reconciler will reap the orphaned token via APNs 410s.
+        #expect(service.cachedDeviceToken == nil)
+        #expect(env.defaults.object(forKey: "dequeue.push.cachedToken") == nil)
+        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
+        #expect(deletes.isEmpty, "DELETE skipped when token unavailable")
+    }
+
     // MARK: Stale-token refresh
 
     @Test("Fresh last_registered_at skips re-POST")
@@ -479,7 +508,32 @@ private final class TestEnv {
             isAuthenticatedProvider: isAuthenticatedProvider,
             silentPushSyncer: silentPushSyncer,
             silentPushSyncTimeout: silentPushSyncTimeout,
+            // Skip the 500ms retry backoff in tests so the retry-on-5xx
+            // test doesn't sleep for half a second.
+            tokenRegisterRetryDelay: 0,
             now: now
         )
+    }
+}
+
+// MARK: - ThrowingTokenProvider
+
+/// Toggleable token provider used by `deregisterClearsLocalStateEvenWhenTokenFetchFails`.
+/// The first call (POST-time, during register) returns a real token; once
+/// `shouldThrow` flips true, subsequent calls (DELETE-time, during sign-out)
+/// throw — simulating the Clerk session being torn down between register
+/// and deregister.
+final class ThrowingTokenProvider: @unchecked Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: false)
+    var shouldThrow: Bool {
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
+    }
+
+    func getToken() async throws -> String {
+        if shouldThrow {
+            throw URLError(.userAuthenticationRequired)
+        }
+        return "bearer-token"
     }
 }

--- a/Dequeue/DequeueTests/PushNotificationServiceTests.swift
+++ b/Dequeue/DequeueTests/PushNotificationServiceTests.swift
@@ -1,0 +1,310 @@
+//
+//  PushNotificationServiceTests.swift
+//  DequeueTests
+//
+//  Tests for the iOS-side push notification pipeline (DEQ-283):
+//   • Device-token register / deregister, including 1-retry on transient 5xx.
+//   • Local-vs-remote dedup bookkeeping (60s NSCache window).
+//   • Silent-push handler timeout behaviour.
+//
+
+import XCTest
+@testable import Dequeue
+
+// MARK: - Stub URLProtocol (no real network)
+
+/// URLProtocol subclass that lets tests script HTTP responses in-process.
+/// Avoids actual network I/O so the suite stays hermetic.
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct StubResponse: Sendable {
+        let statusCode: Int
+        let body: Data
+        let throwError: Error?
+        init(statusCode: Int = 200, body: Data = Data(), throwError: Error? = nil) {
+            self.statusCode = statusCode
+            self.body = body
+            self.throwError = throwError
+        }
+    }
+
+    /// FIFO queue of canned responses keyed by HTTP method. Each request
+    /// pops the head. If no canned response is available we return 200 OK.
+    nonisolated(unsafe) static var responses: [String: [StubResponse]] = [:]
+    /// Records every request the SUT issued (URL + method) so tests can assert on it.
+    nonisolated(unsafe) static var requests: [(url: URL, method: String, body: Data?)] = []
+    nonisolated(unsafe) static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        responses = [:]
+        requests = []
+    }
+
+    static func enqueue(method: String, response: StubResponse) {
+        lock.lock(); defer { lock.unlock() }
+        responses[method, default: []].append(response)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let method = request.httpMethod ?? "GET"
+        let url = request.url ?? URL(string: "about:blank")!
+        Self.lock.lock()
+        Self.requests.append((url, method, request.httpBody))
+        var queue = Self.responses[method] ?? []
+        let response = queue.isEmpty ? StubResponse(statusCode: 200) : queue.removeFirst()
+        Self.responses[method] = queue
+        Self.lock.unlock()
+
+        if let error = response.throwError {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        let httpResponse = HTTPURLResponse(
+            url: url,
+            statusCode: response.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: response.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@MainActor
+final class PushNotificationServiceTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var session: URLSession!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Use a clean, ephemeral UserDefaults suite so tests don't leak state.
+        let suiteName = "PushNotificationServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        session = URLSession(configuration: config)
+        StubURLProtocol.reset()
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
+        StubURLProtocol.reset()
+        try await super.tearDown()
+    }
+
+    // MARK: Token registration
+
+    func testTokenRegistrationPersistsAndPostsToAPI() async throws {
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-abc" }
+        )
+
+        let tokenBytes = Data([0xab, 0xcd, 0xef, 0x01, 0x02, 0x03])
+        await service.handleAPNsTokenRegistered(tokenBytes)
+
+        XCTAssertEqual(service.cachedDeviceToken, "abcdef010203")
+        // last_registered_at should be set after a successful POST.
+        XCTAssertNotNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
+
+        let requests = StubURLProtocol.requests.filter { $0.method == "POST" }
+        XCTAssertEqual(requests.count, 1, "Should POST once on first register")
+        XCTAssertTrue(requests[0].url.absoluteString.contains("/devices/push-token"))
+    }
+
+    func testTokenRegistrationRetriesOnceOnTransient5xx() async throws {
+        // First attempt 503, second attempt 200.
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-xyz" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0x01, 0x02]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(postCount, 2, "Should retry once then succeed")
+        XCTAssertNotNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
+    }
+
+    func testTokenRegistrationDoesNotRetryOn400() async throws {
+        // 400 is permanent — no retry, no last_registered_at write.
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 400))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-xyz" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0x01]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(postCount, 1, "Permanent failure should not retry")
+        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
+    }
+
+    func testTokenRegistrationDoesNotBlockOnRepeatedFailure() async throws {
+        // Both attempts fail with 503 — service must telemetry-only and return.
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 503))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-xyz" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0x01]))
+
+        let postCount = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(postCount, 2, "Should attempt original + 1 retry")
+        // Token still cached locally even though server didn't ack — next launch
+        // will re-attempt.
+        XCTAssertEqual(service.cachedDeviceToken, "01")
+        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
+    }
+
+    // MARK: Deregister
+
+    func testDeregisterIssuesDeleteAndClearsLocalState() async throws {
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        StubURLProtocol.enqueue(method: "DELETE", response: .init(statusCode: 204))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-zzz" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0xfa]))
+        XCTAssertEqual(service.cachedDeviceToken, "fa")
+
+        await service.deregisterOnSignOut()
+
+        XCTAssertNil(service.cachedDeviceToken)
+        XCTAssertNil(defaults.object(forKey: "dequeue.push.cachedToken"))
+        XCTAssertNil(defaults.object(forKey: "dequeue.push.lastRegisteredAt"))
+
+        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
+        XCTAssertEqual(deletes.count, 1)
+        XCTAssertTrue(deletes[0].url.absoluteString.contains("deviceId=device-zzz"))
+    }
+
+    func testDeregisterIsNoopWhenNoTokenCached() async throws {
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-zzz" }
+        )
+
+        await service.deregisterOnSignOut()
+
+        let deletes = StubURLProtocol.requests.filter { $0.method == "DELETE" }
+        XCTAssertEqual(deletes.count, 0, "Should not issue DELETE if no token cached")
+    }
+
+    // MARK: Stale-token refresh
+
+    func testRefreshTokenIfStaleSkipsWhenFresh() async throws {
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-fresh" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0x12]))
+        // Drain the post count.
+        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(baseline, 1)
+
+        // No additional canned response: if it tried to POST, it'd get default 200,
+        // which would also increment requests.
+        await service.refreshTokenIfStale()
+
+        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(afterRefresh, baseline, "Fresh token should not re-POST")
+    }
+
+    func testRefreshTokenIfStaleRepostsWhenStale() async throws {
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+
+        let service = makeService(
+            tokenProvider: { "bearer-token" },
+            deviceIdProvider: { "device-stale" }
+        )
+
+        await service.handleAPNsTokenRegistered(Data([0x99]))
+        // Backdate last_registered_at to 10 days ago.
+        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
+        defaults.set(tenDaysAgo, forKey: "dequeue.push.lastRegisteredAt")
+        let baseline = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+
+        // Queue another 200 response for the refresh POST.
+        StubURLProtocol.enqueue(method: "POST", response: .init(statusCode: 200))
+        await service.refreshTokenIfStale()
+
+        let afterRefresh = StubURLProtocol.requests.filter { $0.method == "POST" }.count
+        XCTAssertEqual(afterRefresh, baseline + 1, "Stale token should trigger one re-POST")
+    }
+
+    // MARK: Dedup bookkeeping
+
+    func testRemoteDeliveryWithinWindowIsRecognized() async throws {
+        let service = makeService()
+
+        service.markRemoteDelivered(reminderId: "rem-1")
+        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-1"))
+        XCTAssertFalse(service.isRemoteRecentlyDelivered(reminderId: "rem-2"))
+    }
+
+    func testRemoteDeliveryWindowExpires() async throws {
+        // Use a service whose `now` we can control via the in-memory NSCache;
+        // we test the window by writing into the NSCache directly through the
+        // service then mutating its bookkeeping via reflection-free path: we
+        // re-stamp by calling `markRemoteDelivered` with an old Date through
+        // a custom subclass. Simplest approach: the production cache stores a
+        // wall-clock Date; we can verify the within-window path here and
+        // trust that the >60s branch removes the entry. The threshold logic
+        // is straightforward (Date subtraction); the contract under test is
+        // "exact match returns true while inside the window".
+        let service = makeService()
+        service.markRemoteDelivered(reminderId: "rem-window")
+        XCTAssertTrue(service.isRemoteRecentlyDelivered(reminderId: "rem-window"))
+    }
+
+    func testMissingReminderIdInUserInfoIsHandledGracefully() async throws {
+        // No reminder_id: handleSilentPush should still complete with .failed
+        // (no sync manager wired) rather than crash on optional unwrap.
+        let service = makeService()
+        let result = await service.handleSilentPush(userInfo: ["other": "junk"])
+        // AppContext is not configured in test → silent sync returns .failed.
+        XCTAssertEqual(result, .failed)
+    }
+
+    // MARK: Helpers
+
+    private func makeService(
+        tokenProvider: @MainActor @escaping () async throws -> String = { "test-token" },
+        deviceIdProvider: @Sendable @escaping () async -> String = { "test-device" }
+    ) -> PushNotificationService {
+        PushNotificationService(
+            urlSession: session,
+            userDefaults: defaults,
+            baseURLProvider: { URL(string: "https://api.test.dequeue.app/v1")! },
+            tokenProvider: tokenProvider,
+            deviceIdProvider: deviceIdProvider,
+            isAuthenticatedProvider: { true },
+            now: { Date() }
+        )
+    }
+}


### PR DESCRIPTION
## What

PR 4/6 of the reminder-delivery pipeline (parent: DEQ-276). Wires the iOS app to actually receive and react to the APNs pushes the backend (PR 3, dequeue-api#201) now sends.

Fixes DEQ-283
Refs DEQ-276

## Why

PRs 1 & 2 added Time Sensitive entitlement + the backend device-token endpoints. PR 3 added the APNs sender + scheduler. Without this PR, the app:
1. Never registers a device token with the API → backend has no targets to push to.
2. Ignores incoming silent pushes → no pre-wake sync.
3. Risks double-banners when both the local-scheduled UNNotification and the remote APNs alert fire for the same `reminderId`.

## Changes

### New: `PushNotificationService` (single owner of push lifecycle)
- Hex-encodes APNs device token on receipt; POSTs to `/v1/devices/push-token` (camelCase JSON to match dequeue-api#200 `DeviceTokenRequest`).
- Idempotent registration with **1 retry on transient 5xx**, telemetry-only on permanent failure (never blocks the OS callback). Retry backoff is injectable so tests don't pay a 500ms sleep.
- DELETE on sign-out (wired into `AuthService.tearDownSignedOutState` so all three sign-out paths — explicit / deferred / 422-confirmed — clean up). Local state is cleared even if the auth-token fetch itself fails (server-side APNs 410 reaper handles the orphan).
- Re-POST on `applicationDidBecomeActive` when `last_registered_at` is >7d stale (stored under `dequeue.push.*` UserDefaults namespace).
- 60s NSCache for recent remote `reminderId`s to drive the dedup contract.
- 20s silent-push REST sync via `SyncManager.syncViaProjections()` (no WebSocket — too slow to establish in BG), with task-group timeout. Timeout is injectable so tests can exercise the path quickly.

### `AppDelegate`
- `didFinishLaunchingWithOptions`: best-effort registration on cold launch (`@UIApplicationDelegateAdaptor` doesn't guarantee `AppContext` is wired yet; the sign-in + foreground-active paths cover the cold-launch nil-pushService case).
- `didRegisterForRemoteNotificationsWithDeviceToken`: hands raw bytes to `PushNotificationService`.
- `didFailToRegisterForRemoteNotificationsWithError`: telemetry only.
- `didReceiveRemoteNotification:fetchCompletionHandler:`: pre-extracts a Sendable `SilentPushPayload` (reminderId + sentAtMs as Int64) BEFORE crossing the Task boundary, then calls completion handler with `.newData` / `.noData` / `.failed`.

### `NotificationService.willPresent` (dedup contract)
- Remote arrives (`UNPushNotificationTrigger`) → `removePendingNotificationRequests(withIdentifiers: [reminderId])`, log `reminder_push_dedup_local_canceled`.
- Local arrives within 60s of a remote for same `reminderId` → suppress with `[]`, log `reminder_push_dedup_remote_ignored`.
- Otherwise present normally (`[.banner, .sound, .badge]`).
- Local `UNNotificationRequest.identifier` is already `reminder.id` (existing behavior — no change needed there).

### `AuthService`
- `tearDownSignedOutState` now also calls `pushService.deregisterOnSignOut()`. Fire-and-forget so a slow network never blocks local sign-out cleanup.

### `DequeueApp` + new `AppContext`
- New `AppContext.swift` is the minimal service locator that bridges UIKit / UNUserNotification delegate callbacks to the live SwiftUI-owned services. Documented as best-effort; callers always treat properties as Optional.
- On sign-in: triggers `pushService.registerIfSignedIn()`.
- On foreground active: triggers `pushService.refreshTokenIfStale()`.

### Entitlements & build settings (per-config, **already wired**)
- `aps-environment = $(APS_ENVIRONMENT)` in `Dequeue.entitlements`.
- `APS_ENVIRONMENT` build setting: `development` for Debug, `production` for Release. No follow-up flip needed for App Store / TestFlight builds.
- `INFOPLIST_KEY_UIBackgroundModes = remote-notification` for iOS Debug + Release configs.

## Telemetry (Sentry breadcrumbs, matching existing patterns)

| Event | Where |
|---|---|
| `reminder_push_received` (reminderId, ageMs) | silent push entry |
| `reminder_push_sync_completed` (durationMs, fetchedCount) | post-sync success |
| `reminder_push_sync_failed` (errorKind) | post-sync failure / timeout |
| `reminder_push_dedup_local_canceled` | remote arrives → cancel local |
| `reminder_push_dedup_remote_ignored` | local suppressed within window |
| `device_token_registered` | POST success |
| `device_token_register_failed` | POST permanent / exhausted retries |
| `device_token_deregistered` | DELETE outcome |

## Tests

`PushNotificationServiceTests` (Swift Testing, `@Suite(.serialized)`, 19 cases, all passing locally on macOS):

Registration / deregistration:
- Token persists + posts on first register.
- Transient 5xx retried once, succeeds.
- 400 doesn't retry (permanent).
- Repeated 5xx → telemetry-only, doesn't block.
- DELETE on sign-out + local state cleared.
- DELETE skipped when no cached token.
- Local state still cleared when auth-token fetch fails (Clerk-torn-down-mid-signout race).

Stale-token refresh:
- Fresh `last_registered_at` skips re-POST.
- Stale `last_registered_at` triggers one re-POST.
- No-op when not authenticated.
- Falls through to `registerIfSignedIn` when no cached token.

Dedup:
- Within-window lookup returns true; unknown reminder false.
- Window expires after 60s (uses injected `FakeClock`).

Silent push:
- Success → `.newData`.
- Throwing → `.failed`.
- Hang → `.failed` (via injected tiny timeout).
- `nil reminderId` payload: sync still runs, dedup cache untouched.
- Unavailable syncer → `.failed`.

Other:
- `handleAPNsRegistrationFailed` doesn't throw + leaves state intact.

## Verification before push

- ✅ `swiftlint lint --config .swiftlint.yml` → 0 violations in 197 files.
- ✅ `xcodebuild build -destination 'platform=macOS'` → BUILD SUCCEEDED.
- ✅ `xcodebuild build -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → BUILD SUCCEEDED.
- ✅ `xcodebuild test -destination 'platform=macOS'` → full suite passes.
- ✅ CI all green (Build iOS, Build macOS, Unit Tests, SwiftLint, SonarCloud, claude-review).

## Follow-ups (NOT in this PR)

- **DEQ-284** — `POST /v1/devices/notification-displayed` reconciliation telemetry + surfacing true fetched-count from the projection sync so `handleSilentPush` returns `.noData` when zero events were applied (currently hardcoded to `.newData` so iOS doesn't deprioritise the silent-push wake budget; trade-off documented inline).
- **DEQ-285** — macOS push parity (PR 6).