### PR TITLE
feat(push): macOS APNs parity — silent-push handler + token registration + dedup (PR 6/6)

### DIFF
--- a/Dequeue/Dequeue/DequeueApp.swift
+++ b/Dequeue/Dequeue/DequeueApp.swift
@@ -30,6 +30,8 @@ extension EnvironmentValues {
 struct DequeueApp: App {
     #if os(iOS)
     @UIApplicationDelegateAdaptor(DequeueAppDelegate.self) var appDelegate
+    #elseif os(macOS)
+    @NSApplicationDelegateAdaptor(DequeueAppDelegate.self) var appDelegate
     #endif
 
     @State private var authService: any AuthServiceProtocol

--- a/Dequeue/Dequeue/Services/AppContext.swift
+++ b/Dequeue/Dequeue/Services/AppContext.swift
@@ -61,5 +61,12 @@ final class AppContext {
         authService = nil
         pushService = nil
     }
+
+    /// Test-only setter that wires just the push service without requiring a
+    /// real `SyncManager` or `AuthService`. Callers must call `resetForTesting()`
+    /// in their teardown to avoid leaking state across tests.
+    func setPushServiceForTesting(_ service: any PushNotificationServiceProtocol) {
+        pushService = service
+    }
     #endif
 }

--- a/Dequeue/Dequeue/Services/AppDelegate.swift
+++ b/Dequeue/Dequeue/Services/AppDelegate.swift
@@ -2,9 +2,9 @@
 //  AppDelegate.swift
 //  Dequeue
 //
-//  UIKit App Delegate for handling system callbacks that require UIApplicationDelegate:
-//   • Home screen quick actions (3D Touch / Haptic Touch shortcuts).
-//   • APNs remote-notification registration and silent push delivery (DEQ-283).
+//  Platform App Delegates for handling system callbacks:
+//   • iOS (UIApplicationDelegate): quick actions, APNs registration, silent push.
+//   • macOS (NSApplicationDelegate): APNs registration, silent push (DEQ-285).
 //
 
 #if os(iOS)
@@ -170,6 +170,103 @@ final class DequeueSceneDelegate: NSObject, UIWindowSceneDelegate {
     ) {
         let handled = QuickActionService.shared.handleShortcutItem(shortcutItem)
         completionHandler(handled)
+    }
+}
+#endif
+
+// MARK: - macOS NSApplicationDelegate
+
+#if os(macOS)
+import AppKit
+import os.log
+
+/// macOS app delegate handling APNs registration and silent-push delivery
+/// (DEQ-285). Mirrors the iOS `DequeueAppDelegate` surface using the
+/// `NSApplicationDelegate` equivalents.
+///
+/// Key differences from iOS:
+///  • Uses `NSApplication` instead of `UIApplication`.
+///  • `application(_:didReceiveRemoteNotification:)` has no
+///    `fetchCompletionHandler` — macOS does not gate background execution
+///    on a completion callback. We spawn a Task so the 20s REST sync runs
+///    without blocking the delegate call.
+///  • Time-Sensitive interruption level is iOS-only; macOS does not have it.
+final class DequeueAppDelegate: NSObject, NSApplicationDelegate {
+    private let logger = Logger(subsystem: "com.dequeue", category: "AppDelegate")
+
+    /// App-level cold-launch hook. Best-effort APNs registration if the user
+    /// is already signed in.
+    ///
+    /// `@NSApplicationDelegateAdaptor` does NOT guarantee that the SwiftUI
+    /// `App.init()` (which wires `AppContext`) completes before this delegate
+    /// fires. The sign-in completion path (`handleAuthStateChange`) and the
+    /// foreground-active path (scenePhase `.active` → `refreshTokenIfStale`)
+    /// provide the authoritative registration; this call is belt-and-suspenders
+    /// for warm launches where `AppContext` is already populated.
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            await push.registerIfSignedIn()
+        }
+    }
+
+    // MARK: - APNs registration callbacks
+
+    /// Apple-callback: macOS successfully provisioned a device token.
+    /// Forwards to `PushNotificationService` for hex-encoding + API upload.
+    func application(
+        _ application: NSApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            await push.handleAPNsTokenRegistered(deviceToken)
+        }
+    }
+
+    /// Apple-callback: macOS could not provision a device token.
+    /// Telemetry only — Apple will call us again the next time we register.
+    func application(
+        _ application: NSApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            push.handleAPNsRegistrationFailed(error)
+        }
+    }
+
+    /// Apple-callback: silent / background push arrived on macOS.
+    ///
+    /// Unlike iOS (`fetchCompletionHandler` form), macOS delivers this
+    /// synchronously and does not require a completion callback. macOS also
+    /// does not enforce a hard execution deadline the way iOS background-fetch
+    /// does, but we preserve the same 20s timeout inside
+    /// `PushNotificationService.handleSilentPush` for hygiene and to keep
+    /// behaviour symmetric across platforms.
+    ///
+    /// `userInfo` on macOS is `[String: Any]` (not `[AnyHashable: Any]`).
+    /// We still extract the Sendable `SilentPushPayload` before the Task
+    /// boundary to satisfy Swift 6 strict concurrency.
+    func application(
+        _ application: NSApplication,
+        didReceiveRemoteNotification userInfo: [String: Any]
+    ) {
+        // Extract Sendable fields before crossing the Task / actor boundary.
+        let reminderId = (userInfo[NotificationConstants.UserInfoKey.remoteReminderId] as? String)
+            ?? (userInfo[NotificationConstants.UserInfoKey.reminderId] as? String)
+        let sentAtMs: Int64? =
+            (userInfo[NotificationConstants.UserInfoKey.remoteSentAtMs] as? NSNumber)?.int64Value
+        let payload = SilentPushPayload(reminderId: reminderId, sentAtMs: sentAtMs)
+
+        Task { @MainActor in
+            guard let push = AppContext.shared.pushService else { return }
+            // Discard result — macOS has no fetchCompletionHandler to call.
+            // The 20s timeout inside handleSilentPush still caps the sync
+            // duration. On macOS the OS won't kill the Task for exceeding it,
+            // but capping here keeps CPU and network usage predictable.
+            _ = await push.handleSilentPush(payload: payload)
+        }
     }
 }
 #endif

--- a/Dequeue/Dequeue/Services/PushNotificationService.swift
+++ b/Dequeue/Dequeue/Services/PushNotificationService.swift
@@ -21,6 +21,9 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 #endif
+#if os(macOS)
+import AppKit
+#endif
 import os.log
 import Sentry
 
@@ -292,15 +295,22 @@ final class PushNotificationService: PushNotificationServiceProtocol {
         // attempt.
         #if canImport(UIKit) && os(iOS)
         UIApplication.shared.registerForRemoteNotifications()
-        Self.logger.info("Requested registerForRemoteNotifications")
+        Self.logger.info("Requested registerForRemoteNotifications (iOS)")
         ErrorReportingService.addBreadcrumb(
             category: "push",
             message: "Requested registerForRemoteNotifications"
         )
+        #elseif os(macOS)
+        NSApplication.shared.registerForRemoteNotifications()
+        Self.logger.info("Requested registerForRemoteNotifications (macOS)")
+        ErrorReportingService.addBreadcrumb(
+            category: "push",
+            message: "Requested registerForRemoteNotifications (macOS)"
+        )
         #else
         ErrorReportingService.addBreadcrumb(
             category: "push",
-            message: "registerForRemoteNotifications skipped (non-iOS platform)"
+            message: "registerForRemoteNotifications skipped (unsupported platform)"
         )
         #endif
     }

--- a/Dequeue/DequeueTests/MacOSAppDelegateTests.swift
+++ b/Dequeue/DequeueTests/MacOSAppDelegateTests.swift
@@ -1,0 +1,265 @@
+//
+//  MacOSAppDelegateTests.swift
+//  DequeueTests
+//
+//  Unit tests for the macOS NSApplicationDelegate shim (DEQ-285).
+//  Tests are guarded by `#if os(macOS)` and only exercise the macOS-specific
+//  delta from the shared PushNotificationService logic:
+//
+//   • Payload extraction from `[String: Any]` (macOS userInfo type).
+//   • Forwarding to PushNotificationService without a fetchCompletionHandler.
+//   • applicationDidFinishLaunching delegates to registerIfSignedIn.
+//   • didRegisterForRemoteNotifications / didFail forwarding.
+//
+//  Shared sync logic (handleSilentPush paths, dedup, token register) is
+//  already exercised on macOS by PushNotificationServiceTests which build
+//  and run under the macOS destination.
+//
+
+#if os(macOS)
+import AppKit
+import Testing
+import Foundation
+@testable import Dequeue
+
+// MARK: - Spy push-notification service
+
+/// Records calls to `PushNotificationServiceProtocol` methods so the
+/// AppDelegate tests can assert on forwarding behaviour without spinning up
+/// the full push-notification stack.
+@MainActor
+final class SpyPushNotificationService: PushNotificationServiceProtocol, @unchecked Sendable {
+    // MARK: Protocol surface
+    private(set) var cachedDeviceToken: String?
+
+    // MARK: Call recording
+    private(set) var registerIfSignedInCallCount = 0
+    private(set) var refreshTokenIfStaleCallCount = 0
+    private(set) var deregisterOnSignOutCallCount = 0
+    private(set) var handleAPNsTokenRegisteredCalls: [Data] = []
+    private(set) var handleAPNsRegistrationFailedErrors: [Error] = []
+    private(set) var handleSilentPushPayloads: [SilentPushPayload] = []
+
+    /// Configurable result for `handleSilentPush`; defaults to `.newData`.
+    var stubbedSilentPushResult: SilentPushResult = .newData
+
+    // MARK: Thread-safe nonisolated bookkeeping
+    nonisolated(unsafe) private var _markedRemoteIds: [String] = []
+    nonisolated(unsafe) private var _isRecentlyDelivered = false
+    private let lock = NSLock()
+
+    // MARK: Protocol conformance
+
+    func handleAPNsTokenRegistered(_ tokenData: Data) async {
+        handleAPNsTokenRegisteredCalls.append(tokenData)
+        cachedDeviceToken = tokenData.map { String(format: "%02x", $0) }.joined()
+    }
+
+    func handleAPNsRegistrationFailed(_ error: Error) {
+        handleAPNsRegistrationFailedErrors.append(error)
+    }
+
+    func registerIfSignedIn() async {
+        registerIfSignedInCallCount += 1
+    }
+
+    func refreshTokenIfStale() async {
+        refreshTokenIfStaleCallCount += 1
+    }
+
+    func deregisterOnSignOut() async {
+        deregisterOnSignOutCallCount += 1
+    }
+
+    nonisolated func markRemoteDelivered(reminderId: String) {
+        lock.lock(); defer { lock.unlock() }
+        _markedRemoteIds.append(reminderId)
+    }
+
+    nonisolated func isRemoteRecentlyDelivered(reminderId: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isRecentlyDelivered
+    }
+
+    func handleSilentPush(payload: SilentPushPayload) async -> SilentPushResult {
+        handleSilentPushPayloads.append(payload)
+        return stubbedSilentPushResult
+    }
+}
+
+// MARK: - Tests
+
+@Suite("macOS AppDelegate (DEQ-285)", .serialized)
+@MainActor
+struct MacOSAppDelegateTests {
+
+    // MARK: - Test lifecycle helpers
+
+    /// Wire AppContext with a fresh spy; return both the delegate and the spy.
+    /// Callers are responsible for tearing down by calling `cleanup()`.
+    func makeDelegate() -> (DequeueAppDelegate, SpyPushNotificationService) {
+        AppContext.shared.resetForTesting()
+        let spy = SpyPushNotificationService()
+        AppContext.shared.setPushServiceForTesting(spy)
+        return (DequeueAppDelegate(), spy)
+    }
+
+    func cleanup() {
+        AppContext.shared.resetForTesting()
+    }
+
+    // MARK: - applicationDidFinishLaunching
+
+    @Test("applicationDidFinishLaunching calls registerIfSignedIn")
+    func applicationDidFinishLaunchingRegisters() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+
+        // Delegate spawns a Task; yield to let it land.
+        try await Task.sleep(nanoseconds: 50_000_000) // 50 ms
+        #expect(spy.registerIfSignedInCallCount == 1)
+    }
+
+    @Test("applicationDidFinishLaunching no-ops when pushService is nil")
+    func applicationDidFinishLaunchingNoOpWhenNilService() async throws {
+        AppContext.shared.resetForTesting() // no pushService wired
+        defer { cleanup() }
+
+        let delegate = DequeueAppDelegate()
+        // Must not crash
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        // No assertion needed beyond "does not crash"
+    }
+
+    // MARK: - didRegisterForRemoteNotificationsWithDeviceToken
+
+    @Test("didRegisterForRemoteNotificationsWithDeviceToken forwards token data")
+    func didRegisterForwardsToken() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        let tokenBytes: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF]
+        let tokenData = Data(tokenBytes)
+        delegate.application(NSApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: tokenData)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(spy.handleAPNsTokenRegisteredCalls.count == 1)
+        #expect(spy.handleAPNsTokenRegisteredCalls.first == tokenData)
+    }
+
+    @Test("didRegisterForRemoteNotificationsWithDeviceToken no-ops when service is nil")
+    func didRegisterNoOpWhenNilService() async throws {
+        AppContext.shared.resetForTesting()
+        defer { cleanup() }
+
+        let delegate = DequeueAppDelegate()
+        let tokenData = Data([0x01, 0x02])
+        // Must not crash
+        delegate.application(NSApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: tokenData)
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+
+    // MARK: - didFailToRegisterForRemoteNotificationsWithError
+
+    @Test("didFailToRegisterForRemoteNotificationsWithError forwards error")
+    func didFailForwardsError() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        struct FakeAPNsError: Error {}
+        let error = FakeAPNsError()
+        delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: error)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(spy.handleAPNsRegistrationFailedErrors.count == 1)
+    }
+
+    // MARK: - didReceiveRemoteNotification (macOS silent push)
+
+    @Test("didReceiveRemoteNotification extracts reminder_id and sent_at correctly")
+    func didReceiveRemoteNotificationExtracts() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        let userInfo: [String: Any] = [
+            "reminder_id": "rem-abc123",
+            "sent_at": NSNumber(value: Int64(1_700_000_000_000))
+        ]
+        delegate.application(NSApplication.shared, didReceiveRemoteNotification: userInfo)
+
+        try await Task.sleep(nanoseconds: 100_000_000) // 100 ms for Task + sync
+        #expect(spy.handleSilentPushPayloads.count == 1)
+        let payload = try #require(spy.handleSilentPushPayloads.first)
+        #expect(payload.reminderId == "rem-abc123")
+        #expect(payload.sentAtMs == 1_700_000_000_000)
+    }
+
+    @Test("didReceiveRemoteNotification falls back to camelCase reminderId key")
+    func didReceiveRemoteNotificationFallsBackToLocalKey() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        // Only the camelCase key is present (local notification shape).
+        let userInfo: [String: Any] = ["reminderId": "rem-camel"]
+        delegate.application(NSApplication.shared, didReceiveRemoteNotification: userInfo)
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(spy.handleSilentPushPayloads.count == 1)
+        let payload = try #require(spy.handleSilentPushPayloads.first)
+        #expect(payload.reminderId == "rem-camel")
+        #expect(payload.sentAtMs == nil)
+    }
+
+    @Test("didReceiveRemoteNotification handles missing reminderId gracefully")
+    func didReceiveRemoteNotificationMissingReminderId() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        // No identifier at all — sync should still run (mirrors iOS behaviour).
+        let userInfo: [String: Any] = ["content-available": NSNumber(value: 1)]
+        delegate.application(NSApplication.shared, didReceiveRemoteNotification: userInfo)
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(spy.handleSilentPushPayloads.count == 1)
+        let payload = try #require(spy.handleSilentPushPayloads.first)
+        #expect(payload.reminderId == nil)
+        #expect(payload.sentAtMs == nil)
+    }
+
+    @Test("didReceiveRemoteNotification no-ops when pushService is nil")
+    func didReceiveRemoteNotificationNoOpWhenNilService() async throws {
+        AppContext.shared.resetForTesting()
+        defer { cleanup() }
+
+        let delegate = DequeueAppDelegate()
+        // Must not crash regardless of the result value.
+        delegate.application(
+            NSApplication.shared,
+            didReceiveRemoteNotification: ["reminder_id": "rem-noop"]
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+
+    @Test("didReceiveRemoteNotification discards SilentPushResult (no completion handler)")
+    func didReceiveRemoteNotificationDiscardsResult() async throws {
+        let (delegate, spy) = makeDelegate()
+        defer { cleanup() }
+
+        // Even when handleSilentPush returns .failed, the macOS path must not
+        // crash — there is no UIBackgroundFetchResult completion handler to
+        // call. If this test compiles and runs without error, the contract is
+        // satisfied.
+        spy.stubbedSilentPushResult = .failed
+
+        let userInfo: [String: Any] = ["reminder_id": "rem-fail"]
+        delegate.application(NSApplication.shared, didReceiveRemoteNotification: userInfo)
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(spy.handleSilentPushPayloads.count == 1)
+        // No crash = success
+    }
+}
+#endif // os(macOS)


### PR DESCRIPTION
## What

PR 6/6 of the reminder-delivery pipeline (parent: DEQ-276). Brings the macOS target to feature parity with the iOS push pipeline shipped in PR 4/6 (DEQ-283, #484).

Fixes DEQ-285
Refs DEQ-276

## Why

After PR 4 (#484), iOS devices register APNs tokens, receive silent pushes for pre-wake sync, and dedup local notifications against remote ones. macOS had none of that — users on the macOS app wouldn't receive pre-wake syncs or benefit from the push pipeline at all.

## Changes

### `AppDelegate.swift` — new `#if os(macOS)` section
- `DequeueAppDelegate: NSApplicationDelegate` handling:
  - `applicationDidFinishLaunching`: best-effort `registerIfSignedIn()` on cold launch, same pattern as iOS.
  - `didRegisterForRemoteNotificationsWithDeviceToken`: forwards raw bytes to `PushNotificationService.handleAPNsTokenRegistered`.
  - `didFailToRegisterForRemoteNotificationsWithError`: telemetry-only, same as iOS.
  - `application(_:didReceiveRemoteNotification:)` **(macOS form — no fetchCompletionHandler)**:
    - Extracts `SilentPushPayload` from `[String: Any]` before the Task boundary (Swift 6 Sendable).
    - Spawns `@MainActor` Task → `handleSilentPush` → discards `SilentPushResult` (no completion callback on macOS).
    - Same 20 s REST-only sync timeout as iOS.

### `DequeueApp.swift`
- Wire `@NSApplicationDelegateAdaptor(DequeueAppDelegate.self)` inside `#elseif os(macOS)`.

### `PushNotificationService.swift`
- `registerIfSignedIn()`: add `#elseif os(macOS)` that calls `NSApplication.shared.registerForRemoteNotifications()`, replacing the former "skipped (non-iOS platform)" breadcrumb with the real macOS call. AppKit import guarded under `#if os(macOS)`.

### `AppContext.swift`
- DEBUG-only `setPushServiceForTesting(_:)` so tests can inject a spy push service without a full `SyncManager` + `AuthService` stack.

### `MacOSAppDelegateTests.swift` (new, 10 cases, `#if os(macOS)`)
All passing locally:
- `applicationDidFinishLaunching` → calls `registerIfSignedIn`
- No-ops when `AppContext.pushService` is nil (crash guard)
- `didRegisterForRemoteNotificationsWithDeviceToken` forwards token data
- `didFailToRegisterForRemoteNotificationsWithError` forwards error
- `didReceiveRemoteNotification` extracts snake_case `reminder_id` + `sent_at`
- Fallback to camelCase `reminderId` key
- Handles missing `reminderId` gracefully (sync still runs)
- No-ops when service is nil
- Discards `SilentPushResult` without crash (no completion handler to call)

## Entitlements
`aps-environment = $(APS_ENVIRONMENT)` is already in the shared `Dequeue.entitlements` (added in PR 2). macOS uses the same file. No changes needed.

## Token lifecycle / dedup / teardown
- **Re-register on sign-in**: `handleAuthStateChange` in `DequeueApp.swift` calls `registerIfSignedIn()` — not platform-gated.
- **Re-register on foreground**: `scenePhase == .active` calls `refreshTokenIfStale()` — not platform-gated.
- **De-register on sign-out**: `tearDownSignedOutState` in `AuthService` calls `deregisterOnSignOut()` — not platform-gated.
- **Dedup**: `NotificationService.willPresent` (shared) wires the `UNUserNotificationCenterDelegate` and is set in `DequeueApp.init()` for both platforms. The 60 s NSCache window is process-local and works identically on macOS.

## Verification
- ✅ `swiftlint lint --config Dequeue/.swiftlint.yml` → 0 violations in 198 files
- ✅ `xcodebuild build -destination 'platform=macOS'` → BUILD SUCCEEDED
- ✅ `xcodebuild build -destination 'generic/platform=iOS'` → BUILD SUCCEEDED
- ✅ `xcodebuild test -destination 'platform=macOS'` → all 10 MacOSAppDelegate + 19 PushNotificationService + 20 NotificationService tests pass