### PR TITLE
feat: inline multi-line editable title in stack editor

### DIFF
--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+Actions.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+Actions.swift
@@ -102,7 +102,9 @@ extension StackEditorView {
             do {
                 try await service.updateStack(stack, title: trimmedTitle, description: stack.stackDescription)
                 editedTitle = ""
+                isEditingTitle = false
             } catch {
+                isEditingTitle = false
                 handleError(error)
             }
         }

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -15,6 +15,7 @@ private let logger = Logger(subsystem: "com.dequeue", category: "StackEditorView
 extension StackEditorView {
     var editModeContent: some View {
         List {
+            titleSection
             completionStatusBanner
             activeStatusBanner
             descriptionSection
@@ -33,6 +34,73 @@ extension StackEditorView {
             detailsSection
             eventHistorySection
         }
+    }
+
+    // MARK: - Inline Title Section
+
+    @ViewBuilder
+    var titleSection: some View {
+        if case .edit(let stack) = mode {
+            Section {
+                if isReadOnly {
+                    Text(stack.title)
+                        .font(.largeTitle.bold())
+                        .accessibilityAddTraits(.isHeader)
+                        .accessibilityLabel(stack.title)
+                } else {
+                    TextField(
+                        "Stack title",
+                        text: Binding(
+                            get: { isEditingTitle ? editedTitle : stack.title },
+                            set: { editedTitle = $0 }
+                        ),
+                        axis: .vertical
+                    )
+                    .font(.largeTitle.bold())
+                    .lineLimit(1...10)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(isEditingTitle ? Color(.systemFill) : Color.clear)
+                            .padding(.horizontal, -8)
+                    )
+                    .focused($titleFocused)
+                    .onTapGesture {
+                        if !isEditingTitle {
+                            editedTitle = stack.title
+                            isEditingTitle = true
+                            titleFocused = true
+                        }
+                    }
+                    .onChange(of: titleFocused) { _, focused in
+                        if !focused && isEditingTitle {
+                            commitTitleEdit()
+                        }
+                    }
+                    .accessibilityLabel("Stack title")
+                    .accessibilityHint("Double tap to edit the title")
+                    .accessibilityValue(stack.title)
+                }
+            }
+        }
+    }
+
+    /// Commit the in-progress title edit, saving if valid or reverting if empty.
+    private func commitTitleEdit() {
+        let trimmed = editedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        isEditingTitle = false
+        guard !trimmed.isEmpty else {
+            // Revert — don't allow blank title
+            editedTitle = ""
+            return
+        }
+        guard case .edit(let stack) = mode, trimmed != stack.title else {
+            editedTitle = ""
+            return
+        }
+        // Persist via the existing saveStackTitle path
+        editedTitle = trimmed
+        saveStackTitle()
     }
 
     // MARK: - Completion Status Banner

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -65,21 +65,17 @@ extension StackEditorView {
                             .padding(.horizontal, -8)
                     )
                     .focused($titleFocused)
-                    .onTapGesture {
-                        if !isEditingTitle {
+                    .onChange(of: titleFocused) { _, focused in
+                        if focused && !isEditingTitle {
                             editedTitle = stack.title
                             isEditingTitle = true
-                            titleFocused = true
-                        }
-                    }
-                    .onChange(of: titleFocused) { _, focused in
-                        if !focused && isEditingTitle {
+                        } else if !focused && isEditingTitle {
                             commitTitleEdit()
                         }
                     }
                     .accessibilityLabel("Stack title")
                     .accessibilityHint("Double tap to edit the title")
-                    .accessibilityValue(stack.title)
+                    .accessibilityValue(isEditingTitle ? editedTitle : stack.title)
                 }
             }
         }

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView+EditMode.swift
@@ -40,7 +40,9 @@ extension StackEditorView {
 
     @ViewBuilder
     var titleSection: some View {
-        if case .edit(let stack) = mode {
+        // Only show inline title for non-draft stacks in edit mode.
+        // Draft stacks use createModeContent (routed via isCreateMode) which has its own title field.
+        if case .edit(let stack) = mode, !stack.isDraft {
             Section {
                 if isReadOnly {
                     Text(stack.title)
@@ -84,17 +86,21 @@ extension StackEditorView {
     /// Commit the in-progress title edit, saving if valid or reverting if empty.
     private func commitTitleEdit() {
         let trimmed = editedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        isEditingTitle = false
         guard !trimmed.isEmpty else {
             // Revert — don't allow blank title
+            isEditingTitle = false
             editedTitle = ""
             return
         }
         guard case .edit(let stack) = mode, trimmed != stack.title else {
+            // Title unchanged — just exit editing
+            isEditingTitle = false
             editedTitle = ""
             return
         }
-        // Persist via the existing saveStackTitle path
+        // Persist via the existing saveStackTitle path.
+        // Keep isEditingTitle = true so the TextField continues showing editedTitle
+        // until the model update lands; saveStackTitle() flips it on completion.
         editedTitle = trimmed
         saveStackTitle()
     }

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -215,7 +215,7 @@ extension StackEditorView {
         #if os(macOS)
         .frame(minWidth: 500, minHeight: 400)
         #endif
-        .navigationTitle(displayedTitle)
+        .navigationTitle(navigationTitle)
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -500,15 +500,14 @@ private extension StackEditorView {
         switch mode {
         case .create:
             return draftStack != nil ? "Edit Draft" : "New Stack"
-        case .edit:
-            // Title is shown inline in edit mode content; keep nav bar empty
+        case .edit(let stack):
+            if stack.isDraft {
+                // Draft stacks use createModeContent which has no inline title section
+                return stack.title
+            }
+            // Non-draft edit mode shows title inline in editModeContent
             return ""
         }
-    }
-
-    /// The title to display in the navigation bar
-    var displayedTitle: String {
-        navigationTitle
     }
 
     /// Whether there's unsaved content that should prevent accidental dismissal

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -99,6 +99,8 @@ struct StackEditorView: View {
     // Edit mode state
     @State var showEditTitleAlert = false
     @State var editedTitle = ""
+    @State var isEditingTitle = false
+    @FocusState var titleFocused: Bool
     @State var isEditingDescription = false
     @State var editedDescription = ""
     @State var showCompletedTasks = false
@@ -511,19 +513,15 @@ private extension StackEditorView {
         switch mode {
         case .create:
             return draftStack != nil ? "Edit Draft" : "New Stack"
-        case .edit(let stack):
-            return stack.title
+        case .edit:
+            // Title is shown inline in edit mode content; keep nav bar empty
+            return ""
         }
     }
 
-    /// Whether to show a custom title view with edit button (for edit mode, non-read-only)
-    var showsCustomTitle: Bool {
-        !isCreateMode && !isReadOnly
-    }
-
-    /// The title to display in the navigation bar (empty when using custom editable title)
+    /// The title to display in the navigation bar
     var displayedTitle: String {
-        showsCustomTitle ? "" : navigationTitle
+        navigationTitle
     }
 
     /// Whether there's unsaved content that should prevent accidental dismissal
@@ -562,12 +560,6 @@ extension StackEditorView {
                 Button("Close") { dismiss() }
                     .accessibilityIdentifier("closeButton")
             }
-            // Custom title with inline edit button for editable stacks
-            if showsCustomTitle {
-                ToolbarItem(placement: .principal) {
-                    editableTitleView
-                }
-            }
             if !isReadOnly {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Complete") { handleCompleteButtonTapped() }
@@ -575,29 +567,6 @@ extension StackEditorView {
                         .accessibilityIdentifier("completeButton")
                 }
             }
-        }
-    }
-
-    /// Custom title view with inline pencil button for editing
-    @ViewBuilder
-    private var editableTitleView: some View {
-        if case .edit(let stack) = mode {
-            Button {
-                editedTitle = stack.title
-                showEditTitleAlert = true
-            } label: {
-                HStack(spacing: 4) {
-                    Text(stack.title)
-                        .font(.headline)
-                        .lineLimit(1)
-                    Image(systemName: "pencil")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Edit title: \(stack.title)")
-            .accessibilityHint("Double tap to edit the stack title")
         }
     }
 

--- a/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
+++ b/Dequeue/Dequeue/Views/Stack/StackEditorView.swift
@@ -97,7 +97,6 @@ struct StackEditorView: View {
     }
 
     // Edit mode state
-    @State var showEditTitleAlert = false
     @State var editedTitle = ""
     @State var isEditingTitle = false
     @FocusState var titleFocused: Bool
@@ -277,8 +276,6 @@ extension StackEditorView {
             errorMessage: errorMessage,
             showDiscardAlert: $showDiscardAlert,
             showSaveDraftPrompt: $showSaveDraftPrompt,
-            showEditTitleAlert: $showEditTitleAlert,
-            editedTitle: $editedTitle,
             showCompleteConfirmation: $showCompleteConfirmation,
             showCloseConfirmation: $showCloseConfirmation,
             showDeleteConfirmation: $showDeleteConfirmation,
@@ -289,7 +286,6 @@ extension StackEditorView {
             onDismiss: { dismiss() },
             onDiscardDraft: discardDraftAndDismiss,
             onCreateDraft: createDraftAndDismiss,
-            onSaveTitle: saveStackTitle,
             onCompleteStack: completeStack,
             onCloseStack: closeStack,
             onDeleteStack: deleteStack
@@ -302,8 +298,6 @@ private struct StackEditorAlertsModifier: ViewModifier {
     let errorMessage: String
     @Binding var showDiscardAlert: Bool
     @Binding var showSaveDraftPrompt: Bool
-    @Binding var showEditTitleAlert: Bool
-    @Binding var editedTitle: String
     @Binding var showCompleteConfirmation: Bool
     @Binding var showCloseConfirmation: Bool
     @Binding var showDeleteConfirmation: Bool
@@ -314,7 +308,6 @@ private struct StackEditorAlertsModifier: ViewModifier {
     let onDismiss: () -> Void
     let onDiscardDraft: () -> Void
     let onCreateDraft: () -> Void
-    let onSaveTitle: () -> Void
     let onCompleteStack: (Bool) -> Void
     let onCloseStack: () -> Void
     let onDeleteStack: () -> Void
@@ -334,12 +327,6 @@ private struct StackEditorAlertsModifier: ViewModifier {
                 Button("Discard", role: .destructive) { onDismiss() }
                 Button("Cancel", role: .cancel) { }
             } message: { Text("You have unsaved content. Would you like to save it as a draft?") }
-            .alert("Edit Title", isPresented: $showEditTitleAlert) {
-                TextField("Title", text: $editedTitle)
-                Button("Save") { onSaveTitle() }
-                    .disabled(editedTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                Button("Cancel", role: .cancel) { editedTitle = "" }
-            } message: { Text("Enter a new title for this stack") }
             .confirmationDialog("Complete Stack", isPresented: $showCompleteConfirmation, titleVisibility: .visible) {
                 Button("Complete All Tasks & Stack") { onCompleteStack(true) }
                 Button("Complete Stack Only") { onCompleteStack(false) }


### PR DESCRIPTION
## Summary

Replace single-line truncated toolbar title with a large, prominent inline TextField at the top of the stack editor's edit mode content.

## Changes

### StackEditorView.swift
- **Remove** title from toolbar `.principal` position
- **Simplify** toolbar to Close + Complete only (no title/pencil button)
- Remove dead `showsCustomTitle` / `editableTitleView` code

### StackEditorView+EditMode.swift
- **Add** `titleSection` as the first element in `editModeContent` List
- Large `TextField` with `.largeTitle.bold()` font, `axis: .vertical`, wraps to 10 lines
- Subtle background highlight (`.systemFill`) appears when editing
- Commit-on-blur: saves on focus loss, reverts if empty/whitespace
- Read-only mode shows plain `Text` with `.isHeader` accessibility trait

## Acceptance Criteria

- [x] Stack titles of any length are fully visible and never truncated
- [x] Title is editable inline via the large TextField
- [x] Toolbar shows only Close + Complete
- [x] Dynamic Type supported — title scales with user font size preference
- [x] Accessibility: TextField has meaningful accessibilityLabel/hint/value
- [x] VoiceOver: header trait on read-only, label+hint on editable

## Testing

- SwiftLint: 0 violations
- Build: ✅ (iOS Simulator, iPhone 17 Pro)
- Unit tests: ✅ all passing

Fixes DEQ-286